### PR TITLE
fix: allow disabling OIDC/room/completions/quizzes search paths

### DIFF
--- a/example/installation.yaml
+++ b/example/installation.yaml
@@ -31,7 +31,7 @@ secrets:
 # Unlike secrets, environment variables are configured explicitly as part
 # of an installation.
 #==========================================================================
-#
+
 environment:
   # Don't set this in development:  should only be set by the script whih
   # is starting a container
@@ -90,3 +90,107 @@ environment:
 
   - name: "LOGFIRE_SERVICE_NAME"
     value: "soliplex"
+
+
+#==========================================================================
+# OIDC authentication provider configuration
+#==========================================================================
+# Specify one or more filesystem paths to search for OIDC provider configs.
+#
+# Non-absolute paths will be evaluated relative to the installation directory.
+#
+# If the 'oidc_paths' key is not found, load provider configurations found
+# under the path './oidc'.
+#
+# To disable authentication, list a single, "null" path, e.g.:
+#
+# oidc_paths:
+#   -
+#==========================================================================
+
+
+#==========================================================================
+# Rooms configuration
+#==========================================================================
+# Specify one or more filesystem paths to search for room configs.
+#
+# Each path can be either:
+#
+# - a directory containing its own 'room_config.yaml' file:  this directory
+#   will be mapped as a single room.
+#
+# - a directory whose immediate subdirectories will be treated as rooms
+#   IFF they contain a `room_config.yaml` file.
+#
+# Non-absolute paths will be evaluated relative to the installation directory.
+#
+# The order of 'room_paths' in this list controls which room configuration
+# is used for any conflict on room ID:  rooms found earlier in the list
+# "win" over later ones with the same ID.
+#
+# If the 'room_paths' key is not found, load room configurations found
+# under the path './rooms'.
+#
+# To disable all rooms, list a single, "null" path, e.g.:
+#
+# room_paths:
+#   -
+#==========================================================================
+
+
+#==========================================================================
+# Completions configuration
+#==========================================================================
+# Specify one or more filesystem paths to search for completion configs.
+#
+# Each path can be either:
+#
+# - a directory containing its own 'room_config.yaml' file:  this directory
+#   will be mapped as a single completion.
+#
+# - a directory whose immediate subdirectories will be treated as rooms
+#   IFF they contain a `room_config.yaml` file.
+#
+# Non-absolute paths will be evaluated relative to the installation directory.
+#
+# The order of 'room_paths' in this list controls which completion
+# configuration is used for any conflict on completion ID:  completions
+# found earlier in the list "win" over later ones with the same ID.
+#
+# If the 'completions_paths' key is not found, load completion configurations
+# found under the path './completions'.
+#
+# To disable all completions, list a single, "null" path, e.g.:
+#
+# completion_paths:
+#   -
+#==========================================================================
+
+
+#==========================================================================
+# Quizes configuration
+#==========================================================================
+# Specify one or more filesystem paths to search for quiz question files.
+#
+# Each path should be a directory containing one or more '<quiz_id>.json'
+# files.
+#
+# Non-absolute paths will be evaluated relative to the installation directory.
+#
+# The order of 'quiz_paths' in this list controls which question file
+# configuration is used for any conflict on quiz name:  question files
+# found earlier in the list "win" over later ones with the same name.
+#
+# If the 'quizzes_paths' key is not found, search quiz for question files
+# found under the path './quizzes'.
+#
+# To disable all quizzes, list a single, "null" path, e.g.:
+#
+# quizzes_paths:
+#   -
+#
+# TODO:  update 'soliplex.config.RoomConfig._load_questions_file' to implement
+#        the non-default search of the configured path, rather than using
+#        the 'INSTALLATION_PATH' environment variable.
+#        See issue #13.
+#==========================================================================

--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -902,7 +902,7 @@ class InstallationConfig:
     #
     # Defaults to one path: './oidc' (set in '__post_init__')
     #
-    oidc_paths: list[pathlib.Path] = None
+    oidc_paths: list[pathlib.Path | None] = None
 
     _oidc_auth_system_configs: list[OIDCAuthSystemConfig] = None
 
@@ -976,21 +976,25 @@ class InstallationConfig:
             self.oidc_paths = [
                 parent_dir / oidc_path
                 for oidc_path in self.oidc_paths
+                if oidc_path is not None
             ]
 
             self.room_paths = [
                 parent_dir / room_path
                 for room_path in self.room_paths
+                if room_path is not None
             ]
 
             self.completion_paths = [
                 parent_dir / completion_path
                 for completion_path in self.completion_paths
+                if completion_path is not None
             ]
 
             self.quizzes_paths = [
                 parent_dir / quizzes_path
                 for quizzes_path in self.quizzes_paths
+                if quizzes_path is not None
             ]
 
     def _load_oidc_auth_system_configs(self) -> list[OIDCAuthSystemConfig]:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -472,6 +472,17 @@ oidc_paths:
     - "{OIDC_PATH_2}"
 """
 
+W_OIDC_PATHS_ONLY_NULL_INSTALLATION_CONFIG_KW = {
+    "id": INSTALLATION_ID,
+    "oidc_paths": [
+    ],
+}
+W_OIDC_PATHS_ONLY_NULL_INSTALLATION_CONFIG_YAML = f"""\
+id: "{INSTALLATION_ID}"
+oidc_paths:
+    -
+"""
+
 ROOM_PATH_1 = "./rooms"
 ROOM_PATH_2 = "/path/to/other/rooms"
 
@@ -487,6 +498,17 @@ id: "{INSTALLATION_ID}"
 room_paths:
     - "{ROOM_PATH_1}"
     - "{ROOM_PATH_2}"
+"""
+
+W_ROOM_PATHS_ONLY_NULL_INSTALLATION_CONFIG_KW = {
+    "id": INSTALLATION_ID,
+    "room_paths": [
+    ],
+}
+W_ROOM_PATHS_ONLY_NULL_INSTALLATION_CONFIG_YAML = f"""\
+id: "{INSTALLATION_ID}"
+room_paths:
+    -
 """
 
 COMPLETION_PATH_1 = "./completions"
@@ -506,6 +528,17 @@ completion_paths:
     - "{COMPLETION_PATH_2}"
 """
 
+W_COMPLETION_PATHS_ONLY_NULL_INSTALLATION_CONFIG_KW = {
+    "id": INSTALLATION_ID,
+    "completion_paths": [
+    ],
+}
+W_COMPLETION_PATHS_ONLY_NULL_INSTALLATION_CONFIG_YAML = f"""\
+id: "{INSTALLATION_ID}"
+completion_paths:
+    -
+"""
+
 QUIZZES_PATH_1 = "./quizzes"
 QUIZZES_PATH_2 = "/path/to/other/quizzes"
 
@@ -521,6 +554,17 @@ id: "{INSTALLATION_ID}"
 quizzes_paths:
     - "{QUIZZES_PATH_1}"
     - "{QUIZZES_PATH_2}"
+"""
+
+W_QUIZZES_PATHS_ONLY_NULL_INSTALLATION_CONFIG_KW = {
+    "id": INSTALLATION_ID,
+    "quizzes_paths": [
+    ],
+}
+W_QUIZZES_PATHS_ONLY_NULL_INSTALLATION_CONFIG_YAML = f"""\
+id: "{INSTALLATION_ID}"
+quizzes_paths:
+    -
 """
 
 
@@ -1599,16 +1643,32 @@ def test__find_configs_w_multiple(temp_dir):
         W_OIDC_PATHS_INSTALLATION_CONFIG_KW,
     ),
     (
+        W_OIDC_PATHS_ONLY_NULL_INSTALLATION_CONFIG_YAML,
+        W_OIDC_PATHS_ONLY_NULL_INSTALLATION_CONFIG_KW,
+    ),
+    (
         W_ROOM_PATHS_INSTALLATION_CONFIG_YAML,
         W_ROOM_PATHS_INSTALLATION_CONFIG_KW,
+    ),
+    (
+        W_ROOM_PATHS_ONLY_NULL_INSTALLATION_CONFIG_YAML,
+        W_ROOM_PATHS_ONLY_NULL_INSTALLATION_CONFIG_KW,
     ),
     (
         W_COMPLETION_PATHS_INSTALLATION_CONFIG_YAML,
         W_COMPLETION_PATHS_INSTALLATION_CONFIG_KW,
     ),
     (
+        W_COMPLETION_PATHS_ONLY_NULL_INSTALLATION_CONFIG_YAML,
+        W_COMPLETION_PATHS_ONLY_NULL_INSTALLATION_CONFIG_KW,
+    ),
+    (
         W_QUIZZES_PATHS_INSTALLATION_CONFIG_YAML,
         W_QUIZZES_PATHS_INSTALLATION_CONFIG_KW,
+    ),
+    (
+        W_QUIZZES_PATHS_ONLY_NULL_INSTALLATION_CONFIG_YAML,
+        W_QUIZZES_PATHS_ONLY_NULL_INSTALLATION_CONFIG_KW,
     ),
 ])
 def test_installationconfig_from_yaml(temp_dir, config_yaml, expected_kw):


### PR DESCRIPTION
Document the search path config in 'example/installation.yaml'.

Closes #11.