### PR TITLE
feat: '_installation_config' field

### DIFF
--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -27,7 +27,6 @@ ROOM_ID = "test-room"
 RAG_LANCEDB_OVERRIDE_PATH = "/path/to/db/rag"
 
 TC_TOOL_CONFIG = config.ToolConfig(
-    kind="test_tool",
     tool_name="soliplex.tools.test_tool"
 )
 

--- a/tests/unit/test_completions.py
+++ b/tests/unit/test_completions.py
@@ -38,7 +38,6 @@ W_TOOLS_CONFIG = config.CompletionConfig(
     ),
     tool_configs={
         "get_current_datetime": config.ToolConfig(
-            kind="get_current_datetime",
             tool_name="soliplex.tools.get_current_datetime",
         ),
         "search_documents": config.SearchDocumentsToolConfig(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -111,14 +111,13 @@ def test_tool_from_config_w_toolconfig():
         """This is a test tool"""
 
     tool_config = config.ToolConfig(
-        kind="testing",
         tool_name="soliplex.tools.test_tool",
     )
 
     with mock.patch.dict("soliplex.tools.__dict__", test_tool=test_tool):
         tool_model = models.Tool.from_config(tool_config)
 
-    assert tool_model.kind == "testing"
+    assert tool_model.kind == "test_tool"
     assert tool_model.tool_name == "soliplex.tools.test_tool"
     assert tool_model.tool_description == test_tool.__doc__.strip()
     assert tool_model.tool_requires == config.ToolRequires.BARE
@@ -248,7 +247,6 @@ def room_tools(request):
         kw["tool_configs"] = {
             "get_current_datetime":
                 config.ToolConfig(
-                    kind="testing",
                     tool_name="soliplex.tools.get_current_datetime",
                 ),
         }


### PR DESCRIPTION
Gives all dependent configs loaded from YAML access to the "root" config, to allow resolution of values currently loaded from 'os.environ'.

Closes #15.