### PR TITLE
fix: add 'the_installation' to 'models.AgentDependencies'

### DIFF
--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -9,6 +9,7 @@ import pydantic
 
 from soliplex import config
 from soliplex import convos
+from soliplex import installation
 
 # ============================================================================
 #   Public config models
@@ -310,6 +311,7 @@ class UserProfile(pydantic.BaseModel):
 
 
 class AgentDependencies(pydantic.BaseModel):
+    the_installation: installation.Installation
     user: UserProfile = None  # TBD make required
 
 

--- a/src/soliplex/views/completions.py
+++ b/src/soliplex/views/completions.py
@@ -83,6 +83,7 @@ async def post_chat_completion(
         ) from None
 
     agent_deps = models.AgentDependencies(
+        the_installation=the_installation,
         user=user_profile,
     )
 

--- a/src/soliplex/views/convos.py
+++ b/src/soliplex/views/convos.py
@@ -53,6 +53,7 @@ async def post_convos_new(
         ) from None
 
     agent_deps = models.AgentDependencies(
+        the_installation=the_installation,
         user=user_profile,
     )
 
@@ -107,6 +108,7 @@ async def post_convos_new_room(
         ) from None
 
     agent_deps = models.AgentDependencies(
+        the_installation=the_installation,
         user=user_profile,
     )
 
@@ -204,6 +206,7 @@ async def post_convo(
         ) from None
 
     agent_deps = models.AgentDependencies(
+        the_installation=the_installation,
         user=user_profile,
     )
 

--- a/tests/unit/views/test_completions_views.py
+++ b/tests/unit/views/test_completions_views.py
@@ -201,7 +201,10 @@ async def test_post_chat_completion_hit(
     assert response is occ.return_value
 
     exp_user_profile = models.UserProfile(**exp_user)
-    exp_agent_deps = models.AgentDependencies(user=exp_user_profile)
+    exp_agent_deps = models.AgentDependencies(
+        the_installation=the_installation,
+        user=exp_user_profile,
+    )
     occ.assert_awaited_once_with(
         the_installation.get_agent_for_completion.return_value,
         exp_agent_deps,

--- a/tests/unit/views/test_convos_views.py
+++ b/tests/unit/views/test_convos_views.py
@@ -231,6 +231,7 @@ async def test_post_convos_new(
         exp_user_profile = models.UserProfile(**exp_user)
 
         expected_deps = models.AgentDependencies(
+            the_installation=the_installation,
             user=exp_user_profile,
         )
 
@@ -336,6 +337,7 @@ async def test_post_convos_new_room(
         exp_user_profile = models.UserProfile(**exp_user)
 
         expected_deps = models.AgentDependencies(
+            the_installation=the_installation,
             user=exp_user_profile,
         )
 
@@ -522,6 +524,7 @@ async def test_post_convo(
         exp_user_profile = models.UserProfile(**exp_user)
 
         expected_deps = models.AgentDependencies(
+            the_installation=the_installation,
             user=exp_user_profile,
         )
 


### PR DESCRIPTION
FBO tools which need access to runtime features of the Soliplex installation

Closes #49.