### PR TITLE
OIDC Support for ORY

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Remote Attach",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ]
+        }
+    ]
+}

--- a/README_OIDC.md
+++ b/README_OIDC.md
@@ -1,0 +1,33 @@
+1. Create workspace in ORY
+2. Create a project inside that workspace
+3. Go to Oauth2 tab in your project
+4. Create a new Oauth2 Client of type "Server application"
+5. Give it a name
+6. For scope, specify "openid" "email" "profile" "offline_access"
+7. For "Redirect URIs" it will depend on your case, but if running in localhost, specify http://localhost:8000/api/auth/{client_name}
+8. For the rest of configurations, you can leave them as the default values.
+
+When clicking "Save", you will get a Client Secret. Note it down as CLIENT_SECRET
+
+Now, click the three dots for the client you just created, and click "Edit client". In the modal that pops up, you will find the "Client ID". Note it down as CLIENT_ID. You can click "Cancel" to close the modal
+
+On the left side, click the "Endpoints" menu. Look for any of the provided endpoints and only copy the hostname, without the path, as the SERVER_URL
+
+
+Now, when configuring the "oidc" for soliplex, in the config.yaml, you will have something like this:
+```
+oidc_client_pem_path: "./cacert.pem"
+auth_systems:
+
+  - id: "ory"
+    title: "Authenticate with Ory"
+    server_url: "{{ SERVER_URL }}"
+    client_id: "{{ CLIENT_ID }}"
+    client_secret: "{{ CLIENT_SECRET }}"
+    scope: "openid email profile offline_access"
+    include_return_to: false
+```
+
+After saving and restarting the server, you should be able to login by visiting http://localhost:8000/api/login/{client_name}
+
+the `include_return_to` setting is included so you can avoid having the `return_to` added to the `redirect_url` as apparently ory doesn't support that.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.11"
 description = "<ALAN FILL THIS IN>"
 authors = [{ name = "Enfold", email = "info@enfoldsystems.net" }]
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.13,<4.0"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
@@ -43,6 +43,7 @@ dev = [
     "pytest-cov",
     "pytest-asyncio",
     "coverage",
+    "debugpy",
     "anyio",
     "trio",
     "ruff",

--- a/src/soliplex/auth.py
+++ b/src/soliplex/auth.py
@@ -3,10 +3,20 @@ import os
 import fastapi
 import jwt
 import starlette.config
+
 from authlib.integrations import starlette_client
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+from datetime import datetime, timedelta, timezone
+from fastapi import HTTPException, Request
 from fastapi import security
 
 from soliplex import installation
+
+TOKEN_CHECK_INTERVAL = timedelta(minutes=15)
+
+
+depend_the_installation = installation.depend_the_installation
+
 
 oauth2_scheme = security.OAuth2PasswordBearer(
     tokenUrl="token",
@@ -90,3 +100,56 @@ def validate_access_token(token, token_validation_pem):
         )
     except jwt.InvalidTokenError:
         return None
+
+
+async def refresh_token(oauth_app, refresh_token: str):
+    # Load provider metadata to get token_endpoint
+    metadata = await oauth_app.load_server_metadata()
+    token_endpoint = metadata["token_endpoint"]
+
+    async with AsyncOAuth2Client(
+        client_id=oauth_app.client_id,
+        client_secret=oauth_app.client_secret,
+    ) as client:
+        new_token = await client.refresh_token(
+            token_endpoint,
+            refresh_token=refresh_token,
+        )
+    return new_token
+
+
+async def get_current_user(
+        request: Request,
+        the_installation: installation.Installation = depend_the_installation):
+    """Retrieve current user, refreshing token if needed"""
+
+    if the_installation.auth_disabled:
+        return {"name": "Phreddy Phlyntstone", "email": "phreddy@example.com"}
+
+    user = request.session.get("user")
+    token = request.session.get("token")
+    if not user or not token:
+        raise HTTPException(401, "Not authenticated")
+
+    now = datetime.now(timezone.utc)
+    expires_at = datetime.fromtimestamp(token["expires_at"], tz=timezone.utc)
+
+    # If token expired → refresh
+    if now >= expires_at:
+        if not token.get("refresh_token"):
+            request.session.clear()
+            raise HTTPException(401, "Session expired; please re-login")
+
+        oauth = get_oauth(the_installation)
+        system = token.get("system")
+        oauth_app = oauth.create_client(system)
+
+        new_token = await refresh_token(oauth_app, token["refresh_token"])
+
+        # update session
+        token["access_token"] = new_token["access_token"]
+        token["expires_at"] = new_token["expires_at"]
+        token["refresh_token"] = new_token.get("refresh_token", token["refresh_token"])
+        request.session["token"] = token
+
+    return user

--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -152,11 +152,12 @@ class OIDCAuthSystemConfig:
     title: str
 
     server_url: str
-    token_validation_pem: str
     client_id: str
+    token_validation_pem: str = None
     scope: str = None
     client_secret: str = ""  # "env:{JOSCE_CLIENT_SECRET}"
     oidc_client_pem_path: pathlib.Path = None
+    include_return_to: bool = True
 
     # Set in 'from_yaml' below
     _installation_config: InstallationConfig = None

--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -21,6 +21,12 @@ from soliplex.views import installation as installation_views
 from soliplex.views import quizzes as quizzes_views
 from soliplex.views import rooms as rooms_views
 
+try:
+    import debugpy
+    debugpy.listen(("localhost", 5678))
+except:
+    pass
+
 
 def curry_lifespan(installation_path: pathlib.Path = None):
     if installation_path is None:

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -210,6 +210,7 @@ class OIDCAuthSystem(pydantic.BaseModel):
     server_url: str
     token_validation_pem: str
     client_id: str
+    include_return_to: bool
     scope: str | None = None
 
     @classmethod

--- a/src/soliplex/views/auth.py
+++ b/src/soliplex/views/auth.py
@@ -2,6 +2,7 @@ import dataclasses
 
 import fastapi
 from authlib.integrations import starlette_client
+from datetime import datetime, timedelta
 from fastapi import responses
 from fastapi import security
 
@@ -43,13 +44,18 @@ async def get_login_system(
             status_code=404,
             detail="system in no-auth mode",
         )
-    return_to = request.query_params.get("return_to", "/")
-    redirect_uri = request.url_for("get_auth_system", system=system)
-    redirect_uri = redirect_uri.replace_query_params(return_to=return_to)
-    redirect_uri = util.strip_default_port(redirect_uri)
 
     oauth = auth.get_oauth(the_installation)
     oauth_app = oauth.create_client(system)
+
+    redirect_uri = request.url_for("get_auth_system", system=system)
+
+    for auth_system in the_installation.oidc_auth_system_configs:
+        if auth_system.id == system and auth_system.include_return_to:
+            return_to = request.query_params.get("return_to", "/")
+            redirect_uri = redirect_uri.replace_query_params(return_to=return_to)
+
+    redirect_uri = util.strip_default_port(redirect_uri)
 
     found = await oauth_app.authorize_redirect(request, redirect_uri)
     return found
@@ -78,20 +84,34 @@ async def get_auth_system(
             status_code=401, detail=f"JWT validation failed {e}"
         ) from None
 
-    access_token = tokendict["access_token"]
-    auth.authenticate(the_installation, access_token)
+    try:
+        id_token = await oauth_app.parse_id_token(request, tokendict)
+    except Exception:
+        id_token = None
 
-    refresh_token = tokendict["refresh_token"]
-    expires_in = tokendict["expires_in"]
-    refresh_expires_in = tokendict["refresh_expires_in"]
+    try:
+        userinfo = await oauth_app.userinfo(token=tokendict)
+    except Exception:
+        userinfo = {}
 
-    # NB: explicitly putting the "query parameters" after the URL,
-    # even if the url ends with an anchor tag (support GoRouter)
+    profile = userinfo or id_token or tokendict.get("userinfo", {})
+
+    request.session["user"] = {
+        "sub": profile.get("sub"),
+        "email": profile.get("email"),
+        "name": profile.get("name"),
+    }
+
+    request.session["token"] = {
+        "system": system,
+        "access_token": tokendict["access_token"],
+        "refresh_token": tokendict.get("refresh_token"),
+        "expires_at": tokendict.get("expires_at") or (
+            datetime.utcnow() + timedelta(seconds=tokendict.get("expires_in", 3600))
+        ).isoformat()
+    }
+
     return_to = request.query_params.get("return_to", "/")
-    return_to += f"?token={access_token}"
-    return_to += f"&refresh_token={refresh_token}"
-    return_to += f"&expires_in={expires_in}"
-    return_to += f"&refresh_expires_in={refresh_expires_in}"
     return responses.RedirectResponse(return_to)
 
 
@@ -107,4 +127,4 @@ async def get_user_info(
             detail="system in no-auth mode",
         )
 
-    return auth.authenticate(the_installation, token)
+    return await auth.authenticate(the_installation, token)

--- a/src/soliplex/views/completions.py
+++ b/src/soliplex/views/completions.py
@@ -1,4 +1,5 @@
 import fastapi
+from fastapi import Depends
 from fastapi import responses
 from fastapi import security
 
@@ -22,9 +23,8 @@ depend_the_installation = installation.depend_the_installation
 async def get_chat_completions(
     request: fastapi.Request,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.ConfiguredCompletions:
-    user = auth.authenticate(the_installation, token)
     completion_configs = the_installation.get_completion_configs(user)
 
     return {
@@ -39,9 +39,8 @@ async def get_chat_completion(
     request: fastapi.Request,
     completion_id: str,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.Completion:
-    user = auth.authenticate(the_installation, token)
     try:
         completion_config = the_installation.get_completion_config(
             completion_id,
@@ -62,9 +61,8 @@ async def post_chat_completion(
     completion_id: str,
     chat_request: models.ChatCompletionRequest,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> responses.StreamingResponse:
-    user = auth.authenticate(the_installation, token)
     user_profile = models.UserProfile(
         given_name=user.get("given_name", "<unknown>"),
         family_name=user.get("family_name", "<unknown>"),

--- a/src/soliplex/views/convos.py
+++ b/src/soliplex/views/convos.py
@@ -3,6 +3,7 @@ import json
 import uuid
 
 import fastapi
+from fastapi import Depends
 from fastapi import responses
 from fastapi import security
 from pydantic_ai import messages as ai_messages
@@ -29,10 +30,9 @@ async def post_convos_new(
     convo_msg: models.NewConvoClientMessage,
     the_installation: installation.Installation = depend_the_installation,
     the_convos: convos.Conversations = convos.depend_the_convos,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.Conversation:
     """Create a new convo, including room ID and URI with UUID"""
-    user = auth.authenticate(the_installation, token)
     user_profile = models.UserProfile(
         given_name=user.get("given_name", "<unknown>"),
         family_name=user.get("family_name", "<unknown>"),
@@ -84,10 +84,9 @@ async def post_convos_new_room(
     convo_msg: models.UserPromptClientMessage,
     the_installation: installation.Installation = depend_the_installation,
     the_convos: convos.Conversations = convos.depend_the_convos,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.Conversation:
     """Create a new convo, including room ID and URI with UUID"""
-    user = auth.authenticate(the_installation, token)
     user_profile = models.UserProfile(
         given_name=user.get("given_name", "<unknown>"),
         family_name=user.get("family_name", "<unknown>"),
@@ -137,10 +136,9 @@ async def get_convos(
     request: fastapi.Request,
     the_installation: installation.Installation = depend_the_installation,
     the_convos: convos.Conversations = convos.depend_the_convos,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.ConversationMap:
     """Return a map of conversations by UUID, including name and room ID"""
-    user = auth.authenticate(the_installation, token)
     user_name = user.get("preferred_username", "<unknown>")
     user_convos = await the_convos.user_conversations(user_name)
     return {
@@ -156,13 +154,12 @@ async def get_convo(
     convo_uuid: uuid.UUID,
     the_installation: installation.Installation = depend_the_installation,
     the_convos: convos.Conversations = convos.depend_the_convos,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.Conversation:
     """Return the conversation, by id
 
     Include the message history for the conversation, along with room ID, etc.
     """
-    user = auth.authenticate(the_installation, token)
     user_name = user.get("preferred_username", "<unknown>")
     info = await the_convos.get_conversation_info(user_name, convo_uuid)
     return models.Conversation.from_convos_info(info)
@@ -176,14 +173,12 @@ async def post_convo(
     convo_msg: models.UserPromptClientMessage,
     the_installation: installation.Installation = depend_the_installation,
     the_convos: convos.Conversations = convos.depend_the_convos,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> responses.StreamingResponse:
     """Send another query to an existing convo.
 
     Return the final response message.
     """
-    user = auth.authenticate(the_installation, token)
-
     user_profile = models.UserProfile(
         given_name=user.get("given_name", "<unknown>"),
         family_name=user.get("family_name", "<unknown>"),
@@ -269,10 +264,9 @@ async def delete_convo(
     convo_uuid: uuid.UUID,
     the_installation: installation.Installation = depend_the_installation,
     the_convos: convos.Conversations = convos.depend_the_convos,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ):
     """Delete an existing convo."""
-    user = auth.authenticate(the_installation, token)
     user_name = user.get("preferred_username", "<unknown>")
 
     await the_convos.delete_conversation(user_name, convo_uuid)

--- a/src/soliplex/views/installation.py
+++ b/src/soliplex/views/installation.py
@@ -1,4 +1,5 @@
 import fastapi
+from fastapi import Depends
 from fastapi import security
 
 from soliplex import auth
@@ -16,7 +17,6 @@ depend_the_installation = installation.depend_the_installation
 async def get_installation(
     request: fastapi.Request,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.Installation:
-    auth.authenticate(the_installation, token)
     return models.Installation.from_config(the_installation._config)

--- a/src/soliplex/views/quizzes.py
+++ b/src/soliplex/views/quizzes.py
@@ -1,4 +1,5 @@
 import fastapi
+from fastapi import Depends
 from fastapi import security
 
 from soliplex import auth
@@ -17,9 +18,8 @@ async def get_quiz(
     room_id: str,
     quiz_id: str,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.Quiz:
-    user = auth.authenticate(the_installation, token)
 
     try:
         room_config = the_installation.get_room_config(room_id, user=user)
@@ -48,9 +48,8 @@ async def post_quiz_question(
     question_uuid: str,
     answer: models.UserPromptClientMessage,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.QuizQuestionResponse:
-    user = auth.authenticate(the_installation, token)
 
     try:
         room_config = the_installation.get_room_config(room_id, user=user)

--- a/src/soliplex/views/rooms.py
+++ b/src/soliplex/views/rooms.py
@@ -1,4 +1,5 @@
 import fastapi
+from fastapi import Depends
 from fastapi import responses
 from fastapi import security
 
@@ -18,9 +19,8 @@ depend_the_installation = installation.depend_the_installation
 async def get_rooms(
     request: fastapi.Request,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.ConfiguredRooms:
-    user = auth.authenticate(the_installation, token)
     room_configs = the_installation.get_room_configs(user)
 
     def _key(item):
@@ -40,9 +40,8 @@ async def get_room(
     request: fastapi.Request,
     room_id: str,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ) -> models.Room:
-    user = auth.authenticate(the_installation, token)
 
     try:
         room_config = the_installation.get_room_config(room_id, user)
@@ -64,10 +63,8 @@ async def get_room_bg_image(
     request: fastapi.Request,
     room_id: str,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ):
-    user = auth.authenticate(the_installation, token)
-
     try:
         room_config = the_installation.get_room_config(room_id, user)
     except KeyError:
@@ -93,10 +90,8 @@ async def get_room_mcp_token(
     request: fastapi.Request,
     room_id: str,
     the_installation: installation.Installation = depend_the_installation,
-    token: security.HTTPAuthorizationCredentials = auth.oauth2_predicate,
+    user=Depends(auth.get_current_user),
 ):
-    user = auth.authenticate(the_installation, token)
-
     try:
         the_installation.get_room_config(room_id, user=user)
     except ValueError as e:


### PR DESCRIPTION
@tseaver @runyaga Here are the changes so OIDC authentication will work with ORY. I included a README, but will include the contents here

1. Create workspace in ORY
2. Create a project inside that workspace
3. Go to Oauth2 tab in your project
4. Create a new Oauth2 Client of type "Server application"
5. Give it a name
6. For scope, specify "openid" "email" "profile" "offline_access"
7. For "Redirect URIs" it will depend on your case, but if running in localhost, specify http://localhost:8000/api/auth/{client_name}
8. For the rest of configurations, you can leave them as the default values.

When clicking "Save", you will get a Client Secret. Note it down as CLIENT_SECRET

Now, click the three dots for the client you just created, and click "Edit client". In the modal that pops up, you will find the "Client ID". Note it down as CLIENT_ID. You can click "Cancel" to close the modal

On the left side, click the "Endpoints" menu. Look for any of the provided endpoints and only copy the hostname, without the path, as the SERVER_URL


Now, when configuring the "oidc" for soliplex, in the config.yaml, you will have something like this:
```
oidc_client_pem_path: "./cacert.pem"
auth_systems:

  - id: "ory"
    title: "Authenticate with Ory"
    server_url: "{{ SERVER_URL }}"
    client_id: "{{ CLIENT_ID }}"
    client_secret: "{{ CLIENT_SECRET }}"
    scope: "openid email profile offline_access"
    include_return_to: false
```

After saving and restarting the server, you should be able to login by visiting http://localhost:8000/api/login/{client_name}

the `include_return_to` setting is included so you can avoid having the `return_to` added to the `redirect_url` as apparently ory doesn't support that.


Notice I implemented a `auth.get_current_user` and use that as dependency on the views, instead of manually calling `auth.authenticate`, but I didn't remove that, just in case...