### PR TITLE
fix: secret source registration using wrong list.

### DIFF
--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -617,8 +617,8 @@ class WithQueryMCPWrapper:
         return self._func(query, tool_config=self._tool_config)
 
 
-MCP_TOOL_CONFIG_WRAPPERS_BY_KIND = {
-    SearchDocumentsToolConfig.kind: WithQueryMCPWrapper,
+MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME = {
+    SearchDocumentsToolConfig.tool_name: WithQueryMCPWrapper,
 }
 
 
@@ -1477,11 +1477,12 @@ class InstallationConfigMeta:
         self.mcp_server_tool_wrappers = list(self.mcp_server_tool_wrappers)
         for mstw_meta in self.mcp_server_tool_wrappers:
             config_klass = mstw_meta.config_klass
+            tool_name = config_klass.tool_name
             wrapper_klass = mstw_meta.wrapper_klass
-            MCP_TOOL_CONFIG_WRAPPERS_BY_KIND[config_klass.kind] = wrapper_klass
+            MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME[tool_name] = wrapper_klass
 
         self.secret_sources = list(self.secret_sources)
-        for ss_meta in self.mcp_server_tool_wrappers:
+        for ss_meta in self.secret_sources:
             config_klass = ss_meta.config_klass
             registered_func = ss_meta.registered_func
             SECRET_GETTERS_BY_KIND[config_klass.kind] = registered_func

--- a/src/soliplex/mcp_server.py
+++ b/src/soliplex/mcp_server.py
@@ -15,8 +15,8 @@ def mcp_tool(tool_config: config.ToolConfig) -> fmcp_tools.Tool | None:
         tool_config.allow_mcp
         and tool_config.tool_requires != config.ToolRequires.FASTAPI_CONTEXT
     ):
-        wrapper_type = config.MCP_TOOL_CONFIG_WRAPPERS_BY_KIND.get(
-            tool_config.kind,
+        wrapper_type = config.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME.get(
+            tool_config.tool_name,
         )
 
         if wrapper_type is not None:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -17,6 +17,7 @@ def tool_for_testing():
 TOOL_CONFIG_WO_MCP = mock.create_autospec(
     config.ToolConfig,
     kind="testing",
+    tool_name="soliplex.config.testing",
     tool=tool_for_testing,
     tool_id="mcp_false_bare",
     allow_mcp=False,
@@ -25,6 +26,7 @@ TOOL_CONFIG_WO_MCP = mock.create_autospec(
 TOOL_CONFIG_W_MCP_WO_REQ_CTX = mock.create_autospec(
     config.ToolConfig,
     kind="testing",
+    tool_name="soliplex.tools.testing",
     tool=tool_for_testing,
     allow_mcp=True,
     tool_id="mcp_true_bare",
@@ -33,6 +35,7 @@ TOOL_CONFIG_W_MCP_WO_REQ_CTX = mock.create_autospec(
 TOOL_CONFIG_W_MCP_W_REQ_CTX = mock.create_autospec(
     config.ToolConfig,
     kind="testing",
+    tool_name="soliplex.tools.testing",
     tool=tool_for_testing,
     tool_id="mcp_true_w_ctx",
     allow_mcp=True,
@@ -42,6 +45,7 @@ TOOL_CONFIG_W_MCP_W_REQ_CTX = mock.create_autospec(
 SDTC_WO_MCP = mock.create_autospec(
     config.SearchDocumentsToolConfig,
     kind="search_documents",
+    tool_name="soliplex.tools.search_documents",
     tool=tool_for_testing,
     allow_mcp=False,
     tool_id="mcp_false_sdtc",
@@ -50,6 +54,7 @@ SDTC_WO_MCP = mock.create_autospec(
 SDTC_W_MCP = mock.create_autospec(
     config.SearchDocumentsToolConfig,
     kind="search_documents",
+    tool_name="soliplex.tools.search_documents",
     tool=tool_for_testing,
     allow_mcp=True,
     tool_id="mcp_true_sdtc",


### PR DESCRIPTION
refactor: look up MCP tool config wrappers by tool name

For consistency, better testability.

tests: unb0rk global metaconfig at `tests/unit/test_config.py` import time.