### PR TITLE
chore: work around 'pydantic-ai #2818'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "soliplex"
-version = "0.13"
+version = "0.14dev0"
 description = "<ALAN FILL THIS IN>"
 authors = [{ name = "Enfold", email = "info@enfoldsystems.net" }]
 readme = "README.md"
@@ -19,13 +19,16 @@ dependencies = [
     "python-dotenv",
     "fastapi",
     "fastmcp>=2.13.0.2,<2.14",
-    "haiku.rag >= 0.13.2",
+    "haiku.rag >= 0.13.1",
     "httpx",
     "itsdangerous",
     "jwcrypto",
     "logfire[fastapi]",
     "openai>=1.12.0",
-    "pydantic-ai >= 1.0.11",
+    # Work around https://github.com/pydantic/pydantic-ai/issues/2818
+    # We may need to exclude more versions if they make e.g. a 1.10.*
+    # release without fixing the bug.
+    "pydantic-ai >= 1.0.11, !=1.5.*, !=1.6.*, !=1.7.*, !=1.8.*, !=1.9.*",
     "pyjwt",
     "python-dotenv",
     "python-keycloak",


### PR DESCRIPTION
See: https://github.com/pydantic/pydantic-ai/issues/2818

Exclude versions 1.5.0 -- 1.9.*, which have the bug.

Downgrade our 'haiku-rag' dependency to match.

Closes #148.