### PR TITLE
feat: 'AgentConfig._template_id'

### DIFF
--- a/example/installation.yaml
+++ b/example/installation.yaml
@@ -200,6 +200,15 @@ haiku_rag_config_file: "./haiku.rag.yaml"
 
 agent_configs:
 
+  - id: "ollama_qwen3"
+    model_name: "qwen3:latest"
+    system_prompt: |
+      You are an expert AI assistant specializing in information retrieval.
+
+      Your answers should be clear, concise, and ready for production use.
+
+      Always provide code or examples in Markdown blocks.
+
   - id: "ollama_gpt_oss"
     model_name: "gpt-oss:20b"
     system_prompt: |

--- a/example/minimal.yaml
+++ b/example/minimal.yaml
@@ -81,6 +81,16 @@ environment:
 # Agent configurations
 #==========================================================================
 
+agent_configs:
+
+  - id: "ollama_qwen3"
+    model_name: "qwen3:latest"
+    # No prompt:  this config is just a template
+
+  - id: "ollama_gpt_oss"
+    model_name: "gpt-oss:20b"
+    # No prompt:  this config is just a template
+
 #==========================================================================
 # OIDC authentication provider configuration
 #==========================================================================

--- a/example/rooms/haiku/room_config.yaml
+++ b/example/rooms/haiku/room_config.yaml
@@ -6,6 +6,7 @@ suggestions:
 - "Who am I?"
 - "What is a Soliplex installation?"
 agent:
+  template_id: "ollama_qwen3"
   system_prompt: "./prompt.txt"
 allow_mcp: true
 tools:

--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # forward refs in typing decls
 
+import copy
 import dataclasses
 import enum
 import functools
@@ -660,6 +661,10 @@ class AgentConfig:
     _installation_config: InstallationConfig = None
     _config_path: pathlib.Path = None
 
+    # Use a config from the top-level InstallationConfig's 'agent_configs'
+    # as a template.
+    _template_id: str = None
+
     def __post_init__(self, system_prompt):
         if self.model_name is None:
             if self._installation_config is not None:
@@ -680,6 +685,22 @@ class AgentConfig:
         try:
             config["_installation_config"] = installation_config
             config["_config_path"] = config_path
+
+            if "template_id" in config:
+                template_id = config.pop("template_id")
+
+                # Cannot use 'agent_configs_map' because we might still be
+                # initalizing the IC.
+                ic_agent_configs_map = {
+                    agent_config.id: agent_config
+                    for agent_config in installation_config.agent_configs
+                }
+
+                template_config = ic_agent_configs_map[template_id]
+                local_config = copy.deepcopy(config)
+                local_config["_template_id"] = template_id
+
+                config = template_config.as_yaml | local_config
 
             if "system_prompt" in config:
                 system_prompt = config.pop("system_prompt")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -212,9 +212,12 @@ FULL_HTTP_MCTC_CONFIG_YAML = """
 
 
 AGENT_ID = "testing"
+TEMPLATE_AGENT_ID = "testing-template"
 SYSTEM_PROMPT = "You are a test"
 MODEL_NAME = "test-model"
+OTHER_MODEL_NAME = "test-model-other"
 PROVIDER_BASE_URL = "https://provider.example.com/api"
+OTHER_PROVIDER_BASE_URL = "https://other-provider.example.com/api"
 PROVIDER_KEY_ENVVAR = "TEST_API_KEY"
 PROVIDER_KEY_VALUE = "DEADBEEF"
 OLLAMA_BASE_URL = "https://example.com:12345"
@@ -368,6 +371,17 @@ W_PROMPT_FILE_AGENT_CONFIG_YAML = f"""
 id: "{AGENT_ID}"
 system_prompt: ./prompt.txt
 model_name: "{MODEL_NAME}"
+"""
+
+W_PROMPT_FILE_W_TEMPLATE_ID_AGENT_CONFIG_KW = dict(
+    id=AGENT_ID,
+    _template_id=TEMPLATE_AGENT_ID,
+    _system_prompt_path="./prompt.txt",
+)
+W_PROMPT_FILE_W_TEMPLATE_ID_AGENT_CONFIG_YAML = f"""
+id: "{AGENT_ID}"
+template_id: "{TEMPLATE_AGENT_ID}"
+system_prompt: ./prompt.txt
 """
 
 WO_CONFIG_PYTHON_AGENT_CONFIG_KW = dict(
@@ -1926,6 +1940,10 @@ def test_agentconfig_ctor(installation_config, kw):
             W_PROMPT_FILE_AGENT_CONFIG_YAML,
             W_PROMPT_FILE_AGENT_CONFIG_KW.copy(),
         ),
+        (
+            W_PROMPT_FILE_W_TEMPLATE_ID_AGENT_CONFIG_YAML,
+            W_PROMPT_FILE_W_TEMPLATE_ID_AGENT_CONFIG_KW.copy(),
+        ),
     ],
 )
 def test_agentconfig_from_yaml(
@@ -1948,12 +1966,22 @@ def test_agentconfig_from_yaml(
                 config_dict,
             )
     else:
-        expected = config.AgentConfig(**expected_kw)
+        template_id = config_dict.get("template_id")
 
-        expected = dataclasses.replace(
-            expected,
+        if template_id is not None:
+            template_kw = {
+                "model_name": OTHER_MODEL_NAME,
+                "provider_base_url": OTHER_PROVIDER_BASE_URL,
+            }
+            installation_config.agent_configs = [
+                config.AgentConfig(id=template_id, **template_kw),
+            ]
+            expected_kw = template_kw | expected_kw
+
+        expected = config.AgentConfig(
             _installation_config=installation_config,
             _config_path=yaml_file,
+            **expected_kw,
         )
 
         found = config.AgentConfig.from_yaml(


### PR DESCRIPTION
If passed in YAML (as 'template_id'), looks up the template config from the installation, and merges it with the locally-specified config (local wins on any override).

Closes #169.