### PR TITLE
fix: disuse 'deepcopy' in 'AgentConfig.from_yaml

### DIFF
--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations  # forward refs in typing decls
 
-import copy
 import dataclasses
 import enum
 import functools
@@ -697,10 +696,12 @@ class AgentConfig:
                 }
 
                 template_config = ic_agent_configs_map[template_id]
-                local_config = copy.deepcopy(config)
-                local_config["_template_id"] = template_id
 
-                config = template_config.as_yaml | local_config
+                config = (
+                    template_config.as_yaml
+                    | config
+                    | {"_template_id": template_id}
+                )
 
             if "system_prompt" in config:
                 system_prompt = config.pop("system_prompt")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1992,6 +1992,9 @@ def test_agentconfig_from_yaml(
 
         assert found == expected
 
+        # See #180.
+        assert found._installation_config is installation_config
+
 
 @pytest.mark.parametrize("w_config_path", [False, True])
 @pytest.mark.parametrize(


### PR DESCRIPTION
It clones the installation_config, which can break subsequent lookups of e.g. the 'provider_base_url'.

Fixes #180.