### PR TITLE
chore: enable 'SOLIPLEX_PORT' envvar as default for '--port'

### DIFF
--- a/src/soliplex/cli.py
+++ b/src/soliplex/cli.py
@@ -137,6 +137,7 @@ def serve(
         "-p",
         "--port",
         help="Port number",
+        envvar="SOLIPLEX_PORT",
     ),
     uds: str = typer.Option(
         None,


### PR DESCRIPTION
Closes #193.

@runyaga I'm not sure that this fix actually satisfies your need in #193.

@mcdonc I'm not sure whether adding another envvar is a good idea.