### PR TITLE
chore: use template agents everywhere

### DIFF
--- a/example/completions/chat-bot/completion_config.yaml
+++ b/example/completions/chat-bot/completion_config.yaml
@@ -1,8 +1,9 @@
 id: "chat-bot"
 agent:
   system_prompt: "./prompt.txt"
-  model_name: "qwen3:latest"
+  template_id: "template_qwen3"
 tools:
   - tool_name: "soliplex.tools.get_current_datetime"
+  - tool_name: "soliplex.tools.get_current_user"
 # - tool_name: "<yourapp>.tools.search_documents"
 #     search_path: "/path/to/documents"

--- a/example/installation.yaml
+++ b/example/installation.yaml
@@ -200,7 +200,7 @@ haiku_rag_config_file: "./haiku.rag.yaml"
 
 agent_configs:
 
-  - id: "ollama_qwen3"
+  - id: "template_qwen3"
     model_name: "qwen3:latest"
     system_prompt: |
       You are an expert AI assistant specializing in information retrieval.
@@ -209,7 +209,7 @@ agent_configs:
 
       Always provide code or examples in Markdown blocks.
 
-  - id: "ollama_gpt_oss"
+  - id: "template_gpt_oss"
     model_name: "gpt-oss:20b"
     system_prompt: |
       You are an expert AI assistant specializing in information retrieval.

--- a/example/minimal.yaml
+++ b/example/minimal.yaml
@@ -83,13 +83,23 @@ environment:
 
 agent_configs:
 
-  - id: "ollama_qwen3"
+  - id: "template_qwen3"
     model_name: "qwen3:latest"
-    # No prompt:  this config is just a template
+    system_prompt: |
+      You are an expert AI assistant specializing in information retrieval.
 
-  - id: "ollama_gpt_oss"
+      Your answers should be clear, concise, and ready for production use.
+
+      Always provide code or examples in Markdown blocks.
+
+  - id: "template_gpt_oss"
     model_name: "gpt-oss:20b"
-    # No prompt:  this config is just a template
+    system_prompt: |
+      You are an expert AI assistant specializing in information retrieval.
+
+      Your answers should be clear, concise, and ready for production use.
+
+      Always provide code or examples in Markdown blocks.
 
 #==========================================================================
 # OIDC authentication provider configuration

--- a/example/rooms/haiku/room_config.yaml
+++ b/example/rooms/haiku/room_config.yaml
@@ -6,7 +6,7 @@ suggestions:
 - "Who am I?"
 - "What is a Soliplex installation?"
 agent:
-  template_id: "ollama_qwen3"
+  template_id: "template_qwen3"
   system_prompt: "./prompt.txt"
 allow_mcp: true
 tools:

--- a/example/rooms/mcptest/room_config.yaml
+++ b/example/rooms/mcptest/room_config.yaml
@@ -5,6 +5,7 @@ suggestions:
 - "What is the weather in <your location>?"
 
 agent:
+  template_id: "template_qwen3"
   system_prompt: "./prompt.txt"
 
 tools:

--- a/example/rooms/quiztest/room_config.yaml
+++ b/example/rooms/quiztest/room_config.yaml
@@ -3,6 +3,7 @@ name: "Quiz testing"
 description: "Quiz testing."
 logo_image: "./jeopardy.png"
 agent:
+  template_id: "template_qwen3"
   system_prompt: "UNUSED, see quiz config"
 quizzes:
   - id: "test_quiz"
@@ -12,4 +13,4 @@ quizzes:
     max_questions: 20
     judge_agent:
       id: "test_quiz_judge"
-      model_name: "qwen3"
+      template_id: "template_gpt_oss"


### PR DESCRIPTION
Uses feature from PR #170 to centralize agent config in the installation.  Prep for a rework of PR #128 to avoid duplicating room / completion configs.