### PR TITLE
chore!: disuse 'DEFAULT_AGENT_MODEL' env setting.

### DIFF
--- a/docs/config/agents.md
+++ b/docs/config/agents.md
@@ -21,10 +21,15 @@ agent:
   If it starts with a `./`, it will be treated as a filename in the
   same directory, whose contents will be read in its place.
 
+- `model_name`: a string, should be the identifier of an LLM model for the
+  agent.
+
+
 A minimal configuration, without an external prompt file:
 
 ```yaml
 agent:
+    model_name: "mistral:7b"
     system_prompt: |
         You are a knowledgeable assistant that helps users find information from a document knowledge base.
 
@@ -37,18 +42,16 @@ A minimal configuration, but with the prompt stored in external file:
 
 ```yaml
 agent:
+    model_name: "mistral:7b"
     system_prompt: "./prompt.txt"
 ```
 
 ## Optional Agent Elements
 
-- `model_name`: a string, defaulting to the value configured in
-  the installation environment as `DEFAULT_AGENT_MODEL`, should be the
-  identifier of an alternate model for the agent.  E.g.:
-
-  ```yaml
-  model_name: "mistral:7b"
-  ```
+- `template_id`: at string.  It must match the ID of one of the agents
+  configured in the top-level `installation.agent_configs` mapping.
+  If it is present, then any fields not set in the local configuration
+  will be copied from the template.
 
 - `provider_base_url`: a string, defaulting to the value configured in
   the installation environment as `OLLAMA_BASE_URL` is the base API URL for the agent's

--- a/docs/config/environment.md
+++ b/docs/config/environment.md
@@ -50,7 +50,6 @@ $ soliplex-cli list-environment example/installation.yaml
 ─────────────────────── Configured environment variables ───────────────────────
 
 - OLLAMA_BASE_URL          : MISSING
-- DEFAULT_AGENT_MODEL      : qwen3:latest
 - INSTALLATION_PATH        : file:.
 - RAG_LANCE_DB_PATH        : file:../db/rag
 - LOGFIRE_ENVIRONMENT      : container

--- a/docs/config/installation.md
+++ b/docs/config/installation.md
@@ -70,7 +70,10 @@ on how to configure the `haiku.rag` client used by Soliplex.
 
 An installation can declare agent configurations (which are normally bound
 to rooms / completions) at the top-level, such that they can be
-looked up by ID from Python code using `the_installation.get_agent_by_id`.
+looked up by ID from Python code using `the_installation.get_agent_by_id`,
+These top-level agent configurations are alos available as "templates" for
+agents defined in rooms / completions.
+
 
 ```yaml
 agent_configs:

--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -652,8 +652,8 @@ class AgentConfig:
     # Agent-specific options
     #
     id: str  # set as 'room-{room_id}' or 'completion-{completion_id}'
+    model_name: str
     kind: typing.ClassVar[str] = "default"
-    model_name: str = None
     retries: int = 3
 
     system_prompt: dataclasses.InitVar[str] = None
@@ -673,12 +673,6 @@ class AgentConfig:
     _template_id: str = None
 
     def __post_init__(self, system_prompt):
-        if self.model_name is None:
-            if self._installation_config is not None:
-                self.model_name = self._installation_config.get_environment(
-                    "DEFAULT_AGENT_MODEL",
-                )
-
         if system_prompt is not None:
             self._system_prompt_text = system_prompt
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -224,7 +224,6 @@ OLLAMA_BASE_URL = "https://example.com:12345"
 
 BARE_INSTALLATION_CONFIG_ENVIRONMENT = {
     "OLLAMA_BASE_URL": PROVIDER_BASE_URL,
-    "DEFAULT_AGENT_MODEL": MODEL_NAME,
 }
 
 TEST_QUIZ_ID = "test_quiz"
@@ -327,9 +326,11 @@ BOGUS_AGENT_CONFIG_YAML = ""
 
 EMPTY_AGENT_CONFIG_KW = dict(
     id=AGENT_ID,
+    model_name=MODEL_NAME,
 )
 EMPTY_AGENT_CONFIG_YAML = f"""
 id: "{AGENT_ID}"
+model_name: "{MODEL_NAME}"
 """
 
 EMPTY_W_KIND_AGENT_CONFIG_KW = dict(
@@ -355,10 +356,12 @@ model_name: "{MODEL_NAME}"
 AGENT_RETRIES = 7
 W_RETRIES_AGENT_CONFIG_KW = dict(
     id=AGENT_ID,
+    model_name=MODEL_NAME,
     retries=AGENT_RETRIES,
 )
 W_RETRIES_AGENT_CONFIG_YAML = f"""
 id: "{AGENT_ID}"
+model_name: "{MODEL_NAME}"
 retries: {AGENT_RETRIES}
 """
 
@@ -449,6 +452,7 @@ BARE_ROOM_CONFIG_KW = {
     "agent_config": config.AgentConfig(
         id=f"room-{ROOM_ID}",
         system_prompt=SYSTEM_PROMPT,
+        model_name=MODEL_NAME,
     ),
 }
 BARE_ROOM_CONFIG_YAML = f"""\
@@ -457,6 +461,7 @@ name: "{ROOM_NAME}"
 description: "{ROOM_DESCRIPTION}"
 agent:
     system_prompt: "{SYSTEM_PROMPT}"
+    model_name: "{MODEL_NAME}"
 """
 
 FULL_ROOM_CONFIG_KW = {
@@ -472,6 +477,7 @@ FULL_ROOM_CONFIG_KW = {
     "agent_config": config.AgentConfig(
         id=f"room-{ROOM_ID}",
         system_prompt=SYSTEM_PROMPT,
+        model_name=MODEL_NAME,
     ),
     "quizzes": [
         config.QuizConfig(
@@ -526,6 +532,7 @@ enable_attachments: true
 logo_image: "./{IMAGE_FILENAME}"
 agent:
     system_prompt: "{SYSTEM_PROMPT}"
+    model_name: "{MODEL_NAME}"
 tools:
     - tool_name: "soliplex.tools.get_current_datetime"
       allow_mcp: true
@@ -566,12 +573,14 @@ BARE_COMPLETION_CONFIG_KW = {
     "agent_config": config.AgentConfig(
         id=f"completion-{COMPLETION_ID}",
         system_prompt=SYSTEM_PROMPT,
+        model_name=MODEL_NAME,
     ),
 }
 BARE_COMPLETION_CONFIG_YAML = f"""\
 id: "{COMPLETION_ID}"
 agent:
     system_prompt: "{SYSTEM_PROMPT}"
+    model_name: "{MODEL_NAME}"
 """
 
 FULL_COMPLETION_CONFIG_KW = {
@@ -580,6 +589,7 @@ FULL_COMPLETION_CONFIG_KW = {
     "agent_config": config.AgentConfig(
         id=f"completion-{COMPLETION_ID}",
         system_prompt=SYSTEM_PROMPT,
+        model_name=MODEL_NAME,
     ),
     "tool_configs": {
         "get_current_datetime": config.ToolConfig(
@@ -614,6 +624,7 @@ id: "{COMPLETION_ID}"
 name: "{COMPLETION_NAME}"
 agent:
     system_prompt: "{SYSTEM_PROMPT}"
+    model_name: "{MODEL_NAME}"
 tools:
     - tool_name: "soliplex.tools.get_current_datetime"
     - tool_name: "soliplex.tools.search_documents"
@@ -1917,13 +1928,7 @@ def test_agentconfig_ctor(installation_config, kw):
 
     found = config.AgentConfig(**kw)
 
-    if "model_name" in kw:
-        assert found.model_name == kw["model_name"]
-    else:
-        assert (
-            found.model_name
-            is installation_config.get_environment.return_value
-        )
+    assert found.model_name == kw["model_name"]
 
 
 @pytest.mark.parametrize(
@@ -2068,7 +2073,10 @@ def test_agentconfig_llm_provider_kw(
         expected["api_key"] = installation_config.get_secret.return_value
 
     aconfig = config.AgentConfig(
-        id="test-agent", system_prompt="You are a test", **kw
+        id="test-agent",
+        system_prompt="You are a test",
+        model_name=MODEL_NAME,
+        **kw,
     )
 
     found = aconfig.llm_provider_kw
@@ -2104,7 +2112,6 @@ def test_agentconfig_as_yaml(
 
     ic_environ = {
         "OLLAMA_BASE_URL": OLLAMA_BASE_URL,
-        "DEFAULT_AGENT_MODEL": MODEL_NAME,
     }
     installation_config.get_environment = ic_environ.get
     agent_config_kw["_installation_config"] = installation_config
@@ -3768,6 +3775,7 @@ def test_installationconfig_agent_configs_map_wo_existing():
     agent_configs = [
         config.AgentConfig(
             id=f"agent-config-{i_agent_config}",
+            model_name=MODEL_NAME,
         )
         for i_agent_config in range(5)
     ]


### PR DESCRIPTION
BREAKING CHANGE:  do not merge this PR until dependent configs can catch up.

Agent configurations must now configure their 'model_name', either directly or via their template.

Closes #191.