### PR TITLE
Bump main to v0.17 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "soliplex"
-version = "0.15"
+version = "0.17"
 description = "<ALAN FILL THIS IN>"
 authors = [{ name = "Enfold", email = "info@enfoldsystems.net" }]
 readme = "README.md"


### PR DESCRIPTION
main is now 0.17 to allow its use from afsoc-rag that expects v0.16