### PR TITLE
Bump main to 0.18 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "soliplex"
-version = "0.17"
+version = "0.18"
 description = "<ALAN FILL THIS IN>"
 authors = [{ name = "Enfold", email = "info@enfoldsystems.net" }]
 readme = "README.md"


### PR DESCRIPTION
main in pyproject.,toml is now 0.18 to allow its checkout from afsoc-rag that expects >=v0.17