### PR TITLE
fix: ignore rooms whose dirnames start w/ '.'

### DIFF
--- a/docs/config/completions.md
+++ b/docs/config/completions.md
@@ -1,6 +1,8 @@
 # Completion Configuration Filesystem Layout
 
-A completion is configured via directory, whose name is the completion ID.
+A completion is configured via a directory, whose name is the completion ID.
+
+**NOTE:** directories whose names start with '.' are ignored.
 
 Within that directory should be one or two files:
 

--- a/docs/config/rooms.md
+++ b/docs/config/rooms.md
@@ -1,6 +1,8 @@
 # Room Configuration Filesystem Layout
 
-A room is configured via directory, whose name is the room ID.
+A room is configured via a directory, whose name is the room ID.
+
+**NOTE:** directories whose names start with '.' are ignored.
 
 Within that directory should be one or two files:
 

--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -1519,6 +1519,10 @@ def _find_configs(
 
     except NoSuchConfig:
         for sub in sorted(to_search.glob("*")):
+            # See #233
+            if sub.name.startswith("."):
+                continue
+
             if sub.is_dir():
                 sub_config = sub / filename_yaml
                 try:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4329,7 +4329,7 @@ def test_installationconfig_oidc_auth_system_configs_w_existing():
 
 
 def test_installationconfig_room_configs_wo_existing(temp_dir):
-    ROOM_IDS = ["foo", "bar"]
+    ROOM_IDS = ["foo", "bar", ".baz"]
 
     kw = BARE_INSTALLATION_CONFIG_KW.copy()
     kw["_config_path"] = temp_dir / "installation.yaml"
@@ -4342,6 +4342,10 @@ def test_installationconfig_room_configs_wo_existing(temp_dir):
         room_path = rooms / room_id
         room_path.mkdir()
         room_config = room_path / "room_config.yaml"
+
+        if room_id.startswith("."):
+            room_id = room_id[1:]
+
         room_config.write_text(
             BARE_ROOM_CONFIG_YAML.replace(
                 f'id: "{ROOM_ID}"',
@@ -4356,6 +4360,9 @@ def test_installationconfig_room_configs_wo_existing(temp_dir):
 
     assert found["foo"].id == "foo"
     assert found["bar"].id == "bar"
+
+    assert ".baz" not in found
+    assert "baz" not in found
 
 
 def test_installationconfig_room_configs_wo_existing_w_conflict(temp_dir):


### PR DESCRIPTION
Completions, too.

Closes #233.