### PR TITLE
fix: raise better error for missing secret

### DIFF
--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -1810,7 +1810,12 @@ class InstallationConfig:
         from soliplex import secrets as secrets_module  # avoid cycle
 
         secret_name = strip_secret_prefix(secret_name)
-        secret_config = self.secrets_map[secret_name]
+
+        try:
+            secret_config = self.secrets_map[secret_name]
+        except KeyError:
+            raise secrets_module.UnknownSecret(secret_name) from None
+
         return secrets_module.get_secret(secret_config)
 
     def interpolate_secret(self, value):

--- a/src/soliplex/secrets.py
+++ b/src/soliplex/secrets.py
@@ -9,6 +9,12 @@ class SecretError(ValueError):
     pass
 
 
+class UnknownSecret(SecretError):
+    def __init__(self, secret_name: str):
+        self.secret_name = secret_name
+        super().__init__(f"Unknown secret: {secret_name}")
+
+
 class SecretEnvVarNotFound(SecretError):
     def __init__(self, secret_name: str, env_var: str):
         self.secret_name = secret_name

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3719,14 +3719,14 @@ def test_installationconfig_secrets_map_w_existing():
     assert found is already
 
 
-NoSuchSecret = pytest.raises(KeyError)
+RaiseUnknownSecret = pytest.raises(secrets.UnknownSecret)
 NoRaise = contextlib.nullcontext()
 
 
 @pytest.mark.parametrize(
     "secret_map, expectation",
     [
-        ({}, NoSuchSecret),
+        ({}, RaiseUnknownSecret),
         ({SECRET_NAME_1: SECRET_CONFIG_1}, NoRaise),
     ],
 )
@@ -3751,7 +3751,7 @@ def test_installationconfig_get_secret(gs, secret_map, expectation):
     "value, secret_map, expectation, exp_value",
     [
         ("No secret here", {}, NoRaise, "No secret here"),
-        (f"Foo secret:{SECRET_NAME_1}", {}, NoSuchSecret, None),
+        (f"Foo secret:{SECRET_NAME_1}", {}, RaiseUnknownSecret, None),
         (
             f"Foo secret:{SECRET_NAME_1}",
             {SECRET_NAME_1: SECRET_CONFIG_1},


### PR DESCRIPTION
The bare 'KeyError' can get mapped into a 404 by view code.

Closes #241.