### PR TITLE
feat: show step events in the ui / chatroom

### DIFF
--- a/src/flutter/lib/agui_provider.dart
+++ b/src/flutter/lib/agui_provider.dart
@@ -18,6 +18,8 @@ class AguiProvider extends LlmProvider with ChangeNotifier {
   final AppStateController appState;
   final List<String> chatVariables;
 
+  Stream<ag_ui.BaseEvent> get stepsStream => _thread.stepsStream;
+
   static Future<AguiProvider> initialize({
     required ag_ui.AgUiClient aguiClient,
     required http.Client httpClient,

--- a/src/flutter/lib/infrastructure/quick_agui/thread.dart
+++ b/src/flutter/lib/infrastructure/quick_agui/thread.dart
@@ -71,6 +71,7 @@ class Thread {
     );
 
     await for (final event in client.runAgent(endpoint, agentInput)) {
+      _stepsController.add(event);
       switch (event) {
         case ag_ui.TextMessageChunkEvent(
           messageId: final msgId,

--- a/src/flutter/lib/views/chat_page.dart
+++ b/src/flutter/lib/views/chat_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:soliplex_client/agui_provider.dart';
 import 'package:soliplex_client/controllers.dart';
 import 'package:soliplex_client/views/map_page.dart';
 
@@ -24,7 +25,20 @@ class ChatPage extends ConsumerWidget {
         .roomConfig;
 
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        StreamBuilder(
+          stream: (llmProvider as AguiProvider).stepsStream.map<String>(
+            (e) => e.eventType.name,
+          ),
+          builder: (context, snapshot) {
+            final data = snapshot.data;
+            return Padding(
+              padding: EdgeInsetsGeometry.symmetric(horizontal: 8),
+              child: Text('Phase: ${data ?? ''}'),
+            );
+          },
+        ),
         Expanded(
           child: LlmChatView(
             provider: llmProvider,


### PR DESCRIPTION
@svarlet Seb, the `StepStartedEvent` and `StepFinishedEvent` didn't show up much / if at all, so I added every event to the `stepsStream` (line 74 of `thread.dart`) and displayed their event name in the ui at the top left