### PR TITLE
Revert "chore: drop 'room_id' from run-related persistence methods"

### DIFF
--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -183,6 +183,7 @@ class ThreadStorage(abc.ABC):
     async def new_run(
         self,
         *,
+        room_id: str,
         user_name: str,
         thread_id: str,
         run_metadata: RunMetadata = None,
@@ -198,6 +199,7 @@ class ThreadStorage(abc.ABC):
     @abc.abstractmethod
     async def get_run(
         self,
+        room_id: str,
         user_name: str,
         thread_id: str,
         run_id: str,
@@ -208,6 +210,7 @@ class ThreadStorage(abc.ABC):
     async def update_run(
         self,
         *,
+        room_id: str,
         user_name: str,
         thread_id: str,
         run_id: str,

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -564,6 +564,7 @@ class ThreadStorage(agui_package.ThreadStorage):
     async def new_run(
         self,
         *,
+        room_id: str,
         user_name: str,
         thread_id: str,
         run_metadata: RunMetadata | dict = None,
@@ -630,6 +631,7 @@ class ThreadStorage(agui_package.ThreadStorage):
 
     async def get_run(
         self,
+        room_id: str,
         user_name: str,
         thread_id: str,
         run_id: str,
@@ -651,6 +653,7 @@ class ThreadStorage(agui_package.ThreadStorage):
     async def update_run(
         self,
         *,
+        room_id: str,
         user_name: str,
         thread_id: str,
         run_id: str,

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -117,14 +117,9 @@ async def _check_user_thread_run(
     the_threads: agui_package.ThreadStorage,
 ) -> agui_package.Run:
     """Check for an existing thread / run for the user within the given room"""
-    await _check_user_thread(
-        room_id=room_id,
-        thread_id=thread_id,
-        user_name=user_name,
-        the_threads=the_threads,
-    )
     try:
         run = await the_threads.get_run(
+            room_id=room_id,
             thread_id=thread_id,
             user_name=user_name,
             run_id=run_id,
@@ -341,6 +336,7 @@ async def post_room_agui_thread_id(
 
     try:
         run = await the_threads.new_run(
+            room_id=room_id,
             user_name=user_name,
             thread_id=thread_id,
             parent_run_id=parent_run_id,
@@ -510,6 +506,7 @@ async def post_room_agui_thread_id_run_id_meta(
     }
 
     await the_threads.update_run(
+        room_id=room_id,
         thread_id=thread_id,
         user_name=user_name,
         run_id=run_id,

--- a/tests/unit/agui/test_persistence.py
+++ b/tests/unit/agui/test_persistence.py
@@ -652,6 +652,7 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     gotten = await ts.get_run(
         user_name=USER_NAME,
+        room_id=ROOM_ID,  # XXX why?
         thread_id=thread_id,
         run_id=initial_run_id,
     )
@@ -663,12 +664,14 @@ async def test_threadstorage_thread_run_cru(the_async_session):
     with pytest.raises(agui_package.UnknownRun):
         await ts.get_run(
             user_name=USER_NAME,
+            room_id=ROOM_ID,  # XXX why?
             thread_id=thread_id,
             run_id="NONESUCH",
         )
 
     added = await ts.new_run(
         user_name=USER_NAME,
+        room_id=ROOM_ID,  # XXX why?
         thread_id=thread_id,
         run_metadata={"label": "added"},
     )
@@ -678,6 +681,7 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     updated = await ts.update_run(
         user_name=USER_NAME,
+        room_id=ROOM_ID,  # XXX why?
         thread_id=thread_id,
         run_id=added_id,
         run_metadata={
@@ -694,6 +698,7 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     updated_again = await ts.update_run(
         user_name=USER_NAME,
+        room_id=ROOM_ID,  # XXX why?
         thread_id=thread_id,
         run_id=added_id,
         run_metadata=agui_persistence.RunMetadata(
@@ -710,6 +715,7 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     cleared = await ts.update_run(
         user_name=USER_NAME,
+        room_id=ROOM_ID,  # XXX why?
         thread_id=thread_id,
         run_id=added_id,
         run_metadata=None,
@@ -723,6 +729,7 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     cleared_again = await ts.update_run(
         user_name=USER_NAME,
+        room_id=ROOM_ID,  # XXX why?
         thread_id=thread_id,
         run_id=added_id,
         run_metadata=None,
@@ -736,6 +743,7 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     parent = await ts.new_run(
         user_name=USER_NAME,
+        room_id=ROOM_ID,  # XXX why?
         thread_id=thread_id,
         run_metadata=agui_persistence.RunMetadata(label="parent"),
     )
@@ -756,6 +764,7 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     spare = await ts.new_run(
         user_name=USER_NAME,
+        room_id=ROOM_ID,  # XXX why?
         thread_id=thread_id,
         run_metadata=agui_persistence.RunMetadata(label="spare"),
         parent_run_id=parent_id,
@@ -779,6 +788,7 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     wo_meta = await ts.new_run(
         user_name=USER_NAME,
+        room_id=ROOM_ID,  # XXX why?
         thread_id=thread_id,
     )
 

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -273,17 +273,12 @@ async def test__check_user_thread(
         (True, raises_httpexc(code=404, match="No such run")),
     ],
 )
-@mock.patch("soliplex.views.agui._check_user_thread")
 async def test__check_user_thread_run(
-    cut,
     the_threads,
-    test_thread,
     test_run,
     w_miss,
     expectation,
 ):
-    cut.return_value = test_thread
-
     if w_miss:
         the_threads.get_run.side_effect = agui_package.UnknownRun(
             run_id=TEST_RUN_ID,
@@ -304,16 +299,10 @@ async def test__check_user_thread_run(
         assert found_run is the_threads.get_run.return_value
 
     the_threads.get_run.assert_called_once_with(
+        room_id=TEST_ROOM_ID,
         user_name=USER_NAME,
         thread_id=TEST_THREAD_ID,
         run_id=TEST_RUN_ID,
-    )
-
-    cut.assert_called_once_with(
-        room_id=TEST_ROOM_ID,
-        thread_id=TEST_THREAD_ID,
-        user_name=USER_NAME,
-        the_threads=the_threads,
     )
 
 
@@ -753,6 +742,7 @@ async def test_post_room_agui_thread_id(
         assert found.parent_run_id == w_parent_id
 
         the_threads.new_run.assert_called_once_with(
+            room_id=TEST_ROOM_ID,
             user_name=USER_NAME,
             thread_id=TEST_THREAD_ID,
             run_metadata=run_meta_kw,
@@ -999,6 +989,7 @@ async def test_post_room_agui_thread_id_run_id_meta(cuir, the_threads, w_meta):
     assert found.status_code == 205
 
     the_threads.update_run.assert_called_once_with(
+        room_id=TEST_ROOM_ID,
         user_name=USER_NAME,
         thread_id=TEST_THREAD_ID,
         run_id=TEST_RUN_ID,


### PR DESCRIPTION
Reverts soliplex/soliplex#279

Client fails with "transaction already started":
```
  File "/mnt/work/tseaver/projects/agendaless/Enfold/src/soliplex/src/soliplex/views/agui.py", line 432, in post_room_agui_thread_id_run_id
    run = await _check_user_thread_run(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/mnt/work/tseaver/projects/agendaless/Enfold/src/soliplex/src/soliplex/views/agui.py", line 127, in _check_user_thread_run
    run = await the_threads.get_run(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File "/mnt/work/tseaver/projects/agendaless/Enfold/src/soliplex/src/soliplex/agui/persistence.py", line 637, in get_run
    async with self.session as session:
               ^^^^^^^^^^^^
  File "/opt/Python-3.13.0/lib/python3.13/contextlib.py", line 214, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/work/tseaver/projects/agendaless/Enfold/src/soliplex/src/soliplex/agui/persistence.py", line 412, in session
    async with self._session.begin():
               ~~~~~~~~~~~~~~~~~~~^^
  File "/mnt/work/tseaver/projects/agendaless/Enfold/src/soliplex/venv/lib/python3.13/site-packages/sqlalchemy/ext/asyncio/base.py", line 121, in __aenter__
    return await self.start(is_ctxmanager=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/work/tseaver/projects/agendaless/Enfold/src/soliplex/venv/lib/python3.13/site-packages/sqlalchemy/ext/asyncio/session.py", line 1876, in start
    await greenlet_spawn(
    ...<3 lines>...
    )
  File "/mnt/work/tseaver/projects/agendaless/Enfold/src/soliplex/venv/lib/python3.13/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 190, in greenlet_spawn
    result = context.switch(*args, **kwargs)
  File "/mnt/work/tseaver/projects/agendaless/Enfold/src/soliplex/venv/lib/python3.13/site-packages/sqlalchemy/orm/session.py", line 1941, in begin
    raise sa_exc.InvalidRequestError(
        "A transaction is already begun on this Session."
    )
sqlalchemy.exc.InvalidRequestError: A transaction is already begun on this Session.

```