### PR TITLE
feat: add 'agui_state' tool

### DIFF
--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -10,6 +10,7 @@ from pydantic_ai.models import openai as openai_models
 from pydantic_ai.providers import ollama as ollama_providers
 from pydantic_ai.providers import openai as openai_providers
 
+from soliplex import agui
 from soliplex import config
 from soliplex import mcp_client
 from soliplex import models
@@ -22,6 +23,7 @@ class AgentDependencies(pydantic.BaseModel):
     user: models.UserProfile = None  # TBD make required
     tool_configs: ToolConfigMap = None
     agui_emitter: typing.Any = None
+    state: agui.AGUI_State = None
 
 
 SoliplexAgent = ai_agent.AbstractAgent[AgentDependencies, typing.Any]

--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import abc
 import datetime
+import typing
 
 import fastapi
 from ag_ui import core as agui_core
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
 AGUI_Events = list[agui_core.BaseEvent]
+AGUI_State = dict[str, typing.Any] | None
 
 
 class UnknownThread(fastapi.HTTPException):

--- a/src/soliplex/tools.py
+++ b/src/soliplex/tools.py
@@ -7,6 +7,7 @@ from haiku.rag.graph.research import graph as rag_research_graph
 from haiku.rag.graph.research import state as rag_research_state
 
 from soliplex import agents
+from soliplex import agui
 from soliplex import config
 from soliplex import models
 
@@ -131,3 +132,10 @@ async def research_report(
             agui_emitter=ctx.deps.agui_emitter,
         )
         return await graph.run(state=state, deps=graph_deps)
+
+
+async def agui_state(
+    ctx: pydantic_ai.RunContext[agents.AgentDependencies],
+) -> agui.AGUI_State:
+    """Return the AGUI state."""
+    return ctx.deps.state

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -200,3 +200,36 @@ async def test_rag_research(rr, rr_graph, rr_state, rag_client):
         db_path=rrt_config.rag_lancedb_path,
         config=hr_config,
     )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("w_state", [False, True])
+async def test_agui_state(w_state):
+    state = {
+        "foo": "Foo",
+        "bar": {
+            "baz": "Baz",
+        },
+    }
+    if w_state:
+        deps = mock.create_autospec(
+            agents.AgentDependencies,
+            user=USER,
+            tool_configs={},
+            state=state,
+        )
+        expected = state
+    else:
+        deps = mock.create_autospec(
+            agents.AgentDependencies,
+            user=USER,
+            tool_configs={},
+            state=None,
+        )
+        expected = None
+
+    ctx = mock.Mock(spec_set=(["deps"]), deps=deps)
+
+    found = await tools.agui_state(ctx=ctx)
+
+    assert found == expected


### PR DESCRIPTION
Exposes 'state' from the AG-UI 'RunAgentInput' to the LLM.

The field for that state is in the 'agents.AgentDependencies' model, and gets populated via 'pydantic_ai.ui.agui'.

Closes #285.