### PR TITLE
tests: remove functest bitrot

### DIFF
--- a/.github/workflows/soliplex.yaml
+++ b/.github/workflows/soliplex.yaml
@@ -59,6 +59,11 @@ jobs:
         run: |
           pip list
           py.test
+      - name: Run soliplex functional tests
+        run: |
+          pip list
+          # 'tests/functional/' is excluded by default
+          py.test --no-cov -m "not needs_llm" tests/functional/
       - name: Run ruff linter
         run: |
           ruff check

--- a/example/functest_no_llm.yaml
+++ b/example/functest_no_llm.yaml
@@ -1,0 +1,113 @@
+#==========================================================================
+# Minimal Soliplex installation configuration
+#
+# Please See the corresponding sections 'example/installation.yaml' for
+# descriptions of the defaults for sections not configured here.
+#==========================================================================
+
+id: "soliplex-conf-functest-no-llm"
+
+#==========================================================================
+# Meta-configuration
+#==========================================================================
+
+#==========================================================================
+# Secrets
+#
+# NOTE This configuration does not wire up any external APIs / MCP client
+# tools, and therefore requires no secrets beyond the one defined below,
+# which gets auto-populated at startup if it is not found in the environment.
+#==========================================================================
+
+secrets:
+
+  # ----------------------------------------------------------------------
+  # MCP room token generation / validation secret
+  #
+  # If not set in the environment, we generate a random value at startup,
+  # which will invalidate any previously-generated MCP room tokens.
+  # ----------------------------------------------------------------------
+  - secret_name: "URL_SAFE_TOKEN_SECRET"
+    sources:
+      - kind: "env_var"
+        env_var_name: "SOLIPLEX_URL_SAFE_TOKEN_SECRET"
+      - kind: "random_chars"
+
+#==========================================================================
+# Environment Variables
+#==========================================================================
+
+environment:
+
+  #------------------------------------------------------------------------
+  #  This profile explicitly avoids defining the 'OLLAMA_BASE_URL'
+  #  envvar, FBO running functests under CI without any LLM interaction.
+  #------------------------------------------------------------------------
+  #- "OLLAMA_BASE_URL"
+
+  #------------------------------------------------------------------------
+  # 'soliplex': on-disk configuration locations
+  #------------------------------------------------------------------------
+
+  - name: "INSTALLATION_PATH"
+    value: "file:."
+
+  - name: "RAG_LANCE_DB_PATH"
+    value: "file:../db/rag"
+
+
+#==========================================================================
+# Global 'haiku-rag' configuration
+#==========================================================================
+
+haiku_rag_config_file: "./haiku.rag.yaml"
+
+
+#==========================================================================
+# Agent configurations
+#==========================================================================
+
+agent_configs:
+
+  - id: "default_chat"
+    model_name: "qwen3:latest"
+    system_prompt: |
+      You are an expert AI assistant specializing in information retrieval.
+
+      Your answers should be clear, concise, and ready for production use.
+
+      Always provide code or examples in Markdown blocks.
+
+  - id: "alternate_chat"
+    model_name: "gpt-oss:20b"
+    system_prompt: |
+      You are an expert AI assistant specializing in information retrieval.
+
+      Your answers should be clear, concise, and ready for production use.
+
+      Always provide code or examples in Markdown blocks.
+
+#==========================================================================
+# OIDC authentication provider configuration
+#==========================================================================
+
+#==========================================================================
+# Rooms configuration
+#
+# We avoid the default here, because the 'mcptest' room uses the SmitheryAI
+# registry, and hence requires additional secrets
+#==========================================================================
+room_paths:
+  - "./rooms/haiku"
+  - "./rooms/joker"
+  - "./rooms/faux"
+  - "./rooms/quiztest"
+  - "./rooms/research"
+
+#==========================================================================
+# Completions configuration
+#==========================================================================
+
+#==========================================================================
+# Quizzes configuration
+#==========================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ addopts = "--cov=soliplex --cov=tests/unit --cov-branch --cov-fail-under=100"
 filterwarnings = [
     # "ignore::DeprecationWarning:<source-package>",
 ]
+markers = [
+    "needs_llm: functest requiring an LLM",
+]
 
 [tool.coverage.run]
 omit = []

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from fastapi import testclient
+
+from soliplex import main
+
+
+@pytest.fixture(scope="module")
+def client():
+    with testclient.TestClient(
+        main.create_app("example/minimal.yaml")
+    ) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def client_no_llm():
+    with testclient.TestClient(
+        main.create_app("example/functest_no_llm.yaml")
+    ) as client:
+        yield client

--- a/tests/functional/test_agent_tool_calling.py
+++ b/tests/functional/test_agent_tool_calling.py
@@ -1,0 +1,45 @@
+import pytest
+
+SYSTEM_PROMPT = """\
+You are an expert AI assistant specializing in information retrieval.
+
+Your answers should be clear, concise, and ready for production use.
+
+Always provide code or examples in Markdown blocks.
+
+If asked for the current time, you must use the 'get_current_datetime_test'
+tool.
+"""
+
+
+def get_current_datetime_test():
+    return "2025-09-30T09:30:01.0+00:00"
+
+
+@pytest.fixture(scope="module")
+def agent(client):
+    the_installation = client.app_state["the_installation"]
+    agent = the_installation.get_agent_by_id("alternate_chat")
+    agent.instructions = SYSTEM_PROMPT
+    agent.toolsets[0].add_function(get_current_datetime_test)
+
+    return agent
+
+
+@pytest.mark.asyncio
+@pytest.mark.needs_llm
+async def test_agent_tool_calling_w_run(agent):
+    res = await agent.run("what is the date?")
+    assert "2025" in res.output
+    assert "09" in res.output or "September" in res.output
+
+
+@pytest.mark.asyncio
+@pytest.mark.needs_llm
+async def test_agent_tool_calling_w_streaming(agent):
+    output = ""
+    async with agent.run_stream("what is the date?") as res:
+        async for message in res.stream_text():
+            output = message
+    assert "2025" in output
+    assert "09" in output or "September" in output

--- a/tests/functional/test_agui_thread.py
+++ b/tests/functional/test_agui_thread.py
@@ -1,0 +1,79 @@
+import json
+import uuid
+from unittest import mock
+
+import pydantic
+from ag_ui import core as agui_core
+
+from soliplex.agui import parser as agui_parser
+
+EVENT_DESERIALIZER = pydantic.TypeAdapter(agui_core.Event)
+
+IDENTITY_QUERY = "Who am I?"
+
+
+@mock.patch("soliplex.auth.authenticate")
+def test_post_rooms_roomid_agui_etc(auth_fn, client_no_llm):
+    new_thread_request = {"metadata": {"name": "functest"}}
+
+    auth_fn.return_value = {
+        "name": "Phreddy Phlyntstone",
+        "email": "phreddy@example.com",
+    }
+
+    room_id = "faux"
+
+    print(f"New thread in room {room_id}")
+
+    response = client_no_llm.post(
+        f"/api/v1/rooms/{room_id}/agui",
+        json=new_thread_request,
+    )
+    assert response.status_code == 200
+
+    new_thread_json = response.json()
+    assert new_thread_json["room_id"] == room_id
+    thread_id = new_thread_json["thread_id"]
+
+    (run_id,) = new_thread_json["runs"]
+
+    initial_run_request = {
+        "thread_id": thread_id,
+        "run_id": run_id,
+        "state": None,
+        "messages": [
+            {
+                "id": str(uuid.uuid4()),
+                "role": "user",
+                "content": IDENTITY_QUERY,
+            },
+        ],
+        "context": [],
+        "tools": [],
+        "forwarded_props": None,
+    }
+
+    with client_no_llm.stream(
+        method="POST",
+        url=f"/api/v1/rooms/{room_id}/agui/{thread_id}/{run_id}",
+        json=initial_run_request,
+    ) as response:
+        assert response.status_code == 200
+
+        # Response is SSE JSON
+
+        pfx = "data: "
+        pfx_len = len(pfx)
+
+        event_log = []
+        esp = agui_parser.EventStreamParser(event_log=event_log)
+
+        for raw_line in response.iter_lines():
+            if raw_line:
+                event_json = json.loads(raw_line[pfx_len:])
+                # Work around ag_ui issue #756??
+                # agui_event = EVENT_DESERIALIZER.validate_python(
+                #    event_json
+                # )
+                agui_event = agui_parser.agui_event_from_json(event_json)
+                esp(agui_event)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1,42 +1,24 @@
-import json
-import os
-import random
-import time
 from unittest import mock  # s.b. only for the 'auth_module.authenticate' call
 
 import pytest
-from fastapi import testclient
-
-from soliplex import main
-
-#
-#   Envvar:  limit max number of rooms tested.
-#
-SOLIPLEX_FUNCTEST_MAX_ROOMS = "SOLIPLEX_FUNCTEST_MAX_ROOMS"
 
 
-@pytest.fixture(scope="module")
-def client():
-    with testclient.TestClient(main.create_app()) as client:
-        yield client
-
-
-def test_health_check(client):
-    response = client.get("/api/ok")
+def test_health_check(client_no_llm):
+    response = client_no_llm.get("/api/ok")
 
     assert response.status_code == 200
     assert response.text == "OK"
 
 
 @mock.patch("soliplex.auth.authenticate")
-def test_rooms_endpoints(auth_fn, client):
-    get_rooms_response = client.get("/api/v1/rooms")
+def test_rooms_endpoints(auth_fn, client_no_llm):
+    get_rooms_response = client_no_llm.get("/api/v1/rooms")
     rooms_manifest = get_rooms_response.json()
 
     room_id = "haiku"
     room_info = rooms_manifest[room_id]
 
-    get_room_response = client.get(f"/api/v1/rooms/{room_id}")
+    get_room_response = client_no_llm.get(f"/api/v1/rooms/{room_id}")
     assert get_room_response.status_code == 200
     ext_room_info = get_room_response.json()
 
@@ -50,66 +32,7 @@ def test_rooms_endpoints(auth_fn, client):
 
 
 @mock.patch("soliplex.auth.authenticate")
-def test_post_convos_new_rooms(auth_fn, client):
-    IDENTITY_QUERY = "Who am I?"
-    identity_query = {"text": IDENTITY_QUERY}
-    TIME_QUERY = "What time is it?"
-    time_query = {"text": TIME_QUERY}
-
-    auth_fn.return_value = {
-        "name": "Phreddy Phlyntstone",
-        "email": "phreddy@example.com",
-    }
-
-    get_rooms_response = client.get("/api/v1/rooms")
-    assert get_rooms_response.status_code == 200
-    rooms_manifest = get_rooms_response.json()
-
-    room_ids = sorted(rooms_manifest)
-
-    max_rooms = os.getenv(SOLIPLEX_FUNCTEST_MAX_ROOMS)
-    if max_rooms is not None:
-        room_ids = random.sample(room_ids, int(max_rooms))
-
-    for room_id in room_ids:
-        response = client.post(
-            f"/api/v1/convos/new/{room_id}",
-            json=identity_query,
-        )
-        assert response.status_code == 200
-
-        new_convo_json = response.json()
-        assert new_convo_json["room_id"] == room_id
-        assert new_convo_json["name"] == IDENTITY_QUERY
-        convo_uuid = new_convo_json["convo_uuid"]
-
-        new_convo_messages = new_convo_json["message_history"]
-        user_msg, llm_msg = new_convo_messages
-        assert user_msg["origin"] == "user"
-        assert user_msg["text"] == IDENTITY_QUERY
-        assert llm_msg["origin"] == "llm"
-
-        response = client.post(
-            f"/api/v1/convos/{convo_uuid}",
-            json=time_query,
-        )
-        assert response.status_code == 200
-
-        # Response is NLD JSON.
-        # old_convo_json = response.json()
-        user_msg, *llm_messages = [
-            json.loads(line) for line in response.text.splitlines()
-        ]
-        assert user_msg["role"] == "user"  #  why is this not "origin"?
-        assert user_msg["content"] == TIME_QUERY  #  why is this not "text"?
-
-        last_llm_msg = llm_messages[-1]
-        assert last_llm_msg["role"] == "model"  # why is this not "origin"
-
-        time.sleep(5)
-
-
-@mock.patch("soliplex.auth.authenticate")
+@pytest.mark.needs_llm
 def test_get_quiz_post_quiz_question(auth_fn, client):
     auth_fn.return_value = {
         "name": "Phreddy Phlyntstone",
@@ -150,33 +73,3 @@ def test_get_quiz_post_quiz_question(auth_fn, client):
             assert (
                 answer_info["expected_output"] == question["expected_output"]
             )
-
-
-# Somehow we need the following fixture to make
-# the test_agent_tool_calling test work
-@pytest.fixture
-def anyio_backend():
-    return "asyncio"
-
-
-@pytest.mark.anyio
-async def test_agent_tool_calling(client):
-    def get_current_datetime():
-        return "2025-09-30T09:30:01.0+00:00"
-
-    the_installation = client.app_state["the_installation"]
-    agent = the_installation.get_agent_by_id("ollama_gpt_oss")
-    agent.toolsets[0].add_function(get_current_datetime)
-
-    # Tool support with streaming
-    output = ""
-    async with agent.run_stream("what is the date?") as res:
-        async for message in res.stream_text():
-            output = message
-    assert "2025" in output
-    assert "09" in output or "September" in output
-
-    # Tool support without streaming
-    res = await agent.run("what is the date?")
-    assert "2025" in res.output
-    assert "09" in res.output or "September" in res.output


### PR DESCRIPTION
Split unrelated tests into separate modules.

Drop the 'convos'-related tests.

Add a test of an AGUI run, using the 'faux' room only.

Run the functests do not use Ollama under CI.