### PR TITLE
Add support for Slackbot

### DIFF
--- a/example/installation.yaml
+++ b/example/installation.yaml
@@ -105,6 +105,9 @@ secrets:
   - "SMITHERY_AI_API_KEY"
   - "SMITHERY_AI_PROFILE"
 
+  - "SLACK_SIGNING_SECRET"
+  - "SLACK_BOT_TOKEN"
+
   # ----------------------------------------------------------------------
   # MCP room token generation / validation secret
   #

--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -83,6 +83,7 @@ def create_app(
     app.include_router(installation_views.router, prefix="/api")
     app.include_router(quizzes_views.router, prefix="/api")
     app.include_router(rooms_views.router, prefix="/api")
+    app.include_router(slack_views.router, prefix="/api")
     app.include_router(views.router, prefix="/api")
 
     # pragma: NO COVER

--- a/src/soliplex/views/slack.py
+++ b/src/soliplex/views/slack.py
@@ -1,0 +1,644 @@
+"""Slack events API router.
+
+Implements a Slack bot that connects to Soliplex rooms/agents.
+Based on: https://ai-sdk.dev/cookbook/guides/slackbot
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import time
+import typing
+
+import fastapi
+import httpx
+import pydantic
+from fastapi import BackgroundTasks
+
+from soliplex import installation
+from soliplex import models
+
+logger = logging.getLogger(__name__)
+
+router = fastapi.APIRouter(tags=["slack"])
+
+depend_the_installation = installation.depend_the_installation
+
+
+# =============================================================================
+# Pydantic Models for Slack Events
+# =============================================================================
+
+
+class SlackUrlVerificationPayload(pydantic.BaseModel):
+    """Slack URL verification challenge payload."""
+
+    type: typing.Literal["url_verification"]
+    token: str | None = None
+    challenge: str
+
+
+class SlackEventMessage(pydantic.BaseModel):
+    """A message event from Slack."""
+
+    type: str  # "message" or "app_mention"
+    subtype: str | None = None
+    user: str | None = None
+    text: str | None = None
+    ts: str  # Timestamp, also serves as message ID
+    channel: str
+    channel_type: str | None = None  # "im" for DMs, "channel" for public, etc.
+    thread_ts: str | None = None  # Parent thread timestamp (if in a thread)
+    bot_id: str | None = None  # Present if message is from a bot
+
+    @property
+    def is_bot_message(self) -> bool:
+        """Check if this message was sent by a bot."""
+        return self.bot_id is not None or self.subtype == "bot_message"
+
+    @property
+    def is_dm(self) -> bool:
+        """Check if this message is a direct message."""
+        return self.channel_type == "im"
+
+    @property
+    def thread_id(self) -> str:
+        """Get the thread ID (thread_ts if in thread, otherwise ts)."""
+        return self.thread_ts or self.ts
+
+
+class SlackEventCallbackPayload(pydantic.BaseModel):
+    """Slack event callback payload."""
+
+    type: typing.Literal["event_callback"]
+    token: str | None = None
+    team_id: str
+    event: SlackEventMessage
+    event_id: str
+    event_time: int
+
+
+# Union type for all possible Slack payloads
+SlackEventPayload = SlackUrlVerificationPayload | SlackEventCallbackPayload
+
+
+# =============================================================================
+# Slack API Client
+# =============================================================================
+
+
+class SlackClient:
+    """Simple async Slack API client."""
+
+    def __init__(self, bot_token: str):
+        self.bot_token = bot_token
+        self.base_url = "https://slack.com/api"
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        **kwargs,
+    ) -> dict:
+        """Make a request to the Slack API."""
+        headers = {
+            "Authorization": f"Bearer {self.bot_token}",
+            "Content-Type": "application/json; charset=utf-8",
+        }
+        async with httpx.AsyncClient() as client:
+            response = await client.request(
+                method,
+                f"{self.base_url}/{endpoint}",
+                headers=headers,
+                **kwargs,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    async def post_message(
+        self,
+        channel: str,
+        text: str,
+        thread_ts: str | None = None,
+        mrkdwn: bool = True,
+    ) -> dict:
+        """Post a message to a Slack channel."""
+        payload = {
+            "channel": channel,
+            "text": text,
+            "mrkdwn": mrkdwn,
+        }
+        if thread_ts:
+            payload["thread_ts"] = thread_ts
+        return await self._request("POST", "chat.postMessage", json=payload)
+
+    async def update_message(
+        self,
+        channel: str,
+        ts: str,
+        text: str,
+    ) -> dict:
+        """Update an existing message."""
+        payload = {
+            "channel": channel,
+            "ts": ts,
+            "text": text,
+        }
+        return await self._request("POST", "chat.update", json=payload)
+
+    async def get_thread_messages(
+        self,
+        channel: str,
+        thread_ts: str,
+        limit: int = 100,
+    ) -> list[dict]:
+        """Get messages in a thread."""
+        result = await self._request(
+            "GET",
+            "conversations.replies",
+            params={
+                "channel": channel,
+                "ts": thread_ts,
+                "limit": limit,
+            },
+        )
+        return result.get("messages", [])
+
+    async def get_channel_info(
+        self,
+        channel: str,
+    ) -> dict:
+        """Get channel information including name."""
+        result = await self._request(
+            "GET",
+            "conversations.info",
+            params={"channel": channel},
+        )
+        return result.get("channel", {})
+
+
+# =============================================================================
+# Request Signature Verification
+# =============================================================================
+
+
+async def verify_slack_signature(
+    request: fastapi.Request,
+    the_installation: installation.Installation,
+) -> bytes:
+    """Verify that the request came from Slack.
+
+    Raises HTTPException if verification fails.
+    Returns the raw body bytes for further processing.
+    """
+    try:
+        signing_secret = the_installation.get_secret("SLACK_SIGNING_SECRET")
+    except KeyError:
+        logger.warning("SLACK_SIGNING_SECRET not configured")
+        raise fastapi.HTTPException(
+            status_code=500,
+            detail="Slack signing secret not configured",
+        )
+
+    timestamp = request.headers.get("X-Slack-Request-Timestamp")
+    signature = request.headers.get("X-Slack-Signature")
+
+    if not timestamp or not signature:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail="Missing Slack signature headers",
+        )
+
+    # Check timestamp to prevent replay attacks (allow 5 minutes)
+    current_time = time.time()
+    if abs(current_time - int(timestamp)) > 60 * 5:
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail="Request timestamp too old",
+        )
+
+    # Get raw body
+    body = await request.body()
+
+    # Compute expected signature
+    sig_basestring = f"v0:{timestamp}:{body.decode('utf-8')}"
+    computed_signature = (
+        "v0="
+        + hmac.new(
+            signing_secret.encode("utf-8"),
+            sig_basestring.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+    )
+
+    if not hmac.compare_digest(computed_signature, signature):
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail="Invalid request signature",
+        )
+
+    return body
+
+
+# =============================================================================
+# Markdown Conversion
+# =============================================================================
+
+
+def convert_markdown_to_slack(text: str) -> str:
+    """Convert standard markdown to Slack's mrkdwn format."""
+    # Bold: **text** -> *text*
+    import re
+
+    text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text)
+    # Links: [text](url) -> <url|text>
+    text = re.sub(r"\[(.+?)\]\((.+?)\)", r"<\2|\1>", text)
+    # Code blocks remain the same in Slack
+    return text
+
+
+def extract_room_id_from_channel_name(channel_name: str) -> str | None:
+    """Extract room ID from channel name.
+
+    Channel format: soliplex_ROOM_ID (e.g., soliplex_mcptest, soliplex_faux)
+    Returns the room ID or None if the channel doesn't match the pattern.
+    """
+    prefix = "soliplex_"
+    if channel_name.startswith(prefix):
+        return channel_name[len(prefix):]
+    return None
+
+
+# =============================================================================
+# Caches
+# =============================================================================
+
+# Cache for channel ID -> channel name mapping to avoid repeated API calls
+_channel_name_cache: dict[str, str] = {}
+
+# In-memory store for DM room selections: {channel_id: room_id}
+# In production, consider using Redis or a database for persistence
+_dm_room_selections: dict[str, str] = {}
+
+
+def get_dm_room_selection(channel_id: str) -> str | None:
+    """Get the selected room for a DM channel."""
+    return _dm_room_selections.get(channel_id)
+
+
+def set_dm_room_selection(channel_id: str, room_id: str) -> None:
+    """Set the selected room for a DM channel."""
+    _dm_room_selections[channel_id] = room_id
+
+
+def clear_dm_room_selection(channel_id: str) -> None:
+    """Clear the selected room for a DM channel."""
+    _dm_room_selections.pop(channel_id, None)
+
+
+def parse_room_selection(text: str, available_rooms: list[str]) -> str | None:
+    """Parse user's room selection from text.
+
+    Accepts:
+    - Room name directly (e.g., "mcptest")
+    - Number (e.g., "1", "2")
+    - "switch" or "change" to reset selection
+
+    Returns the room_id or None if not a valid selection.
+    """
+    text = text.strip().lower()
+
+    # Check for reset commands
+    if text in ("switch", "change", "reset", "menu", "rooms"):
+        return "__RESET__"
+
+    # Check if it's a number
+    if text.isdigit():
+        idx = int(text) - 1  # 1-indexed for users
+        if 0 <= idx < len(available_rooms):
+            return available_rooms[idx]
+        return None
+
+    # Check if it matches a room name
+    for room_id in available_rooms:
+        if text == room_id.lower():
+            return room_id
+
+    return None
+
+
+def format_room_menu(rooms: dict) -> str:
+    """Format the room selection menu for Slack."""
+    lines = ["*Please select a room to chat with:*\n"]
+    for i, (room_id, room_info) in enumerate(rooms.items(), 1):
+        name = room_info.get("name", room_id)
+        description = room_info.get("description", "")
+        if description:
+            lines.append(f"*{i}.* {name} (`{room_id}`)\n    _{description}_")
+        else:
+            lines.append(f"*{i}.* {name} (`{room_id}`)")
+    lines.append("\n_Reply with the number or room name to select._")
+    lines.append("_Type `switch` anytime to change rooms._")
+    return "\n".join(lines)
+
+
+# =============================================================================
+# Event Handlers
+# =============================================================================
+
+
+async def handle_message_event(
+    event: SlackEventMessage,
+    the_installation: installation.Installation,
+):
+    """Handle a message event from Slack.
+
+    This runs in the background after the endpoint returns 200.
+
+    For channels: Room ID is extracted from channel name (format: soliplex_ROOM_ID).
+    For DMs: User selects a room from a menu, selection is remembered.
+    """
+    # Skip bot messages to avoid infinite loops
+    if event.is_bot_message:
+        logger.debug("Skipping bot message")
+        return
+
+    if not event.text:
+        logger.debug("Skipping message with no text")
+        return
+
+    try:
+        bot_token = the_installation.get_secret("SLACK_BOT_TOKEN")
+    except KeyError:
+        logger.error("SLACK_BOT_TOKEN not configured")
+        return
+
+    slack = SlackClient(bot_token)
+
+    # Handle DMs differently - require room selection
+    if event.is_dm:
+        await handle_dm_message(event, the_installation, slack)
+        return
+
+    # For channels: Get channel name (from cache or API) to extract room ID
+    channel_name = _channel_name_cache.get(event.channel)
+    if channel_name is None:
+        try:
+            channel_info = await slack.get_channel_info(event.channel)
+            channel_name = channel_info.get("name", "")
+            # Cache the result
+            _channel_name_cache[event.channel] = channel_name
+            logger.debug(
+                "Cached channel name: %s -> %s", event.channel, channel_name
+            )
+        except Exception as e:
+            logger.warning("Failed to get channel info: %s, using default room", e)
+            channel_name = ""
+
+    room_id = extract_room_id_from_channel_name(channel_name) or "mcptest"
+    logger.info(
+        "Processing message in channel '%s' -> room '%s'",
+        channel_name,
+        room_id,
+    )
+
+    await process_message_with_agent(event, the_installation, slack, room_id)
+
+
+async def handle_dm_message(
+    event: SlackEventMessage,
+    the_installation: installation.Installation,
+    slack: SlackClient,
+):
+    """Handle a direct message - manage room selection flow."""
+    # Get available rooms
+    slack_user_info = {"preferred_username": f"slack:{event.user}"}
+    room_configs = the_installation.get_room_configs(slack_user_info)
+    available_room_ids = list(room_configs.keys())
+
+    # Check if user has already selected a room
+    selected_room = get_dm_room_selection(event.channel)
+
+    # Check if user wants to change rooms or is selecting
+    selection = parse_room_selection(event.text or "", available_room_ids)
+
+    if selection == "__RESET__":
+        # User wants to see the menu / change rooms
+        clear_dm_room_selection(event.channel)
+        rooms_dict = {
+            rid: {
+                "name": rc.name,
+                "description": rc.description,
+            }
+            for rid, rc in room_configs.items()
+        }
+        menu_text = format_room_menu(rooms_dict)
+        await slack.post_message(
+            channel=event.channel,
+            text=menu_text,
+        )
+        return
+
+    if selected_room is None:
+        # No room selected yet - check if this message is a selection
+        if selection:
+            # Valid selection
+            set_dm_room_selection(event.channel, selection)
+            room_config = room_configs.get(selection)
+            room_name = room_config.name if room_config else selection
+            await slack.post_message(
+                channel=event.channel,
+                text=f"✓ Selected *{room_name}* (`{selection}`). How can I help you?\n_Type `switch` to change rooms._",
+            )
+            return
+        else:
+            # Show the room menu
+            rooms_dict = {
+                rid: {
+                    "name": rc.name,
+                    "description": rc.description,
+                }
+                for rid, rc in room_configs.items()
+            }
+            menu_text = format_room_menu(rooms_dict)
+            await slack.post_message(
+                channel=event.channel,
+                text=menu_text,
+            )
+            return
+
+    # Room is selected - process the message with that room's agent
+    logger.info(
+        "Processing DM from user '%s' with room '%s'",
+        event.user,
+        selected_room,
+    )
+    await process_message_with_agent(event, the_installation, slack, selected_room)
+
+
+async def process_message_with_agent(
+    event: SlackEventMessage,
+    the_installation: installation.Installation,
+    slack: SlackClient,
+    room_id: str,
+):
+    """Process a message using the specified room's agent."""
+
+    # Post a "thinking" message
+    thinking_response = await slack.post_message(
+        channel=event.channel,
+        text="_Thinking..._",
+        thread_ts=event.thread_id,
+    )
+    thinking_ts: str | None = thinking_response.get("ts")
+
+    try:
+        # Get thread context if in a thread
+        message_history: list[dict[str, str]] = []
+        if event.thread_ts:
+            thread_messages = await slack.get_thread_messages(
+                channel=event.channel,
+                thread_ts=event.thread_ts,
+            )
+            # Convert to simple message format for context
+            for msg in thread_messages[:-1]:  # Exclude current message
+                if msg.get("bot_id"):
+                    message_history.append(
+                        {"role": "assistant", "content": msg.get("text", "")}
+                    )
+                else:
+                    message_history.append(
+                        {"role": "user", "content": msg.get("text", "")}
+                    )
+
+        # Get the agent for the configured room
+        # Use a pseudo-user for Slack interactions
+        slack_user_info = {"preferred_username": f"slack:{event.user}"}
+        slack_user_profile = models.UserProfile(
+            given_name="Slack",
+            family_name="User",
+            email=f"slack-{event.user}@slack.local",
+            preferred_username=f"slack:{event.user}",
+        )
+
+        try:
+            agent = the_installation.get_agent_for_room(room_id, slack_user_info)
+        except KeyError:
+            logger.error("Room not found: %s", room_id)
+            if thinking_ts:
+                await slack.update_message(
+                    channel=event.channel,
+                    ts=thinking_ts,
+                    text=f"_Error: Room '{room_id}' not configured._",
+                )
+            return
+
+        # Build the prompt with context
+        if message_history:
+            # Include history in a structured way
+            context_text = "\n".join(
+                f"{'Assistant' if m['role'] == 'assistant' else 'User'}: {m['content']}"
+                for m in message_history[-10:]  # Last 10 messages for context
+            )
+            full_prompt = f"Previous conversation:\n{context_text}\n\nUser: {event.text}"
+        else:
+            full_prompt = event.text or ""
+
+        # Generate response using PydanticAI
+        from soliplex import agents
+
+        deps = agents.AgentDependencies(
+            the_installation=the_installation,
+            user=slack_user_profile,
+            tool_configs={},
+        )
+
+        result = await agent.run(full_prompt, deps=deps)
+        response_text = result.output
+
+        # Convert markdown to Slack format
+        slack_text = convert_markdown_to_slack(str(response_text))
+
+        # Update the thinking message with the response
+        if thinking_ts:
+            await slack.update_message(
+                channel=event.channel,
+                ts=thinking_ts,
+                text=slack_text,
+            )
+
+    except Exception as e:
+        logger.exception("Error handling Slack message")
+        # Update thinking message with error
+        if thinking_ts:
+            await slack.update_message(
+                channel=event.channel,
+                ts=thinking_ts,
+                text=f"_Sorry, I encountered an error: {str(e)}_",
+            )
+
+
+# =============================================================================
+# API Endpoint
+# =============================================================================
+
+
+@router.post("/slack/events")
+async def slack_events(
+    request: fastapi.Request,
+    background_tasks: BackgroundTasks,
+    the_installation: installation.Installation = depend_the_installation,
+) -> dict:
+    """
+    Handle Slack Events API webhook.
+
+    This endpoint handles:
+    - url_verification: Slack's challenge-response for webhook URL verification
+    - event_callback: Actual events from Slack (messages, mentions)
+
+    Events are processed asynchronously in the background to meet Slack's
+    3-second response requirement.
+    """
+    # Verify signature and get body
+    body = await verify_slack_signature(request, the_installation)
+
+    # Parse the payload
+    import json
+
+    payload_dict = json.loads(body)
+    event_type = payload_dict.get("type")
+
+    logger.info("Received Slack event: type=%s", event_type)
+
+    # Handle URL verification (must respond synchronously)
+    if event_type == "url_verification":
+        challenge = payload_dict.get("challenge")
+        if not challenge:
+            raise fastapi.HTTPException(
+                status_code=400,
+                detail="Missing challenge in url_verification payload",
+            )
+        logger.info("Responding to Slack URL verification challenge")
+        return {"challenge": challenge}
+
+    # Handle event callbacks
+    if event_type == "event_callback":
+        event_data = payload_dict.get("event", {})
+        event = SlackEventMessage(**event_data)
+
+        # Process message events in background
+        # Room ID is extracted from channel name (soliplex_ROOM_ID)
+        if event.type in ("message", "app_mention"):
+            background_tasks.add_task(
+                handle_message_event,
+                event,
+                the_installation,
+            )
+
+        # Return immediately (Slack needs response within 3 seconds)
+        return {"ok": True}
+
+    logger.warning("Unknown Slack event type: %s", event_type)
+    return {"ok": True}

--- a/tests/unit/views/test_slack_views.py
+++ b/tests/unit/views/test_slack_views.py
@@ -1,0 +1,1239 @@
+"""Tests for the Slack events API router."""
+
+import hashlib
+import hmac
+import json
+import time
+from unittest import mock
+
+import fastapi
+import pytest
+
+from soliplex import installation
+from soliplex.views import slack as slack_views
+
+
+# =============================================================================
+# Test Data
+# =============================================================================
+
+SIGNING_SECRET = "test-signing-secret"
+BOT_TOKEN = "xoxb-test-bot-token"
+CHANNEL_ID = "C123ABC456"
+CHANNEL_NAME = "soliplex_mcptest"
+USER_ID = "U061F7AUR"
+MESSAGE_TS = "1515449522.000016"
+THREAD_TS = "1515449500.000001"
+
+
+def make_slack_signature(body: bytes, timestamp: str) -> str:
+    """Create a valid Slack signature for testing."""
+    sig_basestring = f"v0:{timestamp}:{body.decode('utf-8')}"
+    return (
+        "v0="
+        + hmac.new(
+            SIGNING_SECRET.encode("utf-8"),
+            sig_basestring.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+    )
+
+
+# =============================================================================
+# SlackEventMessage Model Tests
+# =============================================================================
+
+
+class TestSlackEventMessage:
+    """Tests for SlackEventMessage model."""
+
+    def test_is_bot_message_with_bot_id(self):
+        """Test is_bot_message returns True when bot_id is present."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            bot_id="B123456",
+        )
+        assert event.is_bot_message is True
+
+    def test_is_bot_message_with_bot_subtype(self):
+        """Test is_bot_message returns True when subtype is bot_message."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            subtype="bot_message",
+        )
+        assert event.is_bot_message is True
+
+    def test_is_bot_message_false(self):
+        """Test is_bot_message returns False for regular user messages."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+        )
+        assert event.is_bot_message is False
+
+    def test_is_dm_true(self):
+        """Test is_dm returns True for direct messages."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            channel_type="im",
+        )
+        assert event.is_dm is True
+
+    def test_is_dm_false(self):
+        """Test is_dm returns False for channel messages."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            channel_type="channel",
+        )
+        assert event.is_dm is False
+
+    def test_thread_id_with_thread_ts(self):
+        """Test thread_id returns thread_ts when in a thread."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            thread_ts=THREAD_TS,
+        )
+        assert event.thread_id == THREAD_TS
+
+    def test_thread_id_without_thread_ts(self):
+        """Test thread_id returns ts when not in a thread."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+        )
+        assert event.thread_id == MESSAGE_TS
+
+
+# =============================================================================
+# Markdown Conversion Tests
+# =============================================================================
+
+
+class TestConvertMarkdownToSlack:
+    """Tests for convert_markdown_to_slack function."""
+
+    def test_bold_conversion(self):
+        """Test bold markdown conversion."""
+        result = slack_views.convert_markdown_to_slack("This is **bold** text")
+        assert result == "This is *bold* text"
+
+    def test_link_conversion(self):
+        """Test link markdown conversion."""
+        result = slack_views.convert_markdown_to_slack(
+            "Check [this link](https://example.com)"
+        )
+        assert result == "Check <https://example.com|this link>"
+
+    def test_combined_conversion(self):
+        """Test multiple markdown elements."""
+        result = slack_views.convert_markdown_to_slack(
+            "**Bold** and [link](https://example.com)"
+        )
+        assert result == "*Bold* and <https://example.com|link>"
+
+    def test_no_conversion_needed(self):
+        """Test text without markdown passes through unchanged."""
+        text = "Plain text without markdown"
+        result = slack_views.convert_markdown_to_slack(text)
+        assert result == text
+
+
+# =============================================================================
+# Room ID Extraction Tests
+# =============================================================================
+
+
+class TestExtractRoomIdFromChannelName:
+    """Tests for extract_room_id_from_channel_name function."""
+
+    def test_valid_channel_name(self):
+        """Test extraction from valid soliplex channel name."""
+        result = slack_views.extract_room_id_from_channel_name("soliplex_mcptest")
+        assert result == "mcptest"
+
+    def test_another_valid_name(self):
+        """Test extraction with different room ID."""
+        result = slack_views.extract_room_id_from_channel_name("soliplex_faux")
+        assert result == "faux"
+
+    def test_invalid_channel_name(self):
+        """Test extraction returns None for non-soliplex channels."""
+        result = slack_views.extract_room_id_from_channel_name("general")
+        assert result is None
+
+    def test_empty_channel_name(self):
+        """Test extraction returns None for empty string."""
+        result = slack_views.extract_room_id_from_channel_name("")
+        assert result is None
+
+    def test_partial_prefix(self):
+        """Test extraction returns None for partial prefix match."""
+        result = slack_views.extract_room_id_from_channel_name("soliplex")
+        assert result is None
+
+
+# =============================================================================
+# DM Room Selection Tests
+# =============================================================================
+
+
+class TestDMRoomSelection:
+    """Tests for DM room selection state management."""
+
+    def setup_method(self):
+        """Clear the DM room selections before each test."""
+        slack_views._dm_room_selections.clear()
+
+    def test_set_and_get_selection(self):
+        """Test setting and getting a room selection."""
+        slack_views.set_dm_room_selection("D123", "mcptest")
+        result = slack_views.get_dm_room_selection("D123")
+        assert result == "mcptest"
+
+    def test_get_nonexistent_selection(self):
+        """Test getting a selection that doesn't exist."""
+        result = slack_views.get_dm_room_selection("D999")
+        assert result is None
+
+    def test_clear_selection(self):
+        """Test clearing a room selection."""
+        slack_views.set_dm_room_selection("D123", "mcptest")
+        slack_views.clear_dm_room_selection("D123")
+        result = slack_views.get_dm_room_selection("D123")
+        assert result is None
+
+    def test_clear_nonexistent_selection(self):
+        """Test clearing a selection that doesn't exist (should not raise)."""
+        slack_views.clear_dm_room_selection("D999")  # Should not raise
+
+
+class TestParseRoomSelection:
+    """Tests for parse_room_selection function."""
+
+    def test_reset_commands(self):
+        """Test reset commands return __RESET__."""
+        rooms = ["mcptest", "faux"]
+        for cmd in ("switch", "change", "reset", "menu", "rooms"):
+            result = slack_views.parse_room_selection(cmd, rooms)
+            assert result == "__RESET__", f"Failed for command: {cmd}"
+
+    def test_numeric_selection(self):
+        """Test selecting room by number."""
+        rooms = ["mcptest", "faux", "another"]
+        assert slack_views.parse_room_selection("1", rooms) == "mcptest"
+        assert slack_views.parse_room_selection("2", rooms) == "faux"
+        assert slack_views.parse_room_selection("3", rooms) == "another"
+
+    def test_invalid_numeric_selection(self):
+        """Test invalid numeric selection returns None."""
+        rooms = ["mcptest", "faux"]
+        assert slack_views.parse_room_selection("0", rooms) is None
+        assert slack_views.parse_room_selection("5", rooms) is None
+
+    def test_name_selection(self):
+        """Test selecting room by name."""
+        rooms = ["mcptest", "faux"]
+        assert slack_views.parse_room_selection("mcptest", rooms) == "mcptest"
+        assert slack_views.parse_room_selection("MCPTEST", rooms) == "mcptest"
+        assert slack_views.parse_room_selection("faux", rooms) == "faux"
+
+    def test_invalid_name_selection(self):
+        """Test invalid room name returns None."""
+        rooms = ["mcptest", "faux"]
+        assert slack_views.parse_room_selection("nonexistent", rooms) is None
+
+    def test_whitespace_handling(self):
+        """Test whitespace is trimmed from input."""
+        rooms = ["mcptest"]
+        assert slack_views.parse_room_selection("  mcptest  ", rooms) == "mcptest"
+        assert slack_views.parse_room_selection("  1  ", rooms) == "mcptest"
+
+
+class TestFormatRoomMenu:
+    """Tests for format_room_menu function."""
+
+    def test_basic_menu(self):
+        """Test basic room menu formatting."""
+        rooms = {
+            "mcptest": {"name": "MCP Test Room", "description": ""},
+            "faux": {"name": "Faux Room", "description": "A fake room"},
+        }
+        result = slack_views.format_room_menu(rooms)
+        assert "*Please select a room to chat with:*" in result
+        assert "*1.* MCP Test Room (`mcptest`)" in result
+        assert "*2.* Faux Room (`faux`)" in result
+        assert "_A fake room_" in result
+        assert "_Reply with the number or room name to select._" in result
+
+    def test_empty_rooms(self):
+        """Test menu with no rooms."""
+        result = slack_views.format_room_menu({})
+        assert "*Please select a room to chat with:*" in result
+
+
+# =============================================================================
+# Signature Verification Tests
+# =============================================================================
+
+
+class TestVerifySlackSignature:
+    """Tests for verify_slack_signature function."""
+
+    @pytest.mark.anyio
+    async def test_missing_signing_secret(self):
+        """Test error when SLACK_SIGNING_SECRET is not configured."""
+        request = mock.create_autospec(fastapi.Request)
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_secret.side_effect = KeyError("SLACK_SIGNING_SECRET")
+
+        with pytest.raises(fastapi.HTTPException) as exc:
+            await slack_views.verify_slack_signature(request, the_installation)
+
+        assert exc.value.status_code == 500
+        assert "not configured" in exc.value.detail
+
+    @pytest.mark.anyio
+    async def test_missing_headers(self):
+        """Test error when Slack headers are missing."""
+        request = mock.create_autospec(fastapi.Request)
+        request.headers = {}
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_secret.return_value = SIGNING_SECRET
+
+        with pytest.raises(fastapi.HTTPException) as exc:
+            await slack_views.verify_slack_signature(request, the_installation)
+
+        assert exc.value.status_code == 400
+        assert "Missing" in exc.value.detail
+
+    @pytest.mark.anyio
+    async def test_old_timestamp(self):
+        """Test error when timestamp is too old."""
+        old_timestamp = str(int(time.time()) - 400)  # 6+ minutes old
+        request = mock.create_autospec(fastapi.Request)
+        request.headers = {
+            "X-Slack-Request-Timestamp": old_timestamp,
+            "X-Slack-Signature": "v0=dummy",
+        }
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_secret.return_value = SIGNING_SECRET
+
+        with pytest.raises(fastapi.HTTPException) as exc:
+            await slack_views.verify_slack_signature(request, the_installation)
+
+        assert exc.value.status_code == 400
+        assert "too old" in exc.value.detail
+
+    @pytest.mark.anyio
+    async def test_invalid_signature(self):
+        """Test error when signature is invalid."""
+        timestamp = str(int(time.time()))
+        body = b'{"test": "payload"}'
+
+        request = mock.create_autospec(fastapi.Request)
+        request.headers = {
+            "X-Slack-Request-Timestamp": timestamp,
+            "X-Slack-Signature": "v0=invalid_signature",
+        }
+        request.body = mock.AsyncMock(return_value=body)
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_secret.return_value = SIGNING_SECRET
+
+        with pytest.raises(fastapi.HTTPException) as exc:
+            await slack_views.verify_slack_signature(request, the_installation)
+
+        assert exc.value.status_code == 400
+        assert "Invalid" in exc.value.detail
+
+    @pytest.mark.anyio
+    async def test_valid_signature(self):
+        """Test successful signature verification."""
+        timestamp = str(int(time.time()))
+        body = b'{"test": "payload"}'
+        signature = make_slack_signature(body, timestamp)
+
+        request = mock.create_autospec(fastapi.Request)
+        request.headers = {
+            "X-Slack-Request-Timestamp": timestamp,
+            "X-Slack-Signature": signature,
+        }
+        request.body = mock.AsyncMock(return_value=body)
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_secret.return_value = SIGNING_SECRET
+
+        result = await slack_views.verify_slack_signature(request, the_installation)
+        assert result == body
+
+
+# =============================================================================
+# Slack Events Endpoint Tests
+# =============================================================================
+
+
+class TestSlackEventsEndpoint:
+    """Tests for the /slack/events endpoint."""
+
+    def setup_method(self):
+        """Clear caches before each test."""
+        slack_views._channel_name_cache.clear()
+        slack_views._dm_room_selections.clear()
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "verify_slack_signature")
+    async def test_url_verification(self, mock_verify):
+        """Test URL verification challenge response."""
+        challenge = "test-challenge-12345"
+        payload = {
+            "type": "url_verification",
+            "challenge": challenge,
+        }
+        mock_verify.return_value = json.dumps(payload).encode()
+
+        request = mock.create_autospec(fastapi.Request)
+        background_tasks = mock.create_autospec(fastapi.BackgroundTasks)
+        the_installation = mock.create_autospec(installation.Installation)
+
+        result = await slack_views.slack_events(
+            request, background_tasks, the_installation
+        )
+
+        assert result == {"challenge": challenge}
+        background_tasks.add_task.assert_not_called()
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "verify_slack_signature")
+    async def test_url_verification_missing_challenge(self, mock_verify):
+        """Test URL verification fails without challenge."""
+        payload = {"type": "url_verification"}
+        mock_verify.return_value = json.dumps(payload).encode()
+
+        request = mock.create_autospec(fastapi.Request)
+        background_tasks = mock.create_autospec(fastapi.BackgroundTasks)
+        the_installation = mock.create_autospec(installation.Installation)
+
+        with pytest.raises(fastapi.HTTPException) as exc:
+            await slack_views.slack_events(request, background_tasks, the_installation)
+
+        assert exc.value.status_code == 400
+        assert "Missing challenge" in exc.value.detail
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "verify_slack_signature")
+    async def test_event_callback_message(self, mock_verify):
+        """Test event callback schedules background task for messages."""
+        payload = {
+            "type": "event_callback",
+            "token": "test-token",
+            "team_id": "T123",
+            "event": {
+                "type": "message",
+                "user": USER_ID,
+                "text": "Hello bot!",
+                "ts": MESSAGE_TS,
+                "channel": CHANNEL_ID,
+            },
+            "event_id": "Ev123",
+            "event_time": 1515449522,
+        }
+        mock_verify.return_value = json.dumps(payload).encode()
+
+        request = mock.create_autospec(fastapi.Request)
+        background_tasks = mock.create_autospec(fastapi.BackgroundTasks)
+        the_installation = mock.create_autospec(installation.Installation)
+
+        result = await slack_views.slack_events(
+            request, background_tasks, the_installation
+        )
+
+        assert result == {"ok": True}
+        background_tasks.add_task.assert_called_once()
+        call_args = background_tasks.add_task.call_args
+        assert call_args[0][0] == slack_views.handle_message_event
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "verify_slack_signature")
+    async def test_event_callback_app_mention(self, mock_verify):
+        """Test event callback schedules background task for app mentions."""
+        payload = {
+            "type": "event_callback",
+            "token": "test-token",
+            "team_id": "T123",
+            "event": {
+                "type": "app_mention",
+                "user": USER_ID,
+                "text": "<@U0LAN0Z89> hello",
+                "ts": MESSAGE_TS,
+                "channel": CHANNEL_ID,
+            },
+            "event_id": "Ev123",
+            "event_time": 1515449522,
+        }
+        mock_verify.return_value = json.dumps(payload).encode()
+
+        request = mock.create_autospec(fastapi.Request)
+        background_tasks = mock.create_autospec(fastapi.BackgroundTasks)
+        the_installation = mock.create_autospec(installation.Installation)
+
+        result = await slack_views.slack_events(
+            request, background_tasks, the_installation
+        )
+
+        assert result == {"ok": True}
+        background_tasks.add_task.assert_called_once()
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "verify_slack_signature")
+    async def test_unknown_event_type(self, mock_verify):
+        """Test unknown event types are handled gracefully."""
+        payload = {"type": "unknown_type"}
+        mock_verify.return_value = json.dumps(payload).encode()
+
+        request = mock.create_autospec(fastapi.Request)
+        background_tasks = mock.create_autospec(fastapi.BackgroundTasks)
+        the_installation = mock.create_autospec(installation.Installation)
+
+        result = await slack_views.slack_events(
+            request, background_tasks, the_installation
+        )
+
+        assert result == {"ok": True}
+        background_tasks.add_task.assert_not_called()
+
+
+# =============================================================================
+# Message Event Handler Tests
+# =============================================================================
+
+
+class TestHandleMessageEvent:
+    """Tests for handle_message_event function."""
+
+    def setup_method(self):
+        """Clear caches before each test."""
+        slack_views._channel_name_cache.clear()
+        slack_views._dm_room_selections.clear()
+
+    @pytest.mark.anyio
+    async def test_skip_bot_message(self):
+        """Test bot messages are skipped."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            bot_id="B123456",
+            text="Bot message",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+
+        # Should return without doing anything (no get_secret call)
+        await slack_views.handle_message_event(event, the_installation)
+        the_installation.get_secret.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_skip_empty_text(self):
+        """Test messages with no text are skipped."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text=None,
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+
+        await slack_views.handle_message_event(event, the_installation)
+        the_installation.get_secret.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_missing_bot_token(self):
+        """Test handling when SLACK_BOT_TOKEN is not configured."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Hello",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_secret.side_effect = KeyError("SLACK_BOT_TOKEN")
+
+        # Should return without crashing
+        await slack_views.handle_message_event(event, the_installation)
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "process_message_with_agent")
+    @mock.patch.object(slack_views.SlackClient, "get_channel_info")
+    async def test_channel_message_uses_cache(self, mock_get_info, mock_process):
+        """Test channel name is cached after first lookup."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Hello",
+            channel_type="channel",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_secret.return_value = BOT_TOKEN
+
+        mock_get_info.return_value = {"name": CHANNEL_NAME}
+
+        # First call - should fetch from API
+        await slack_views.handle_message_event(event, the_installation)
+        mock_get_info.assert_called_once()
+        mock_process.assert_called_once()
+
+        # Check cache was populated
+        assert slack_views._channel_name_cache[CHANNEL_ID] == CHANNEL_NAME
+
+        # Reset mocks
+        mock_get_info.reset_mock()
+        mock_process.reset_mock()
+
+        # Second call - should use cache
+        await slack_views.handle_message_event(event, the_installation)
+        mock_get_info.assert_not_called()  # Should not call API again
+        mock_process.assert_called_once()
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "handle_dm_message")
+    async def test_dm_message_routes_to_handler(self, mock_handle_dm):
+        """Test DM messages are routed to handle_dm_message."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel="D123456",
+            user=USER_ID,
+            text="Hello",
+            channel_type="im",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_secret.return_value = BOT_TOKEN
+
+        await slack_views.handle_message_event(event, the_installation)
+
+        mock_handle_dm.assert_called_once()
+
+
+# =============================================================================
+# SlackClient Tests
+# =============================================================================
+
+
+class TestSlackClient:
+    """Tests for SlackClient class."""
+
+    @pytest.mark.anyio
+    @mock.patch("httpx.AsyncClient")
+    async def test_post_message(self, mock_client_class):
+        """Test posting a message."""
+        mock_client = mock.AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"ok": True, "ts": MESSAGE_TS}
+        mock_client.request.return_value = mock_response
+
+        client = slack_views.SlackClient(BOT_TOKEN)
+        result = await client.post_message(
+            channel=CHANNEL_ID,
+            text="Hello!",
+            thread_ts=THREAD_TS,
+        )
+
+        assert result == {"ok": True, "ts": MESSAGE_TS}
+        mock_client.request.assert_called_once()
+        call_kwargs = mock_client.request.call_args[1]
+        assert call_kwargs["json"]["channel"] == CHANNEL_ID
+        assert call_kwargs["json"]["text"] == "Hello!"
+        assert call_kwargs["json"]["thread_ts"] == THREAD_TS
+
+    @pytest.mark.anyio
+    @mock.patch("httpx.AsyncClient")
+    async def test_update_message(self, mock_client_class):
+        """Test updating a message."""
+        mock_client = mock.AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"ok": True}
+        mock_client.request.return_value = mock_response
+
+        client = slack_views.SlackClient(BOT_TOKEN)
+        result = await client.update_message(
+            channel=CHANNEL_ID,
+            ts=MESSAGE_TS,
+            text="Updated!",
+        )
+
+        assert result == {"ok": True}
+        call_kwargs = mock_client.request.call_args[1]
+        assert call_kwargs["json"]["ts"] == MESSAGE_TS
+        assert call_kwargs["json"]["text"] == "Updated!"
+
+    @pytest.mark.anyio
+    @mock.patch("httpx.AsyncClient")
+    async def test_get_channel_info(self, mock_client_class):
+        """Test getting channel info."""
+        mock_client = mock.AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "channel": {"id": CHANNEL_ID, "name": CHANNEL_NAME},
+        }
+        mock_client.request.return_value = mock_response
+
+        client = slack_views.SlackClient(BOT_TOKEN)
+        result = await client.get_channel_info(CHANNEL_ID)
+
+        assert result == {"id": CHANNEL_ID, "name": CHANNEL_NAME}
+
+    @pytest.mark.anyio
+    @mock.patch("httpx.AsyncClient")
+    async def test_get_thread_messages(self, mock_client_class):
+        """Test getting thread messages."""
+        mock_client = mock.AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "messages": [
+                {"text": "First", "ts": "1"},
+                {"text": "Second", "ts": "2"},
+            ],
+        }
+        mock_client.request.return_value = mock_response
+
+        client = slack_views.SlackClient(BOT_TOKEN)
+        result = await client.get_thread_messages(CHANNEL_ID, THREAD_TS)
+
+        assert len(result) == 2
+        assert result[0]["text"] == "First"
+
+    @pytest.mark.anyio
+    @mock.patch("httpx.AsyncClient")
+    async def test_post_message_without_thread_ts(self, mock_client_class):
+        """Test posting a message without thread_ts (covers lines 133-135)."""
+        mock_client = mock.AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"ok": True, "ts": MESSAGE_TS}
+        mock_client.request.return_value = mock_response
+
+        client = slack_views.SlackClient(BOT_TOKEN)
+        result = await client.post_message(
+            channel=CHANNEL_ID,
+            text="Hello!",
+            # No thread_ts
+        )
+
+        assert result == {"ok": True, "ts": MESSAGE_TS}
+        call_kwargs = mock_client.request.call_args[1]
+        assert "thread_ts" not in call_kwargs["json"]
+
+
+# =============================================================================
+# Handle Message Event - Channel Info Failure Tests
+# =============================================================================
+
+
+class TestHandleMessageEventChannelInfoFailure:
+    """Tests for handle_message_event when get_channel_info fails (lines 396-398)."""
+
+    def setup_method(self):
+        """Clear caches before each test."""
+        slack_views._channel_name_cache.clear()
+        slack_views._dm_room_selections.clear()
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "process_message_with_agent")
+    @mock.patch.object(slack_views.SlackClient, "get_channel_info")
+    async def test_channel_info_failure_uses_default_room(
+        self, mock_get_info, mock_process
+    ):
+        """Test that when get_channel_info fails, default room is used."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Hello",
+            channel_type="channel",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_secret.return_value = BOT_TOKEN
+
+        # Make get_channel_info raise an exception
+        mock_get_info.side_effect = Exception("API error")
+
+        await slack_views.handle_message_event(event, the_installation)
+
+        # Should still call process_message_with_agent with default room
+        mock_process.assert_called_once()
+        call_args = mock_process.call_args
+        # room_id should be "mcptest" (the default)
+        assert call_args[0][3] == "mcptest"
+
+
+# =============================================================================
+# Handle DM Message Tests (lines 417-478)
+# =============================================================================
+
+
+class TestHandleDMMessage:
+    """Tests for handle_dm_message function."""
+
+    def setup_method(self):
+        """Clear caches before each test."""
+        slack_views._channel_name_cache.clear()
+        slack_views._dm_room_selections.clear()
+
+    def _make_mock_room_config(self, name: str, description: str = ""):
+        """Create a mock room config."""
+        config = mock.Mock()
+        config.name = name
+        config.description = description
+        return config
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_dm_reset_command_shows_menu(self, mock_post):
+        """Test reset command clears selection and shows menu."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel="D123456",
+            user=USER_ID,
+            text="switch",
+            channel_type="im",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        room_configs = {
+            "mcptest": self._make_mock_room_config("MCP Test", "Test room"),
+            "faux": self._make_mock_room_config("Faux Room"),
+        }
+        the_installation.get_room_configs.return_value = room_configs
+
+        # Pre-set a selection
+        slack_views.set_dm_room_selection("D123456", "mcptest")
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.handle_dm_message(event, the_installation, slack_client)
+
+        # Selection should be cleared
+        assert slack_views.get_dm_room_selection("D123456") is None
+        # Menu should be posted
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args[1]
+        assert "Please select a room" in call_kwargs["text"]
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_dm_no_selection_shows_menu(self, mock_post):
+        """Test that first message without selection shows menu."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel="D123456",
+            user=USER_ID,
+            text="Hello there!",  # Not a valid selection
+            channel_type="im",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        room_configs = {
+            "mcptest": self._make_mock_room_config("MCP Test"),
+        }
+        the_installation.get_room_configs.return_value = room_configs
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.handle_dm_message(event, the_installation, slack_client)
+
+        # Menu should be posted
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args[1]
+        assert "Please select a room" in call_kwargs["text"]
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_dm_valid_selection_sets_room(self, mock_post):
+        """Test valid room selection is saved and confirmed."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel="D123456",
+            user=USER_ID,
+            text="1",  # Select first room
+            channel_type="im",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        room_configs = {
+            "mcptest": self._make_mock_room_config("MCP Test"),
+            "faux": self._make_mock_room_config("Faux Room"),
+        }
+        the_installation.get_room_configs.return_value = room_configs
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.handle_dm_message(event, the_installation, slack_client)
+
+        # Selection should be saved
+        assert slack_views.get_dm_room_selection("D123456") == "mcptest"
+        # Confirmation should be posted
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args[1]
+        assert "Selected" in call_kwargs["text"]
+        assert "MCP Test" in call_kwargs["text"]
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "process_message_with_agent")
+    async def test_dm_with_existing_selection_processes_message(self, mock_process):
+        """Test message with existing selection is processed."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel="D123456",
+            user=USER_ID,
+            text="What is the weather?",
+            channel_type="im",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        room_configs = {
+            "mcptest": self._make_mock_room_config("MCP Test"),
+        }
+        the_installation.get_room_configs.return_value = room_configs
+
+        # Pre-set a selection
+        slack_views.set_dm_room_selection("D123456", "mcptest")
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.handle_dm_message(event, the_installation, slack_client)
+
+        # Should process with the selected room
+        mock_process.assert_called_once()
+        call_args = mock_process.call_args
+        assert call_args[0][3] == "mcptest"  # room_id
+
+
+# =============================================================================
+# Process Message With Agent Tests (lines 490-576)
+# =============================================================================
+
+
+class TestProcessMessageWithAgent:
+    """Tests for process_message_with_agent function."""
+
+    def setup_method(self):
+        """Clear caches before each test."""
+        slack_views._channel_name_cache.clear()
+        slack_views._dm_room_selections.clear()
+
+    @pytest.mark.anyio
+    @mock.patch("soliplex.agents.AgentDependencies")
+    @mock.patch.object(slack_views.SlackClient, "update_message")
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_process_message_success(
+        self, mock_post, mock_update, mock_agent_deps
+    ):
+        """Test successful message processing."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Hello bot!",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        mock_agent = mock.AsyncMock()
+        mock_result = mock.Mock()
+        mock_result.output = "Hello human!"
+        mock_agent.run.return_value = mock_result
+        the_installation.get_agent_for_room.return_value = mock_agent
+
+        mock_post.return_value = {"ts": "thinking_ts"}
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.process_message_with_agent(
+            event, the_installation, slack_client, "mcptest"
+        )
+
+        # Should post thinking message
+        mock_post.assert_called_once()
+        assert "_Thinking..._" in mock_post.call_args[1]["text"]
+
+        # Should update with response
+        mock_update.assert_called_once()
+        assert "Hello human!" in mock_update.call_args[1]["text"]
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views.SlackClient, "update_message")
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_process_message_room_not_found(self, mock_post, mock_update):
+        """Test handling when room is not found."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Hello bot!",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_agent_for_room.side_effect = KeyError("Room not found")
+
+        mock_post.return_value = {"ts": "thinking_ts"}
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.process_message_with_agent(
+            event, the_installation, slack_client, "nonexistent"
+        )
+
+        # Should update with error
+        mock_update.assert_called_once()
+        assert "not configured" in mock_update.call_args[1]["text"]
+
+    @pytest.mark.anyio
+    @mock.patch("soliplex.agents.AgentDependencies")
+    @mock.patch.object(slack_views.SlackClient, "update_message")
+    @mock.patch.object(slack_views.SlackClient, "get_thread_messages")
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_process_message_with_thread_context(
+        self, mock_post, mock_get_thread, mock_update, mock_agent_deps
+    ):
+        """Test message processing with thread context."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Follow up question",
+            thread_ts=THREAD_TS,  # In a thread
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        mock_agent = mock.AsyncMock()
+        mock_result = mock.Mock()
+        mock_result.output = "Here's the answer!"
+        mock_agent.run.return_value = mock_result
+        the_installation.get_agent_for_room.return_value = mock_agent
+
+        mock_post.return_value = {"ts": "thinking_ts"}
+        mock_get_thread.return_value = [
+            {"text": "First message", "ts": "1"},
+            {"text": "Bot response", "ts": "2", "bot_id": "B123"},
+            {"text": "Follow up question", "ts": MESSAGE_TS},  # Current message
+        ]
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.process_message_with_agent(
+            event, the_installation, slack_client, "mcptest"
+        )
+
+        # Should fetch thread messages
+        mock_get_thread.assert_called_once()
+
+        # Agent should be called with context
+        mock_agent.run.assert_called_once()
+        prompt = mock_agent.run.call_args[0][0]
+        assert "Previous conversation:" in prompt
+
+    @pytest.mark.anyio
+    @mock.patch("soliplex.agents.AgentDependencies")
+    @mock.patch.object(slack_views.SlackClient, "update_message")
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_process_message_agent_error(
+        self, mock_post, mock_update, mock_agent_deps
+    ):
+        """Test handling when agent raises an error."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Hello bot!",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        mock_agent = mock.AsyncMock()
+        mock_agent.run.side_effect = Exception("Agent error")
+        the_installation.get_agent_for_room.return_value = mock_agent
+
+        mock_post.return_value = {"ts": "thinking_ts"}
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.process_message_with_agent(
+            event, the_installation, slack_client, "mcptest"
+        )
+
+        # Should update with error message
+        mock_update.assert_called_once()
+        assert "error" in mock_update.call_args[1]["text"].lower()
+
+    @pytest.mark.anyio
+    @mock.patch("soliplex.agents.AgentDependencies")
+    @mock.patch.object(slack_views.SlackClient, "update_message")
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_process_message_no_thinking_ts(
+        self, mock_post, mock_update, mock_agent_deps
+    ):
+        """Test handling when thinking message doesn't return ts."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Hello bot!",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        mock_agent = mock.AsyncMock()
+        mock_result = mock.Mock()
+        mock_result.output = "Hello!"
+        mock_agent.run.return_value = mock_result
+        the_installation.get_agent_for_room.return_value = mock_agent
+
+        # No ts in response
+        mock_post.return_value = {"ok": True}
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.process_message_with_agent(
+            event, the_installation, slack_client, "mcptest"
+        )
+
+        # Should not try to update (no ts)
+        mock_update.assert_not_called()
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views.SlackClient, "update_message")
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_process_message_room_not_found_no_thinking_ts(
+        self, mock_post, mock_update
+    ):
+        """Test room not found when thinking message has no ts (covers 530->536)."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Hello bot!",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        the_installation.get_agent_for_room.side_effect = KeyError("Room not found")
+
+        # No ts in response - thinking_ts will be None
+        mock_post.return_value = {"ok": True}
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.process_message_with_agent(
+            event, the_installation, slack_client, "nonexistent"
+        )
+
+        # Should NOT try to update (no ts to update)
+        mock_update.assert_not_called()
+
+    @pytest.mark.anyio
+    @mock.patch("soliplex.agents.AgentDependencies")
+    @mock.patch.object(slack_views.SlackClient, "update_message")
+    @mock.patch.object(slack_views.SlackClient, "post_message")
+    async def test_process_message_agent_error_no_thinking_ts(
+        self, mock_post, mock_update, mock_agent_deps
+    ):
+        """Test agent error when thinking message has no ts (covers 575->exit)."""
+        event = slack_views.SlackEventMessage(
+            type="message",
+            ts=MESSAGE_TS,
+            channel=CHANNEL_ID,
+            user=USER_ID,
+            text="Hello bot!",
+        )
+        the_installation = mock.create_autospec(installation.Installation)
+        mock_agent = mock.AsyncMock()
+        mock_agent.run.side_effect = Exception("Agent error")
+        the_installation.get_agent_for_room.return_value = mock_agent
+
+        # No ts in response - thinking_ts will be None
+        mock_post.return_value = {"ok": True}
+
+        slack_client = slack_views.SlackClient(BOT_TOKEN)
+        await slack_views.process_message_with_agent(
+            event, the_installation, slack_client, "mcptest"
+        )
+
+        # Should NOT try to update (no ts to update)
+        mock_update.assert_not_called()
+
+
+# =============================================================================
+# Event Callback - Non-message Event Tests (line 633->641)
+# =============================================================================
+
+
+class TestEventCallbackNonMessageEvent:
+    """Tests for event_callback with non-message events."""
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "verify_slack_signature")
+    async def test_event_callback_reaction_added(self, mock_verify):
+        """Test event callback doesn't schedule task for reaction_added events."""
+        payload = {
+            "type": "event_callback",
+            "token": "test-token",
+            "team_id": "T123",
+            "event": {
+                "type": "reaction_added",  # Not message or app_mention
+                "user": USER_ID,
+                "ts": MESSAGE_TS,
+                "channel": CHANNEL_ID,
+                "reaction": "thumbsup",
+            },
+            "event_id": "Ev123",
+            "event_time": 1515449522,
+        }
+        mock_verify.return_value = json.dumps(payload).encode()
+
+        request = mock.create_autospec(fastapi.Request)
+        background_tasks = mock.create_autospec(fastapi.BackgroundTasks)
+        the_installation = mock.create_autospec(installation.Installation)
+
+        result = await slack_views.slack_events(
+            request, background_tasks, the_installation
+        )
+
+        assert result == {"ok": True}
+        # Should NOT schedule background task for non-message events
+        background_tasks.add_task.assert_not_called()
+
+    @pytest.mark.anyio
+    @mock.patch.object(slack_views, "verify_slack_signature")
+    async def test_event_callback_channel_created(self, mock_verify):
+        """Test event callback doesn't schedule task for channel_created events."""
+        payload = {
+            "type": "event_callback",
+            "token": "test-token",
+            "team_id": "T123",
+            "event": {
+                "type": "channel_created",  # Not message or app_mention
+                "ts": MESSAGE_TS,
+                "channel": CHANNEL_ID,
+            },
+            "event_id": "Ev123",
+            "event_time": 1515449522,
+        }
+        mock_verify.return_value = json.dumps(payload).encode()
+
+        request = mock.create_autospec(fastapi.Request)
+        background_tasks = mock.create_autospec(fastapi.BackgroundTasks)
+        the_installation = mock.create_autospec(installation.Installation)
+
+        result = await slack_views.slack_events(
+            request, background_tasks, the_installation
+        )
+
+        assert result == {"ok": True}
+        background_tasks.add_task.assert_not_called()


### PR DESCRIPTION
This PR implements the `/slack/events` endpoint used by [Slack apps](https://slack.com/help/articles/33076000248851-Understand-AI-apps-in-Slack). This PR closes soliplex/chatbot#3

It requires `SLACK_SIGNING_SECRET` and `SLACK_BOT_TOKEN` properly set, and a [registered app](https://api.slack.com/apps) properly configured to connect to the agent.

The [Test Soliplex](https://api.slack.com/apps/A0A1BJUG56K) app is properly configured to interact with a soliplex backend (Currently at https://soliplex-docker.enfoldsystems.net/)

Right now it works in 2 ways, Private messages and channel membership.

When you talk to the `Test Soliplex` app in DM, it will ask you which room you want to use. When talking in a channel, it will get the room from the channel name, with the `soliplex_` prefix, so `#soliplex_mcptest` would map to `mcptest` room, `#soliplex_joker` to the `joker` room, and so on.

Notice that you need to @ the bot on each reply, even when replying to the bot in a slack thread.

