### PR TITLE
Fix: Null check exception in RoomSession._applyEventResult

### DIFF
--- a/src/flutter/lib/core/network/room_event_handler.dart
+++ b/src/flutter/lib/core/network/room_event_handler.dart
@@ -44,8 +44,8 @@ abstract class RoomEventHandler {
   /// eventType is optional description of current activity.
   /// toolName is optional name of tool being executed.
   void onActivityUpdate({
-    required String eventType,
     bool isActive = false,
+    String? eventType,
     String? toolName,
   });
 
@@ -87,8 +87,8 @@ class NoOpRoomEventHandler implements RoomEventHandler {
 
   @override
   void onActivityUpdate({
-    required String eventType,
     bool isActive = false,
+    String? eventType,
     String? toolName,
   }) {}
 
@@ -137,8 +137,8 @@ class RecordingRoomEventHandler implements RoomEventHandler {
 
   @override
   void onActivityUpdate({
-    required String eventType,
     bool isActive = false,
+    String? eventType,
     String? toolName,
   }) {
     activityUpdates.add(
@@ -191,11 +191,11 @@ class ContextUpdateRecord {
 class ActivityUpdateRecord {
   ActivityUpdateRecord({
     required this.isActive,
-    required this.eventType,
+    this.eventType,
     this.toolName,
   });
   final bool isActive;
-  final String eventType;
+  final String? eventType;
   final String? toolName;
 }
 

--- a/src/flutter/lib/core/network/room_session.dart
+++ b/src/flutter/lib/core/network/room_session.dart
@@ -1124,7 +1124,7 @@ class RoomSession implements ChatSession {
       final act = result.activityUpdate!;
       _eventHandler.onActivityUpdate(
         isActive: act.isActive,
-        eventType: act.eventType!,
+        eventType: act.eventType,
         toolName: act.toolName,
       );
     }


### PR DESCRIPTION
Resolved a Null check operator used on a null value exception in RoomSession._applyEventResult. The issue occurred because act.eventType! was being asserted as non-null, but EventProcessor can provide ActivityUpdate with a null eventType (e.g., when an activity simply stops).

This fix involves:
- Making the 'eventType' parameter nullable in the RoomEventHandler.onActivityUpdate signature and its implementations (NoOpRoomEventHandler, RecordingRoomEventHandler).
- Removing the null assertion operator (!) when accessing act.eventType in RoomSession._applyEventResult.
- Updating ActivityUpdateRecord to reflect nullable eventType.

This ensures that the system correctly handles nullable event types without crashing.