### PR TITLE
feat: 'agui.Run.finished' timestamp

### DIFF
--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -242,6 +242,10 @@ class Run(Base):
         default=agui_util._timestamp,
     )
 
+    finished: Mapped[datetime.datetime | None] = mapped_column(
+        default=None,
+    )
+
     async def list_events(self) -> list[agui_core.Event]:
         return [
             event.to_agui_model()
@@ -725,6 +729,9 @@ class ThreadStorage(agui_package.ThreadStorage):
                 run_id=run_id,
                 session=session,
             )
+
+            run.finished = agui_util._timestamp()
+            session.add(run)
 
             for event in events:
                 session.add(RunEvent(run=run, data=event.model_dump()))

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -430,6 +430,7 @@ class AGUI_Run(pydantic.BaseModel):
 
     run_input: agui_core.RunAgentInput | None = KW_ONLY_NONE
     created: datetime.datetime = KW_ONLY_NONE
+    finished: datetime.datetime | None = KW_ONLY_NONE
 
     events: AGUI_Events | None = pydantic.Field(
         kw_only=True,
@@ -449,6 +450,7 @@ class AGUI_Run(pydantic.BaseModel):
             thread_id=a_run.thread_id,
             run_id=a_run.run_id,
             created=a_run.created,
+            finished=a_run.finished,
             parent_run_id=a_run.parent_run_id,
             run_input=a_run_input,
             events=a_run_events,

--- a/tests/unit/agui/test_persistence.py
+++ b/tests/unit/agui/test_persistence.py
@@ -845,10 +845,14 @@ def the_engine():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("w_agui_events", [[], TEST_AGUI_RUN_EVENTS])
+@mock.patch("soliplex.agui.util._timestamp")
 async def test_threadstorage_save_run_events(
+    ts,
     the_async_session,
     w_agui_events,
 ):
+    ts.return_value = NOW
+
     # Work around https://github.com/ag-ui-protocol/ag-ui/issues/752
     exp_events = [
         event
@@ -877,6 +881,9 @@ async def test_threadstorage_save_run_events(
     )
 
     await the_async_session.commit()
+
+    finished = await run.awaitable_attrs.finished
+    assert finished == NOW.replace(tzinfo=None)  # sqlalchemy drops zone
 
     db_events = await run.list_events()
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -118,6 +118,7 @@ AGUI_RUNS = {
         thread_id=AGUI_THREAD_ID,
         run_id=AGUI_RUN_ID,
         created=NOW,
+        finished=None,
         parent_run_id=None,
         run_metadata=None,
         run_input=EMPTY_AGUI_RUN_INPUT.model_copy(deep=True),
@@ -822,12 +823,14 @@ def test_aguirunmetadata_from_run_metadata(run_metadata, exp_label):
         (AGUI_RUN_METADATA, RUN_LABEL),
     ],
 )
+@pytest.mark.parametrize("w_finished", [False, True])
 @pytest.mark.parametrize("w_events", [False, True])
 @pytest.mark.parametrize("w_parent", [False, True])
 def test_aguirun_from_run(
     run_input,
     w_parent,
     w_events,
+    w_finished,
     run_metadata,
     exp_label,
 ):
@@ -835,6 +838,7 @@ def test_aguirun_from_run(
         thread_id=AGUI_THREAD_ID,
         run_id=AGUI_RUN_ID,
         created=NOW,
+        finished=NOW if w_finished else None,
         parent_run_id=AGUI_PARENT_RUN_ID if w_parent else None,
         run_input=run_input,
     )

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -97,6 +97,7 @@ def test_run():
         parent_run_id=None,
         run_metadata=None,
         created=NOW,
+        finished=None,
         awaitable_attrs=mock.AsyncMock(),
         instance=True,
     )


### PR DESCRIPTION
Toward back-end support for the notion of run duration, per #129