### PR TITLE
feat: schema and 'ThreadStorage' method to store run LLM usage stats

### DIFF
--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -70,6 +70,37 @@ class RunAlreadyStarted(AGUI_Exception):
 #
 
 
+RunUsageStats = collections.namedtuple(
+    "RunUsageStats",
+    [
+        "input_tokens",
+        "output_tokens",
+        "requests",
+        "tool_calls",
+    ],
+)
+
+
+class RunUsage(abc.ABC):
+    """LLM usage for a run"""
+
+    input_tokens: int
+    """LLM input tokens consumed"""
+
+    output_tokens: int
+    """LLM output tokens consumed"""
+
+    requests: int
+    """LLM requests made"""
+
+    tool_calls: int
+    """LLM tool_calls made"""
+
+    @abc.abstractmethod
+    def as_tuple(self) -> RunUsageStats:
+        """Return values as a tuple."""
+
+
 class RunMetadata(abc.ABC):
     """User-defined metadata for a run"""
 
@@ -91,6 +122,9 @@ class Run(abc.ABC):
 
     parent_run_id: str | None
     """ID of the parent run"""
+
+    run_usage: RunUsage | None
+    """Optional LLM usage data for a run"""
 
     run_metadata: RunMetadata | None
     """Optional user-defined metadata for a run"""
@@ -277,6 +311,21 @@ class ThreadStorage(abc.ABC):
         events: AGUI_Events,
     ) -> AGUI_Events:
         """Save the events for a gven run"""
+
+    @abc.abstractmethod
+    async def save_run_usage(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+        input_tokens: int,
+        output_tokens: int,
+        requests: int,
+        tool_calls: int,
+    ):
+        """Save the run usage statistics"""
 
 
 async def get_the_threads(request: fastapi.Request) -> ThreadStorage:

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -204,6 +204,12 @@ class Run(Base):
         passive_deletes=True,
     )
 
+    run_usage: Mapped[RunUsage | None] = relationship(
+        back_populates="run",
+        cascade="all, delete",
+        passive_deletes=True,
+    )
+
     run_agent_input: Mapped[RunAgentInput | None] = relationship(
         back_populates="run",
         cascade="all, delete",
@@ -280,6 +286,44 @@ class RunMetadata(Base):
     #   'soliplex.agui.RunMetadata' contract
     #
     label: Mapped[str] = mapped_column()
+
+
+class RunUsage(Base):
+    """Hold optional usage info for an AG-UI run
+
+    'run' is a one-to-one relationship to 'Run' (but optional from
+          the run side).
+
+    'input_tokens', int, required
+    'output_tokens', int, required
+    'requests', int, required
+    'tool_calls', int, required
+    """
+
+    __tablename__ = "run_usage"
+
+    id_: Mapped[int] = mapped_column(primary_key=True)
+    created: Mapped[datetime.datetime] = mapped_column(
+        default=agui_util._timestamp,
+    )
+
+    run_id_: Mapped[int] = mapped_column(
+        ForeignKey("run.id_", ondelete="CASCADE"),
+    )
+    run: Mapped[Run] = relationship(back_populates="run_usage")
+
+    input_tokens: Mapped[int] = mapped_column()
+    output_tokens: Mapped[int] = mapped_column()
+    requests: Mapped[int] = mapped_column()
+    tool_calls: Mapped[int] = mapped_column()
+
+    def as_tuple(self) -> agui_package.RunUsageStats:
+        return agui_package.RunUsageStats(
+            self.input_tokens,
+            self.output_tokens,
+            self.requests,
+            self.tool_calls,
+        )
 
 
 class RunAgentInput(Base):
@@ -737,6 +781,39 @@ class ThreadStorage(agui_package.ThreadStorage):
                 session.add(RunEvent(run=run, data=event.model_dump()))
 
         return events
+
+    async def save_run_usage(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+        input_tokens: int,
+        output_tokens: int,
+        requests: int,
+        tool_calls: int,
+    ):
+        """Save the run usage statistics"""
+        await self._session.commit()
+
+        async with self.session as session:
+            run = await self._find_thread_run(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                session=session,
+            )
+            session.add(
+                RunUsage(
+                    run=run,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    requests=requests,
+                    tool_calls=tool_calls,
+                )
+            )
 
 
 def get_session(

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -422,6 +422,22 @@ class AGUI_NewRunRequest(pydantic.BaseModel):
     metadata: AGUI_RunMetadata = KW_ONLY_NONE
 
 
+class AGUI_RunUsage(pydantic.BaseModel):
+    input_tokens: int
+    output_tokens: int
+    requests: int
+    tool_calls: int
+
+    @classmethod
+    def from_tuple(cls, ru_tuple: agui_package.RunUsageStats):
+        return cls(
+            input_tokens=ru_tuple.input_tokens,
+            output_tokens=ru_tuple.output_tokens,
+            requests=ru_tuple.requests,
+            tool_calls=ru_tuple.tool_calls,
+        )
+
+
 class AGUI_Run(pydantic.BaseModel):
     thread_id: str = KW_ONLY
     run_id: str = KW_ONLY
@@ -437,6 +453,7 @@ class AGUI_Run(pydantic.BaseModel):
         default_factory=list,
     )
     metadata: AGUI_RunMetadata | None = KW_ONLY_NONE
+    usage: AGUI_RunUsage | None = KW_ONLY_NONE
 
     @classmethod
     def from_run(
@@ -445,6 +462,7 @@ class AGUI_Run(pydantic.BaseModel):
         a_run_input: agui_core.RunAgentInput | None = None,
         a_run_meta: agui_package.RunMetadata = None,
         a_run_events: list[agui_package.RunEvent] = None,
+        a_run_usage: agui_package.RunUsageStats | None = None,
     ):
         return cls(
             thread_id=a_run.thread_id,
@@ -455,6 +473,9 @@ class AGUI_Run(pydantic.BaseModel):
             run_input=a_run_input,
             events=a_run_events,
             metadata=AGUI_RunMetadata.from_run_meta(a_run_meta),
+            usage=(
+                AGUI_RunUsage.from_tuple(a_run_usage) if a_run_usage else None
+            ),
         )
 
 

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -162,6 +162,7 @@ async def get_room_agui_thread_id(
             a_run_input=await _get_run_input(a_run),
             a_run_meta=await a_run.awaitable_attrs.run_metadata,
             a_run_events=None,
+            a_run_usage=None,
         )
 
     return models.AGUI_Thread.from_thread(
@@ -205,12 +206,14 @@ async def get_room_agui_thread_id_run_id(
         ) from None
 
     await run.awaitable_attrs.thread
+    usage = await run.awaitable_attrs.run_usage
 
     return models.AGUI_Run.from_run(
         a_run=run,
         a_run_input=await _get_run_input(run),
         a_run_meta=await run.awaitable_attrs.run_metadata,
         a_run_events=await run.list_events(),
+        a_run_usage=usage.as_tuple() if usage else None,
     )
 
 
@@ -258,6 +261,7 @@ async def post_room_agui(
             a_run_input=await _get_run_input(run),
             a_run_meta=run_meta,
             a_run_events=[],
+            a_run_usage=None,
         )
 
     return models.AGUI_Thread(
@@ -445,13 +449,31 @@ async def post_room_agui_thread_id_run_id(
 
     events = []
 
-    async def finish_stream(_result):
+    async def finish_stream(result):
         await emitter.close()
 
-    mpx = agui_mpx.multiplex_streams(
-        agui_adapter.run_stream(deps=agent_deps, on_complete=finish_stream),
-        agui_parser.agui_events_from_dicts(emitter),
+        usage = getattr(result, "usage", None)
+
+        if usage is not None:
+            usage = usage()
+            await the_threads.save_run_usage(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                requests=usage.requests,
+                tool_calls=usage.tool_calls,
+            )
+
+    agent_stream = agui_adapter.run_stream(
+        deps=agent_deps,
+        on_complete=finish_stream,
     )
+    emitter_stream = agui_parser.agui_events_from_dicts(emitter)
+
+    mpx = agui_mpx.multiplex_streams(agent_stream, emitter_stream)
 
     save_events = functools.partial(
         the_threads.save_run_events,

--- a/tests/unit/agui/test_persistence.py
+++ b/tests/unit/agui/test_persistence.py
@@ -325,6 +325,38 @@ async def test_run_list_events(w_agui_events):
     assert await run.list_events() == w_agui_events
 
 
+@pytest.mark.anyio
+async def test_runusage_as_tuple(the_session):
+    thread = agui_persistence.Thread(
+        room_id=ROOM_ID,
+        user_name=USER_NAME,
+        thread_id=THREAD_UUID,
+    )
+    the_session.add(thread)
+    the_session.commit()
+
+    run = agui_persistence.Run(
+        thread=thread,
+        run_id=RUN_UUID,
+    )
+    the_session.add(run)
+    the_session.commit()
+
+    usage = agui_persistence.RunUsage(
+        run=run,
+        input_tokens=1,
+        output_tokens=2,
+        requests=3,
+        tool_calls=4,
+    )
+    the_session.add(usage)
+    the_session.commit()
+
+    found = usage.as_tuple()
+
+    assert found == (1, 2, 3, 4)
+
+
 @pytest.mark.parametrize(
     "agui_rai",
     [
@@ -834,6 +866,47 @@ async def test_threadstorage_thread_run_cru(the_async_session):
     assert rmd is None
 
     await the_async_session.commit()
+
+    await the_async_session.commit()
+
+    before = await ts.new_run(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+    )
+
+    await the_async_session.commit()
+    before_id = await before.awaitable_attrs.run_id
+
+    usage = await before.awaitable_attrs.run_usage
+    assert usage is None
+
+    await ts.save_run_usage(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=before_id,
+        input_tokens=1,
+        output_tokens=2,
+        requests=3,
+        tool_calls=4,
+    )
+
+    await the_async_session.commit()
+
+    after = await ts.get_run(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=before_id,
+    )
+
+    after_usage = await after.awaitable_attrs.run_usage
+
+    assert after_usage.input_tokens == 1
+    assert after_usage.output_tokens == 2
+    assert after_usage.requests == 3
+    assert after_usage.tool_calls == 4
 
 
 @pytest.fixture

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -419,6 +419,7 @@ async def test_get_room_agui_thread_id(
         (UNKNOWN_RUN, raises_httpexc(code=404, match="Unknown run")),
     ],
 )
+@pytest.mark.parametrize("w_usage", [None, (1, 2, 3, 4)])
 @pytest.mark.parametrize("w_events", [[], AGUI_EVENTS])
 @pytest.mark.parametrize("w_parent", [False, True])
 @pytest.mark.parametrize("w_run_meta", [False, True])
@@ -433,6 +434,7 @@ async def test_get_room_agui_thread_id_run_id(
     w_run_meta,
     w_parent,
     w_events,
+    w_usage,
     tsgr_side_effect,
     expectation,
 ):
@@ -464,6 +466,17 @@ async def test_get_room_agui_thread_id_run_id(
         test_run.parent_run_id = TEST_PARENT_RUN_ID
     else:
         test_run.parent_run_id = None
+
+    if w_usage is not None:
+        w_usage = mock.create_autospec(
+            agui_package.RunUsage,
+            input_tokens=w_usage[0],
+            output_tokens=w_usage[1],
+            requests=w_usage[2],
+            tool_calls=w_usage[3],
+        )
+
+    test_run.awaitable_attrs.run_usage = _awaitable("run_usage", w_usage)
 
     test_run.awaitable_attrs.thread = _awaitable(
         "thread",
@@ -825,6 +838,7 @@ async def test_tee_events(w_event_count):
         (ALREADY_STARTED, raises_httpexc(code=400, match="already started")),
     ],
 )
+@pytest.mark.parametrize("w_usage", [False, True])
 @mock.patch("fastapi.responses.StreamingResponse")
 @mock.patch("pydantic_ai.ui.ag_ui.AGUIAdapter")
 @mock.patch("soliplex.agui.parser.agui_events_from_dicts")
@@ -841,6 +855,7 @@ async def test_post_room_agui_thread_id_run_id(
     the_threads,
     test_run,
     run_input,
+    w_usage,
     ari_side_effect,
     expectation,
 ):
@@ -928,9 +943,38 @@ async def test_post_room_agui_thread_id_run_id(
         # adapter's 'run_stream' calls its 'on_complete' callback.
         exp_emitter.close.assert_not_awaited()
 
+        # the 'ts.save_run_usage' API does not get called until the
+        # adapter's 'run_stream' calls its 'on_complete' callback.
+        the_threads.save_run_usage.assert_not_awaited()
+
         rs_on_complete = rs_call_0.kwargs["on_complete"]
-        faux_result = object()
+
+        if w_usage:
+            faux_result = mock.Mock()
+            faux_result.usage.return_value = agui_package.RunUsageStats(
+                1,
+                2,
+                3,
+                4,
+            )
+        else:
+            faux_result = object()
+
         await rs_on_complete(faux_result)
+
+        if w_usage:
+            the_threads.save_run_usage.assert_awaited_once_with(
+                user_name=USER_NAME,
+                room_id=TEST_ROOM_ID,
+                thread_id=TEST_THREAD_ID,
+                run_id=TEST_RUN_ID,
+                input_tokens=1,
+                output_tokens=2,
+                requests=3,
+                tool_calls=4,
+            )
+        else:
+            the_threads.save_run_usage.assert_not_awaited()
 
         exp_emitter.close.assert_awaited_once_with()
 


### PR DESCRIPTION
Triggered at 'on_complete' of the event stream, IFF the result object carries the expected 'usage' attribute.

Toward the back-end side of #129.