### PR TITLE
a11y: add semantic labels to loading indicators

### DIFF
--- a/src/frontend/lib/features/chat/widgets/message_list.dart
+++ b/src/frontend/lib/features/chat/widgets/message_list.dart
@@ -84,29 +84,32 @@ class _MessageListState extends ConsumerState<MessageList> {
       itemBuilder: (context, index) {
         // Show streaming indicator at the bottom
         if (index == messages.length) {
-          return Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Row(
-              children: [
-                SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    valueColor: AlwaysStoppedAnimation<Color>(
-                      Theme.of(context).colorScheme.primary,
+          return Semantics(
+            label: 'Assistant is thinking',
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        Theme.of(context).colorScheme.primary,
+                      ),
                     ),
                   ),
-                ),
-                const SizedBox(width: 12),
-                Text(
-                  'Assistant is thinking...',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        fontStyle: FontStyle.italic,
-                      ),
-                ),
-              ],
+                  const SizedBox(width: 12),
+                  Text(
+                    'Assistant is thinking...',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          fontStyle: FontStyle.italic,
+                        ),
+                  ),
+                ],
+              ),
             ),
           );
         }

--- a/src/frontend/lib/features/history/widgets/thread_list_item.dart
+++ b/src/frontend/lib/features/history/widgets/thread_list_item.dart
@@ -64,12 +64,15 @@ class ThreadListItem extends StatelessWidget {
       selectedTileColor: colorScheme.primaryContainer.withValues(alpha: 0.3),
       onTap: onTap,
       leading: hasActiveRun
-          ? SizedBox(
-              width: 24,
-              height: 24,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: colorScheme.primary,
+          ? Semantics(
+              label: 'Conversation in progress',
+              child: SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: colorScheme.primary,
+                ),
               ),
             )
           : Icon(

--- a/src/frontend/lib/shared/widgets/empty_state.dart
+++ b/src/frontend/lib/shared/widgets/empty_state.dart
@@ -17,10 +17,13 @@ class EmptyState extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(
-            icon,
-            size: 64,
-            color: Theme.of(context).colorScheme.outline,
+          Semantics(
+            label: message,
+            child: Icon(
+              icon,
+              size: 64,
+              color: Theme.of(context).colorScheme.outline,
+            ),
           ),
           const SizedBox(height: 16),
           Text(

--- a/src/frontend/lib/shared/widgets/loading_indicator.dart
+++ b/src/frontend/lib/shared/widgets/loading_indicator.dart
@@ -12,18 +12,21 @@ class LoadingIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const CircularProgressIndicator(),
-          if (message != null) ...[
-            const SizedBox(height: 16),
-            Text(
-              message!,
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
+      child: Semantics(
+        label: message ?? 'Loading',
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            if (message != null) ...[
+              const SizedBox(height: 16),
+              Text(
+                message!,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary

Add Semantics wrappers to loading and empty state indicators for screen reader support:

- `empty_state.dart`: Wrap icon with `Semantics(label: message)`
- `thread_list_item.dart`: Wrap spinner with `Semantics(label: 'Conversation in progress')`
- `message_list.dart`: Wrap streaming indicator with `Semantics(label: 'Assistant is thinking')`
- `loading_indicator.dart`: Wrap content with `Semantics(label: message ?? 'Loading')`

Phase 2 of #354

## Test plan

- [x] `flutter analyze` reports 0 issues
- [x] All 177 tests pass
- [ ] Manual screen reader verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)