### PR TITLE
a11y: exclude decorative elements from semantics tree

### DIFF
--- a/src/frontend/lib/core/router/app_router.dart
+++ b/src/frontend/lib/core/router/app_router.dart
@@ -58,7 +58,9 @@ final appRouter = GoRouter(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(Icons.error_outline, size: 48),
+          const ExcludeSemantics(
+            child: Icon(Icons.error_outline, size: 48),
+          ),
           const SizedBox(height: 16),
           Text('Page not found: ${state.uri}'),
           const SizedBox(height: 16),

--- a/src/frontend/lib/features/chat/widgets/chat_message_widget.dart
+++ b/src/frontend/lib/features/chat/widgets/chat_message_widget.dart
@@ -128,13 +128,15 @@ class ChatMessageWidget extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        SizedBox(
-          width: 16,
-          height: 16,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-            valueColor: AlwaysStoppedAnimation<Color>(
-              theme.colorScheme.onSurfaceVariant,
+        ExcludeSemantics(
+          child: SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
         ),

--- a/src/frontend/lib/features/history/widgets/new_conversation_button.dart
+++ b/src/frontend/lib/features/history/widgets/new_conversation_button.dart
@@ -41,10 +41,12 @@ class NewConversationButton extends StatelessWidget {
             padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
             child: Row(
               children: [
-                Icon(
-                  Icons.edit_outlined,
-                  color: colorScheme.onPrimaryContainer,
-                  size: 24,
+                ExcludeSemantics(
+                  child: Icon(
+                    Icons.edit_outlined,
+                    color: colorScheme.onPrimaryContainer,
+                    size: 24,
+                  ),
                 ),
                 const SizedBox(width: 16),
                 Expanded(
@@ -56,10 +58,13 @@ class NewConversationButton extends StatelessWidget {
                     ),
                   ),
                 ),
-                Icon(
-                  Icons.arrow_forward_ios,
-                  color: colorScheme.onPrimaryContainer.withValues(alpha: 0.5),
-                  size: 16,
+                ExcludeSemantics(
+                  child: Icon(
+                    Icons.arrow_forward_ios,
+                    color:
+                        colorScheme.onPrimaryContainer.withValues(alpha: 0.5),
+                    size: 16,
+                  ),
                 ),
               ],
             ),

--- a/src/frontend/lib/features/home/home_screen.dart
+++ b/src/frontend/lib/features/home/home_screen.dart
@@ -22,10 +22,12 @@ class HomeScreen extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              Icons.chat_bubble_outline,
-              size: 100,
-              color: Theme.of(context).colorScheme.primary,
+            ExcludeSemantics(
+              child: Icon(
+                Icons.chat_bubble_outline,
+                size: 100,
+                color: Theme.of(context).colorScheme.primary,
+              ),
             ),
             const SizedBox(height: 24),
             Text(

--- a/src/frontend/lib/shared/widgets/error_display.dart
+++ b/src/frontend/lib/shared/widgets/error_display.dart
@@ -73,10 +73,12 @@ class ErrorDisplay extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              _getErrorIcon(),
-              size: 64,
-              color: Theme.of(context).colorScheme.error,
+            ExcludeSemantics(
+              child: Icon(
+                _getErrorIcon(),
+                size: 64,
+                color: Theme.of(context).colorScheme.error,
+              ),
             ),
             const SizedBox(height: 16),
             Text(


### PR DESCRIPTION
## Summary

Wrap decorative icons with `ExcludeSemantics` to reduce screen reader noise:

- `home_screen.dart`: decorative chat icon
- `new_conversation_button.dart`: edit icon and arrow icon  
- `error_display.dart`: error icon (message already conveys meaning)
- `app_router.dart`: 404 error icon
- `chat_message_widget.dart`: spinner in typing indicator (text "Typing..." conveys meaning)

Phase 3 of #354

## Test plan

- [x] `flutter analyze` reports 0 issues
- [x] All 177 tests pass
- [ ] Manual screen reader verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)