### PR TITLE
a11y: add semantic label to chat input

### DIFF
--- a/src/frontend/lib/features/chat/widgets/chat_input.dart
+++ b/src/frontend/lib/features/chat/widgets/chat_input.dart
@@ -87,25 +87,28 @@ class _ChatInputState extends ConsumerState<ChatInput> {
                   LogicalKeyboardKey.escape,
                 ): () => _focusNode.unfocus(),
               },
-              child: TextField(
-                controller: _controller,
-                focusNode: _focusNode,
-                maxLines: null,
-                textInputAction: TextInputAction.newline,
-                decoration: InputDecoration(
-                  hintText: canSend
-                      ? 'Type a message...'
-                      : 'Select a room to start chatting',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(24),
+              child: Semantics(
+                label: 'Chat message input',
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  maxLines: null,
+                  textInputAction: TextInputAction.newline,
+                  decoration: InputDecoration(
+                    hintText: canSend
+                        ? 'Type a message...'
+                        : 'Select a room to start chatting',
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(24),
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 12,
+                    ),
                   ),
-                  contentPadding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 12,
-                  ),
+                  enabled: canSend,
+                  onChanged: (_) => setState(() {}),
                 ),
-                enabled: canSend,
-                onChanged: (_) => setState(() {}),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary

Wrap TextField with `Semantics(label: 'Chat message input')` for screen reader support.

Phase 4 of #354

## Test plan

- [x] `flutter analyze` reports 0 issues
- [x] All 177 tests pass
- [ ] Manual screen reader verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)