### PR TITLE
a11y: semantic cleanup and code block labels

### DIFF
--- a/src/frontend/lib/features/chat/widgets/chat_message_widget.dart
+++ b/src/frontend/lib/features/chat/widgets/chat_message_widget.dart
@@ -166,16 +166,23 @@ class CodeBlockBuilder extends MarkdownElementBuilder {
       language = className.replaceFirst('language-', '');
     }
 
-    return Container(
-      padding: const EdgeInsets.all(12),
-      child: HighlightView(
-        code,
-        language: language.isEmpty ? 'plaintext' : language,
-        theme: githubTheme,
-        padding: EdgeInsets.zero,
-        textStyle: const TextStyle(
-          fontFamily: 'monospace',
-          fontSize: 14,
+    final semanticLabel = language.isEmpty || language == 'plaintext'
+        ? 'Code block'
+        : 'Code block in $language';
+
+    return Semantics(
+      label: semanticLabel,
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        child: HighlightView(
+          code,
+          language: language.isEmpty ? 'plaintext' : language,
+          theme: githubTheme,
+          padding: EdgeInsets.zero,
+          textStyle: const TextStyle(
+            fontFamily: 'monospace',
+            fontSize: 14,
+          ),
         ),
       ),
     );

--- a/src/frontend/lib/features/history/widgets/thread_list_item.dart
+++ b/src/frontend/lib/features/history/widgets/thread_list_item.dart
@@ -99,10 +99,12 @@ class ThreadListItem extends StatelessWidget {
             )
           : null,
       trailing: isSelected
-          ? Icon(
-              Icons.check_circle,
-              color: colorScheme.primary,
-              size: 20,
+          ? ExcludeSemantics(
+              child: Icon(
+                Icons.check_circle,
+                color: colorScheme.primary,
+                size: 20,
+              ),
             )
           : null,
     );


### PR DESCRIPTION
## Summary

- Wrap checkmark icon with `ExcludeSemantics` (ListTile `selected` already conveys selection state)
- Add `Semantics(label: 'Code block in $language')` to code blocks for AI understanding

Phase 6 of #354

## Test plan

- [x] `flutter analyze` reports 0 issues
- [x] All 177 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)