### PR TITLE
feat(soliplex_client): add application layer for AG-UI event processing

### DIFF
--- a/src/frontend/packages/soliplex_client/lib/soliplex_client.dart
+++ b/src/frontend/packages/soliplex_client/lib/soliplex_client.dart
@@ -5,6 +5,9 @@ library soliplex_client;
 export 'package:ag_ui/ag_ui.dart';
 
 export 'src/api/api.dart';
+// Application layer not exported via barrel to avoid naming conflicts with
+// domain layer's StreamingState. Import directly when needed:
+// import 'package:soliplex_client/src/application/application.dart';
 export 'src/domain/domain.dart';
 export 'src/errors/errors.dart';
 export 'src/http/http.dart';

--- a/src/frontend/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/src/frontend/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -1,0 +1,135 @@
+import 'package:ag_ui/ag_ui.dart';
+import 'package:meta/meta.dart';
+import 'package:soliplex_client/src/application/streaming_state.dart';
+import 'package:soliplex_client/src/domain/chat_message.dart';
+import 'package:soliplex_client/src/domain/conversation.dart'
+    hide NotStreaming, Streaming, StreamingState;
+
+/// Result of processing an AG-UI event.
+///
+/// Contains both the updated domain state (Conversation) and ephemeral
+/// streaming state.
+@immutable
+class EventProcessingResult {
+  /// Creates an event processing result.
+  const EventProcessingResult({
+    required this.conversation,
+    required this.streaming,
+  });
+
+  /// Updated conversation (domain state).
+  final Conversation conversation;
+
+  /// Updated streaming state (ephemeral operation state).
+  final StreamingState streaming;
+}
+
+/// Processes a single AG-UI event, returning updated domain and streaming
+/// state.
+///
+/// This is a pure function with no side effects. It takes the current state
+/// and an event, and returns the new state.
+///
+/// Example usage:
+/// ```dart
+/// final result = processEvent(conversation, streaming, event);
+/// // result.conversation - updated domain state
+/// // result.streaming - updated streaming state
+/// ```
+EventProcessingResult processEvent(
+  Conversation conversation,
+  StreamingState streaming,
+  BaseEvent event,
+) {
+  return switch (event) {
+    // Run lifecycle events
+    RunStartedEvent(:final runId) => EventProcessingResult(
+        conversation: conversation.withStatus(Running(runId: runId)),
+        streaming: streaming,
+      ),
+    RunFinishedEvent() => EventProcessingResult(
+        conversation: conversation.withStatus(const Completed()),
+        streaming: const NotStreaming(),
+      ),
+    RunErrorEvent(:final message) => EventProcessingResult(
+        conversation: conversation.withStatus(Failed(error: message)),
+        streaming: const NotStreaming(),
+      ),
+
+    // Text message streaming events
+    TextMessageStartEvent(:final messageId) => EventProcessingResult(
+        conversation: conversation,
+        streaming: Streaming(messageId: messageId, text: ''),
+      ),
+    TextMessageContentEvent(:final messageId, :final delta) =>
+      _processTextContent(conversation, streaming, messageId, delta),
+    TextMessageEndEvent(:final messageId) =>
+      _processTextEnd(conversation, streaming, messageId),
+
+    // Tool call events
+    ToolCallStartEvent(:final toolCallId, :final toolCallName) =>
+      EventProcessingResult(
+        conversation: conversation.withToolCall(
+          ToolCallInfo(id: toolCallId, name: toolCallName),
+        ),
+        streaming: streaming,
+      ),
+    ToolCallEndEvent(:final toolCallId) => EventProcessingResult(
+        conversation: conversation.copyWith(
+          toolCalls: conversation.toolCalls
+              .where((tc) => tc.id != toolCallId)
+              .toList(),
+        ),
+        streaming: streaming,
+      ),
+
+    // All other events pass through unchanged
+    _ => EventProcessingResult(
+        conversation: conversation,
+        streaming: streaming,
+      ),
+  };
+}
+
+// TODO(cleanup): Extract streaming guard pattern if a third streaming event
+// type is added. Both _processTextContent and _processTextEnd share the
+// "check if streaming matches messageId, else return unchanged" pattern.
+EventProcessingResult _processTextContent(
+  Conversation conversation,
+  StreamingState streaming,
+  String messageId,
+  String delta,
+) {
+  if (streaming is Streaming && streaming.messageId == messageId) {
+    return EventProcessingResult(
+      conversation: conversation,
+      streaming: streaming.appendDelta(delta),
+    );
+  }
+  return EventProcessingResult(
+    conversation: conversation,
+    streaming: streaming,
+  );
+}
+
+EventProcessingResult _processTextEnd(
+  Conversation conversation,
+  StreamingState streaming,
+  String messageId,
+) {
+  if (streaming is Streaming && streaming.messageId == messageId) {
+    final newMessage = TextMessage.create(
+      id: messageId,
+      user: ChatUser.assistant,
+      text: streaming.text,
+    );
+    return EventProcessingResult(
+      conversation: conversation.withAppendedMessage(newMessage),
+      streaming: const NotStreaming(),
+    );
+  }
+  return EventProcessingResult(
+    conversation: conversation,
+    streaming: streaming,
+  );
+}

--- a/src/frontend/packages/soliplex_client/lib/src/application/application.dart
+++ b/src/frontend/packages/soliplex_client/lib/src/application/application.dart
@@ -1,0 +1,2 @@
+export 'agui_event_processor.dart';
+export 'streaming_state.dart';

--- a/src/frontend/packages/soliplex_client/lib/src/application/streaming_state.dart
+++ b/src/frontend/packages/soliplex_client/lib/src/application/streaming_state.dart
@@ -1,0 +1,75 @@
+import 'package:meta/meta.dart';
+
+/// Ephemeral streaming state (application layer, not domain).
+///
+/// Streaming is operation state that exists only during active streaming.
+/// When streaming completes, the text becomes a domain message.
+///
+/// Use pattern matching for exhaustive handling:
+/// ```dart
+/// switch (streaming) {
+///   case NotStreaming():
+///     // No message being streamed
+///   case Streaming(:final messageId, :final text):
+///     // Message is streaming
+/// }
+/// ```
+@immutable
+sealed class StreamingState {
+  const StreamingState();
+}
+
+/// No message is currently streaming.
+@immutable
+class NotStreaming extends StreamingState {
+  /// Creates a not streaming state.
+  const NotStreaming();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NotStreaming && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'NotStreaming()';
+}
+
+/// A message is currently streaming.
+@immutable
+class Streaming extends StreamingState {
+  /// Creates a streaming state with the given [messageId] and accumulated
+  /// [text].
+  const Streaming({required this.messageId, required this.text});
+
+  /// The ID of the message being streamed.
+  final String messageId;
+
+  /// The text accumulated so far.
+  final String text;
+
+  // TODO(cleanup): Consider inlining this in agui_event_processor.dart.
+  // This method is only used by one caller (Feature Envy smell). Keeping
+  // Streaming as pure data would be cleaner.
+  /// Creates a copy with the delta appended to text.
+  Streaming appendDelta(String delta) {
+    return Streaming(messageId: messageId, text: text + delta);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Streaming &&
+          runtimeType == other.runtimeType &&
+          messageId == other.messageId &&
+          text == other.text;
+
+  @override
+  int get hashCode => Object.hash(runtimeType, messageId, text);
+
+  @override
+  String toString() =>
+      'Streaming(messageId: $messageId, text: ${text.length} chars)';
+}

--- a/src/frontend/packages/soliplex_client/test/application/agui_event_processor_test.dart
+++ b/src/frontend/packages/soliplex_client/test/application/agui_event_processor_test.dart
@@ -1,0 +1,206 @@
+import 'package:ag_ui/ag_ui.dart';
+import 'package:soliplex_client/src/application/agui_event_processor.dart';
+import 'package:soliplex_client/src/application/streaming_state.dart'
+    as app_streaming;
+import 'package:soliplex_client/src/domain/chat_message.dart';
+import 'package:soliplex_client/src/domain/conversation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('processEvent', () {
+    late Conversation conversation;
+    late app_streaming.StreamingState streaming;
+
+    setUp(() {
+      conversation = Conversation.empty(threadId: 'thread-1');
+      streaming = const app_streaming.NotStreaming();
+    });
+
+    group('run lifecycle events', () {
+      test('RunStartedEvent sets status to Running', () {
+        const event = RunStartedEvent(
+          threadId: 'thread-1',
+          runId: 'run-1',
+        );
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.conversation.status, isA<Running>());
+        expect((result.conversation.status as Running).runId, equals('run-1'));
+        expect(result.streaming, isA<app_streaming.NotStreaming>());
+      });
+
+      test('RunFinishedEvent sets status to Completed', () {
+        final runningConversation = conversation.withStatus(
+          const Running(runId: 'run-1'),
+        );
+        const event = RunFinishedEvent(
+          threadId: 'thread-1',
+          runId: 'run-1',
+        );
+
+        final result = processEvent(runningConversation, streaming, event);
+
+        expect(result.conversation.status, isA<Completed>());
+        expect(result.streaming, isA<app_streaming.NotStreaming>());
+      });
+
+      test('RunErrorEvent sets status to Failed with message', () {
+        final runningConversation = conversation.withStatus(
+          const Running(runId: 'run-1'),
+        );
+        const event = RunErrorEvent(
+          message: 'Something went wrong',
+          code: 'ERROR_CODE',
+        );
+
+        final result = processEvent(runningConversation, streaming, event);
+
+        expect(result.conversation.status, isA<Failed>());
+        expect(
+          (result.conversation.status as Failed).error,
+          equals('Something went wrong'),
+        );
+        expect(result.streaming, isA<app_streaming.NotStreaming>());
+      });
+    });
+
+    group('text message streaming', () {
+      test('TextMessageStartEvent begins streaming', () {
+        const event = TextMessageStartEvent(messageId: 'msg-1');
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.streaming, isA<app_streaming.Streaming>());
+        final streamingState = result.streaming as app_streaming.Streaming;
+        expect(streamingState.messageId, equals('msg-1'));
+        expect(streamingState.text, isEmpty);
+      });
+
+      test('TextMessageContentEvent is ignored when NotStreaming', () {
+        const event = TextMessageContentEvent(
+          messageId: 'msg-1',
+          delta: 'Hello',
+        );
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.streaming, isA<app_streaming.NotStreaming>());
+        expect(result.conversation.messages, isEmpty);
+      });
+
+      test('TextMessageContentEvent appends delta to streaming text', () {
+        const streamingState = app_streaming.Streaming(
+          messageId: 'msg-1',
+          text: 'Hello',
+        );
+        const event = TextMessageContentEvent(
+          messageId: 'msg-1',
+          delta: ' world',
+        );
+
+        final result = processEvent(conversation, streamingState, event);
+
+        expect(result.streaming, isA<app_streaming.Streaming>());
+        final newStreaming = result.streaming as app_streaming.Streaming;
+        expect(newStreaming.messageId, equals('msg-1'));
+        expect(newStreaming.text, equals('Hello world'));
+      });
+
+      test(
+        'TextMessageContentEvent ignores delta if messageId does not match',
+        () {
+          const streamingState = app_streaming.Streaming(
+            messageId: 'msg-1',
+            text: 'Hello',
+          );
+          const event = TextMessageContentEvent(
+            messageId: 'msg-other',
+            delta: ' world',
+          );
+
+          final result = processEvent(conversation, streamingState, event);
+
+          expect(result.streaming, equals(streamingState));
+        },
+      );
+
+      test('TextMessageEndEvent finalizes message and resets streaming', () {
+        const streamingState = app_streaming.Streaming(
+          messageId: 'msg-1',
+          text: 'Hello world',
+        );
+        const event = TextMessageEndEvent(messageId: 'msg-1');
+
+        final result = processEvent(conversation, streamingState, event);
+
+        expect(result.streaming, isA<app_streaming.NotStreaming>());
+        expect(result.conversation.messages, hasLength(1));
+        final message = result.conversation.messages.first;
+        expect(message.id, equals('msg-1'));
+      });
+
+      test(
+        'TextMessageEndEvent ignores if messageId does not match streaming',
+        () {
+          const streamingState = app_streaming.Streaming(
+            messageId: 'msg-1',
+            text: 'Hello',
+          );
+          const event = TextMessageEndEvent(messageId: 'msg-other');
+
+          final result = processEvent(conversation, streamingState, event);
+
+          expect(result.streaming, equals(streamingState));
+          expect(result.conversation.messages, isEmpty);
+        },
+      );
+    });
+
+    group('tool call events', () {
+      test('ToolCallStartEvent adds tool call to conversation', () {
+        const event = ToolCallStartEvent(
+          toolCallId: 'tool-1',
+          toolCallName: 'search',
+        );
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.conversation.toolCalls, hasLength(1));
+        expect(result.conversation.toolCalls.first.id, equals('tool-1'));
+        expect(result.conversation.toolCalls.first.name, equals('search'));
+      });
+
+      test('ToolCallEndEvent removes tool call from active list', () {
+        final conversationWithTool = conversation.withToolCall(
+          const ToolCallInfo(id: 'tool-1', name: 'search'),
+        );
+        const event = ToolCallEndEvent(toolCallId: 'tool-1');
+
+        final result = processEvent(conversationWithTool, streaming, event);
+
+        expect(result.conversation.toolCalls, isEmpty);
+      });
+    });
+
+    group('passthrough events', () {
+      test('StateSnapshotEvent passes through unchanged', () {
+        const event = StateSnapshotEvent(snapshot: {'key': 'value'});
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.conversation, equals(conversation));
+        expect(result.streaming, equals(streaming));
+      });
+
+      test('CustomEvent passes through unchanged', () {
+        const event = CustomEvent(name: 'custom', value: {'data': 123});
+
+        final result = processEvent(conversation, streaming, event);
+
+        expect(result.conversation, equals(conversation));
+        expect(result.streaming, equals(streaming));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add application layer (`streaming_state.dart`, `agui_event_processor.dart`) to cleanly separate ephemeral streaming state from domain concerns
- Pure `processEvent()` function transforms AG-UI events into domain state changes
- 13 unit tests covering all event types and edge cases

## Architecture

This is Step 2 of the [architectural enhancement plan](src/frontend/scratchpad/architectural_enhancement_v3.md).

```
┌─────────────────────────────────────────────────────────────┐
│  UI Layer (Flutter)                                          │
│  - ActiveRunNotifier (will consume StreamingState)           │
└─────────────────────────────────────────────────────────────┘
         │ depends on
         ▼
┌─────────────────────────────────────────────────────────────┐
│  Application Layer (soliplex_client)  ← NEW                  │
│  - AgUiEventProcessor (processes events → StreamingState)    │
│  - StreamingState sealed class (NotStreaming, Streaming)     │
└─────────────────────────────────────────────────────────────┘
         │ depends on
         ▼
┌─────────────────────────────────────────────────────────────┐
│  Domain Layer (soliplex_client)                              │
│  - Conversation (aggregate: threadId, messages, status)      │
└─────────────────────────────────────────────────────────────┘
```

## Key Design Decisions

1. **Streaming is ephemeral operation state**, not domain state. When streaming completes, only then does the domain change (message added).

2. **Application layer NOT exported from main barrel** to avoid naming conflicts with domain layer's `StreamingState` (which will be removed in a later PR). Consumers import directly:
   ```dart
   import 'package:soliplex_client/src/application/application.dart';
   ```

3. **Pure function design** - `processEvent()` has no side effects, making it easy to test and reason about.

## Files Changed

| File | Change |
|------|--------|
| `lib/src/application/streaming_state.dart` | New - Ephemeral streaming state sealed class |
| `lib/src/application/agui_event_processor.dart` | New - Pure event processor function |
| `lib/src/application/application.dart` | New - Barrel export |
| `test/application/agui_event_processor_test.dart` | New - 13 unit tests |
| `lib/soliplex_client.dart` | Comment explaining export strategy |

## Test plan

- [x] `mcp__dart__analyze_files` reports 0 issues
- [x] `mcp__dart__run_tests` - all 491 tests pass
- [x] Blacksmith review passed (minor TODOs added for future cleanup)

## Next Steps

- Steps 3-4: Refactor `ActiveRunState` and `ActiveRunNotifier` to use this application layer
- Step 1: Remove duplicate `StreamingState` from domain layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)