### PR TITLE
refactor(soliplex_client): remove streaming from domain layer

### DIFF
--- a/src/frontend/docs/planning/worklogs/core-frontend-worklog.md
+++ b/src/frontend/docs/planning/worklogs/core-frontend-worklog.md
@@ -21,6 +21,8 @@
 
 **Phase:** AM3 - COMPLETE (Working Chat shipped)
 
+**Architectural Enhancement v3:** ✅ COMPLETE (Clean architecture layers)
+
 **Next Phase:** AM4 (Enhanced Chat) or AM5 (Inspector)
 
 **Blocked by:** None
@@ -595,4 +597,58 @@ Renamed frontend `Failed`/`Cancelled` to `FailedResult`/`CancelledResult` rather
 
 ---
 
-*Last updated: 2025-12-23 (Application layer export & import cleanup)*
+### Session 7: 2025-12-23 - Domain Layer Cleanup (Arch v3 Complete)
+
+**Duration:** ~20 minutes
+
+**Completed:**
+
+- ✅ Removed streaming from domain layer (Step 1 of arch-v3)
+- ✅ Simplified domain barrel export
+- ✅ Cleaned up obsolete hide clauses in application layer
+- ✅ Removed streaming-related tests from conversation_test.dart
+- ✅ Blacksmith review: approved
+
+**Changes:**
+
+1. **conversation.dart:**
+   - Removed `StreamingState` sealed class and subtypes (`NotStreaming`, `Streaming`)
+   - Removed `streaming` field from `Conversation`
+   - Removed `withStreaming()` method
+   - Removed `isStreaming` getter
+   - Updated `copyWith()` and `toString()` to remove streaming references
+
+2. **domain.dart:**
+   - Simplified from explicit `show`/`hide` export to `export 'conversation.dart';`
+
+3. **agui_event_processor.dart:**
+   - Removed obsolete `hide NotStreaming, Streaming, StreamingState` clause
+
+4. **conversation_test.dart:**
+   - Removed `withStreaming` test group
+   - Removed `isStreaming` test group
+   - Removed `StreamingState` test group
+   - Updated `toString` test
+
+**Metrics:**
+
+- **Analyzer:** 0 errors, 0 warnings, 0 hints ✓
+- **Tests:** 187 passing (0 failures) ✓
+- **Files Modified:** 4 files
+- **Lines Removed:** ~150 (dead code + tests for removed behavior)
+
+**Architectural Enhancement v3: COMPLETE**
+
+All success criteria met:
+- Conversation aggregate is pure domain (no streaming state) ✅
+- StreamingState lives in application layer ✅
+- AG-UI event processing is pure function in application layer ✅
+- ActiveRunNotifier uses processor, no direct event switching ✅
+- All tests pass ✅
+- 0 analyzer issues ✅
+
+**Branch:** `arch-v3/domain-cleanup`
+
+---
+
+*Last updated: 2025-12-23 (Domain layer cleanup - Arch v3 complete)*

--- a/src/frontend/packages/soliplex_client/lib/src/application/agui_event_processor.dart
+++ b/src/frontend/packages/soliplex_client/lib/src/application/agui_event_processor.dart
@@ -2,8 +2,7 @@ import 'package:ag_ui/ag_ui.dart';
 import 'package:meta/meta.dart';
 import 'package:soliplex_client/src/application/streaming_state.dart';
 import 'package:soliplex_client/src/domain/chat_message.dart';
-import 'package:soliplex_client/src/domain/conversation.dart'
-    hide NotStreaming, Streaming, StreamingState;
+import 'package:soliplex_client/src/domain/conversation.dart';
 
 /// Result of processing an AG-UI event.
 ///

--- a/src/frontend/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/src/frontend/packages/soliplex_client/lib/src/domain/domain.dart
@@ -1,15 +1,5 @@
 export 'chat_message.dart';
-// Export Conversation and status types
-// (hide streaming types - they're in application layer).
-export 'conversation.dart'
-    show
-        Cancelled,
-        Completed,
-        Conversation,
-        ConversationStatus,
-        Failed,
-        Idle,
-        Running;
+export 'conversation.dart';
 export 'room.dart';
 export 'run_info.dart';
 export 'thread_info.dart';


### PR DESCRIPTION
## Summary

- Complete architectural enhancement v3 by removing ephemeral streaming state from the domain layer
- Streaming now lives solely in the application layer where it belongs
- Enforces clean architecture: domain = persistent state, application = ephemeral operations

## Changes

- Remove `StreamingState`, `NotStreaming`, `Streaming` from `conversation.dart`
- Remove `streaming` field, `withStreaming()`, `isStreaming` from `Conversation`
- Simplify `domain.dart` barrel export (no more show/hide)
- Remove obsolete `hide` clause from `agui_event_processor.dart`
- Remove streaming-related tests (behavior now tested in application layer)

## Test plan

- [x] `mcp__dart__analyze_files` reports 0 issues
- [x] `mcp__dart__run_tests` passes (187 tests)
- [x] Blacksmith review approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)