### PR TITLE
docs: add Related Repositories section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ See `example/` directory for sample configurations.
 ## Related Repositories
 
 - **[soliplex/flutter](https://github.com/soliplex/flutter)** - Flutter frontend (cross-platform mobile/desktop)
-- **[soliplex/docs](https://github.com/soliplex/docs)** - Documentation site (MkDocs)
+- **[Documentation](https://soliplex.github.io/)** - Documentation site (MkDocs)
 - **[soliplex/ingester](https://github.com/soliplex/ingester)** - Content ingestion pipeline
+- **[soliplex/ingester-agents](https://github.com/soliplex/ingester-agents)** - Document ingestion agents
 - **[soliplex/whitelabel](https://github.com/soliplex/whitelabel)** - Customer white-label appshell template
 
 ## License


### PR DESCRIPTION
## Summary
- Add Related Repositories section to README linking to new dedicated repos

## Changes
- **README.md**: Add links to soliplex/flutter, soliplex/docs, soliplex/ingester, soliplex/whitelabel

## Notes
- The `deploy-site.yml` workflow may need updating since docs are now in a separate repo
- The `new_frontend` branch is preserved as-is

## Test plan
- [x] Links are correct
- [x] Formatting is valid