### PR TITLE
feat(ci): add mypy type checking (advisory mode)

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -63,6 +63,10 @@ jobs:
       - name: Run ruff linter
         run: ruff check
 
+      - name: Run mypy type checker
+        run: mypy
+        continue-on-error: true  # Advisory for now, fix types gradually
+
       - name: Security scan dependencies
         run: pip-audit --strict --progress-spinner=off
         continue-on-error: true  # Advisory for now, can make strict later

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "anyio",
     "trio",
     "ruff",
+    "mypy",
 ]
 docs = [
     "mkdocs>=1.6.1",
@@ -120,3 +121,17 @@ force-single-line = true
 
 [tool.ruff.lint.flake8-pytest-style]
 parametrize-names-type = "csv"
+
+[tool.mypy]
+python_version = "3.13"
+show_error_codes = true
+files = ["src/soliplex"]
+# Exclusions - gradually remove as types are fixed
+exclude = [
+    "tests/",
+    "src/soliplex/tui/",
+]
+# Relaxed settings for gradual adoption
+ignore_missing_imports = true
+disallow_untyped_defs = false
+check_untyped_defs = false


### PR DESCRIPTION
## Summary
- Add mypy to dev dependencies for type checking
- Add mypy step to CI workflow in advisory mode
- Configure mypy with relaxed settings for gradual adoption

## Changes
- **pyproject.toml**: Added mypy to dev dependencies, configured `[tool.mypy]` section
- **python-test.yaml**: Added mypy step with `continue-on-error: true`

## Configuration Details
- Excludes `tests/` and `src/soliplex/tui/` directories
- Ignores missing imports for third-party libraries without stubs
- Disables strict untyped checks for gradual adoption

## Current Status
260 type errors to be fixed incrementally. Mypy runs in advisory mode
so CI won't fail, but errors are visible in the workflow output.

## Test plan
- [x] mypy runs locally
- [ ] CI passes (advisory mode)

**Note:** This PR is based on `fix/ci-improvements` branch (PR #411) and should be merged after that PR.