### PR TITLE
feat(config): add GOOGLE provider enum

### DIFF
--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -784,6 +784,7 @@ MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME = {
 class LLMProviderType(enum.StrEnum):
     OPENAI = "openai"
     OLLAMA = "ollama"
+    GOOGLE = "google"
 
 
 @dataclasses.dataclass
@@ -902,6 +903,15 @@ class AgentConfig:
 
     @property
     def llm_provider_kw(self) -> dict:
+        # Early return for providers that don't need base_url
+        if self.provider_type == LLMProviderType.GOOGLE:
+            provider_kw = {}
+            if self.provider_key is not None:
+                provider_kw["api_key"] = self._installation_config.get_secret(
+                    self.provider_key
+                )
+            return provider_kw
+
         if self.provider_base_url is None:
             provider_base_url = self._installation_config.get_environment(
                 "OLLAMA_BASE_URL"

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -131,7 +131,7 @@ class DefaultAgent(pydantic.BaseModel):
     retries: int
     system_prompt: str | None
     provider_type: config.LLMProviderType  # enum, not dataclass
-    provider_base_url: str
+    provider_base_url: str | None
     provider_key: str
 
     @classmethod
@@ -143,7 +143,7 @@ class DefaultAgent(pydantic.BaseModel):
             retries=agent_config.retries,
             system_prompt=agent_config.get_system_prompt(),
             provider_type=agent_config.provider_type,
-            provider_base_url=llm_provider_kw["base_url"],
+            provider_base_url=llm_provider_kw.get("base_url"),
             provider_key=agent_config.provider_key or "dummy",
         )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2740,6 +2740,39 @@ def test_agentconfig_llm_provider_kw(
         installation_config.get_secret.assert_not_called()
 
 
+@pytest.mark.parametrize("has_pk", [False, True])
+def test_agentconfig_llm_provider_kw_google(
+    installation_config,
+    has_pk,
+):
+    """Test llm_provider_kw for GOOGLE provider returns no base_url."""
+    kw = {
+        "_installation_config": installation_config,
+        "provider_type": config.LLMProviderType.GOOGLE,
+    }
+
+    expected = {}
+
+    if has_pk:
+        kw["provider_key"] = "secret:SECRET_NAME"
+        expected["api_key"] = installation_config.get_secret.return_value
+
+    aconfig = config.AgentConfig(
+        id="test-agent", system_prompt="You are a test", **kw
+    )
+
+    found = aconfig.llm_provider_kw
+
+    assert found == expected
+
+    if has_pk:
+        installation_config.get_secret.assert_called_once_with(
+            "secret:SECRET_NAME"
+        )
+    else:
+        installation_config.get_secret.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "agent_config_kw",
     [

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -474,7 +474,13 @@ def test_defaultagent_from_config(
     assert agent_model.model_name == AGENT_MODEL
     assert agent_model.retries == exp_retries
     assert agent_model.system_prompt == AGENT_PROMPT
-    assert agent_model.provider_base_url == exp_base
+
+    # Handle GOOGLE provider having no base_url
+    provider_type = agent_provider_type.get("provider_type")
+    if provider_type == config.LLMProviderType.GOOGLE:
+        assert agent_model.provider_base_url is None
+    else:
+        assert agent_model.provider_base_url == exp_base
 
 
 class FeatureModel(pydantic.BaseModel):


### PR DESCRIPTION
## Summary
- Add `GOOGLE = "google"` to `LLMProviderType` enum
- Add early-return branch in `llm_provider_kw` for GOOGLE provider (no base_url, optional api_key)
- Make `DefaultAgent.provider_base_url` optional (`str | None`)
- Update `from_config` to use `.get("base_url")` for safe access

## Changes
- **src/soliplex/config.py**: Add GOOGLE enum value, add early-return branch in llm_provider_kw
- **src/soliplex/models.py**: Make provider_base_url optional, use .get() for base_url
- **tests/unit/test_config.py**: Add test_agentconfig_llm_provider_kw_google
- **tests/unit/test_models.py**: Update test_defaultagent_from_config to handle GOOGLE

## Test plan
- [x] `ruff check` passes
- [x] 3317 unit tests pass
- [x] 99.98% coverage (pre-existing gap in secrets.py unrelated to this PR)
- [x] Gemini review: PASS
- [x] Codex review: PASS

## Related
PR1 of the google-genai implementation plan. Prepares config/model layers for future Google Gemini provider support.