### PR TITLE
fix: add missing linter ignores to Dart codegen script

### DIFF
--- a/scripts/generate_dart_models.sh
+++ b/scripts/generate_dart_models.sh
@@ -186,6 +186,9 @@ for dart_file in "$OUTPUT_DIR"/*.dart; do
 // ignore_for_file: always_put_required_named_parameters_first
 // ignore_for_file: argument_type_not_assignable
 // ignore_for_file: unnecessary_ignore
+// ignore_for_file: avoid_dynamic_calls
+// ignore_for_file: inference_failure_on_untyped_parameter
+// ignore_for_file: inference_failure_on_collection_literal
 
 EOF
         cat "$dart_file" >> "${dart_file}.tmp"


### PR DESCRIPTION
## Summary
- Add three missing `ignore_for_file` directives to the Dart model generation script
- These suppress strict analysis warnings that quicktype output doesn't satisfy:
  - `avoid_dynamic_calls`
  - `inference_failure_on_untyped_parameter`
  - `inference_failure_on_collection_literal`

## Test plan
- [ ] Regenerate Dart models and verify `flutter analyze --fatal-infos` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)