### PR TITLE
feat: 'GET /api/v1/installation/versions'

### DIFF
--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -382,6 +382,15 @@ class Installation(pydantic.BaseModel):
 
 
 # ----------------------------------------------------------------------------
+#   Python software manifest models
+# ----------------------------------------------------------------------------
+InstalledPackage = dict[str, str]
+
+
+InstalledPackages = dict[str, InstalledPackage]
+
+
+# ----------------------------------------------------------------------------
 #   MCP auth-related models
 # ----------------------------------------------------------------------------
 class MCPToken(pydantic.BaseModel):

--- a/src/soliplex/tui/main.py
+++ b/src/soliplex/tui/main.py
@@ -1016,9 +1016,30 @@ class RoomConfigsView(t_screen.Screen):
         yield t_widgets.Footer()
 
 
+class InstalledVersionsView(t_screen.Screen):
+    BINDINGS = [
+        t_binding.Binding("escape", "app.pop_screen", "Exit"),
+    ]
+
+    def __init__(self, installed_versions, *args, **kw):
+        self._installed_versions = installed_versions
+
+        super().__init__(*args, **kw)
+
+    def compose(self) -> t_app.ComposeResult:
+        yield t_widgets.Header()
+        yield t_widgets.Label("Installed Versions")
+        tree = t_widgets.Tree(label="Root")
+        tree.add_json(self._installed_versions)
+        tree.root.expand()
+        yield tree
+        yield t_widgets.Footer()
+
+
 class InstallationConfigView(t_screen.Screen):
     BINDINGS = [
         t_binding.Binding("ctrl+r", "room_configs", "Rooms"),
+        t_binding.Binding("ctrl+v", "installed_versions", "Versions"),
         t_binding.Binding("escape", "app.pop_screen", "Exit"),
     ]
 
@@ -1042,6 +1063,13 @@ class InstallationConfigView(t_screen.Screen):
 
         rc_view = RoomConfigsView(room_configs)
         await self.app.push_screen_wait(rc_view)
+
+    @textual.work
+    async def action_installed_versions(self) -> None:
+        installed_versions = self.app.rest_api.get_installed_versions()
+
+        iv_view = InstalledVersionsView(installed_versions)
+        await self.app.push_screen_wait(iv_view)
 
 
 class SoliplexTUI(t_app.App):

--- a/src/soliplex/tui/rest_api.py
+++ b/src/soliplex/tui/rest_api.py
@@ -62,6 +62,15 @@ class TUI_REST_API:
 
         return response.json()
 
+    def get_installed_versions(self):
+        response = requests.get(
+            f"{self.api_v1_base}/installation/versions",
+            headers=self.api_v1_headers,
+        )
+        response.raise_for_status()
+
+        return response.json()
+
     def room_agui_base(self, room_id: str) -> str:
         return f"{self.api_v1_base}/rooms/{room_id}/agui"
 

--- a/src/soliplex/views/installation.py
+++ b/src/soliplex/views/installation.py
@@ -1,3 +1,7 @@
+import json
+import subprocess
+import traceback
+
 import fastapi
 from fastapi import security
 
@@ -21,3 +25,34 @@ async def get_installation(
     """Return the installation's top-level configuration"""
     authn.authenticate(the_installation, token)
     return models.Installation.from_config(the_installation._config)
+
+
+@util.logfire_span("GET /v1/installation/versions")
+@router.get("/v1/installation/versions")
+async def get_installation_versions(
+    request: fastapi.Request,
+    the_installation: installation.Installation = depend_the_installation,
+    token: security.HTTPAuthorizationCredentials = authn.oauth2_predicate,
+) -> models.InstalledPackages:
+    """Return the installation's top-level configuration"""
+    authn.authenticate(the_installation, token)
+
+    try:
+        found = (
+            subprocess.check_output(
+                ["pip", "list", "--format", "json"],
+            )
+            .decode("utf-8")
+            .strip()
+        )
+    except Exception:
+        error = traceback.format_exc()
+        raise fastapi.HTTPException(
+            status_code=500,
+            detail=error,
+        ) from None
+
+    installed = json.loads(found)
+    packages = {package.pop("name"): package for package in installed}
+
+    return packages

--- a/tests/unit/views/test_installation_views.py
+++ b/tests/unit/views/test_installation_views.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import fastapi
@@ -28,4 +29,65 @@ async def test_get_installation(auth_fn, fc):
     assert found is fc.return_value
 
     fc.assert_called_once_with(i_config)
+    auth_fn.assert_called_once_with(the_installation, token)
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.views.installation.traceback")
+@mock.patch("soliplex.views.installation.subprocess")
+@mock.patch("soliplex.authn.authenticate")
+async def test_get_installation_versions_w_error(auth_fn, sp, tb):
+    sp.check_output.side_effect = ValueError("testing")
+
+    request = mock.create_autospec(fastapi.Request)
+    the_installation = object()
+    token = object()
+
+    def _check(exc):
+        return exc.status_code == 500
+
+    with pytest.raises(fastapi.HTTPException, check=_check) as exc:
+        await installation_views.get_installation_versions(
+            request,
+            the_installation=the_installation,
+            token=token,
+        )
+
+    assert exc.value.detail is tb.format_exc.return_value
+
+    tb.format_exc.assert_called_once_with()
+    auth_fn.assert_called_once_with(the_installation, token)
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.views.installation.subprocess")
+@mock.patch("soliplex.authn.authenticate")
+async def test_get_installation_versions_wo_error(auth_fn, sp):
+    pip_manifest = [
+        {"name": "one-package", "version": "0.1.2"},
+        {"name": "another-package", "version": "3.4.5", "extra": "blather"},
+    ]
+    expected = {
+        "one-package": {
+            "version": "0.1.2",
+        },
+        "another-package": {
+            "version": "3.4.5",
+            "extra": "blather",
+        },
+    }
+    sp.check_output.return_value = json.dumps(pip_manifest).encode("utf8")
+
+    request = mock.create_autospec(fastapi.Request)
+    the_installation = object()
+    token = object()
+
+    found = await installation_views.get_installation_versions(
+        request,
+        the_installation=the_installation,
+        token=token,
+    )
+
+    assert found == expected
+
     auth_fn.assert_called_once_with(the_installation, token)


### PR DESCRIPTION
Return mapping of installed Python package names to versions.

Add a view in the TUI to show the manifest.

Toward #452.