### PR TITLE
fix(ci): overhaul Slack notification workflows

### DIFF
--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -1,4 +1,4 @@
-name: Notify Slack on New issue
+name: Notify Slack on New Issue
 
 on:
   issues:
@@ -8,14 +8,25 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Send Slack notification when new issue is opened
+      - name: Send Slack notification
         env:
           SLACK_NOTIFY_URL: ${{ secrets.SLACK_NOTIFY_URL }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
-          curl -X POST \
-            --data-urlencode \
-            "payload={\"channel\": \"#soliplex\", \"username\": \"soliplex\", \"text\": \":bell: New issue by *${ISSUE_AUTHOR}*:\n*${ISSUE_TITLE}*\n${ISSUE_URL}\", \"icon_emoji\": \":ghost:\"}" \
+          if [ -z "$SLACK_NOTIFY_URL" ]; then
+            echo "::warning::SLACK_NOTIFY_URL secret not configured, skipping"
+            exit 0
+          fi
+
+          payload=$(jq -n \
+            --arg author "$ISSUE_AUTHOR" \
+            --arg title "$ISSUE_TITLE" \
+            --arg url "$ISSUE_URL" \
+            '{text: ":bell: New Issue by *\($author)*:\n*\($title)*\n\($url)"}')
+
+          curl --fail-with-body -X POST \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
             "$SLACK_NOTIFY_URL"

--- a/.github/workflows/pr-opened.yaml
+++ b/.github/workflows/pr-opened.yaml
@@ -8,14 +8,25 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Send Slack notification when new PR is opened
+      - name: Send Slack notification
         env:
           SLACK_NOTIFY_URL: ${{ secrets.SLACK_NOTIFY_URL }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          curl -X POST \
-            --data-urlencode \
-            "payload={\"channel\": \"#soliplex\", \"username\": \"soliplex\", \"text\": \":bell: New Pull Request by *${PR_AUTHOR}*:\n*${PR_TITLE}*\n${PR_URL}\", \"icon_emoji\": \":ghost:\"}" \
+          if [ -z "$SLACK_NOTIFY_URL" ]; then
+            echo "::warning::SLACK_NOTIFY_URL secret not configured, skipping"
+            exit 0
+          fi
+
+          payload=$(jq -n \
+            --arg author "$PR_AUTHOR" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            '{text: ":bell: New Pull Request by *\($author)*:\n*\($title)*\n\($url)"}')
+
+          curl --fail-with-body -X POST \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
             "$SLACK_NOTIFY_URL"


### PR DESCRIPTION
## Summary
- Fix CI failures caused by Slack notification workflows
- Exit code 3 was occurring due to missing/malformed webhook URL

## Changes

**Both `pr-opened.yaml` and `issue-opened.yaml`:**

| Before | After |
|--------|-------|
| No validation, fails with exit 3 if secret missing | Graceful skip with warning |
| `--data-urlencode` with inline JSON | `jq` for proper JSON escaping |
| No error reporting from curl | `--fail-with-body` for HTTP error visibility |
| Legacy webhook format (channel/username/icon) | Modern format (just text payload) |

## Test plan
- [x] Workflow syntax valid
- [ ] Test with actual Slack webhook after merge