### PR TITLE
refactor: decompose '.main.create_app'

### DIFF
--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import contextlib
 import functools
 import os
 import pathlib
 import sys
+import typing
 
 import fastapi
 import logfire
@@ -25,8 +28,11 @@ from soliplex.views import rooms as rooms_views
 
 def curry_lifespan(
     installation_path: pathlib.Path = None,
-    no_auth_mode: bool = False,
+    no_auth_mode: bool | None = None,
 ):
+    if no_auth_mode is None:
+        no_auth_mode = os.environ.get("SOLIPLEX_NO_AUTH_MODE") == "Y"
+
     if installation_path is None:
         installation_path = os.environ.get("SOLIPLEX_INSTALLATION_PATH")
 
@@ -42,17 +48,14 @@ def curry_lifespan(
     )
 
 
-def create_app(
-    installation_path: pathlib.Path = None,
-    no_auth_mode: bool = None,
-):  # pragma: NO COVER
-    if no_auth_mode is None:
-        no_auth_mode = os.environ.get("SOLIPLEX_NO_AUTH_MODE") == "Y"
-
-    curried_lifespan = curry_lifespan(installation_path, no_auth_mode)
+def app_with_lifespan(curried_lifespan: typing.Callable) -> fastapi.FastAPI:
     acm_lifespan = contextlib.asynccontextmanager(curried_lifespan)
     app = fastapi.FastAPI(lifespan=acm_lifespan)
 
+    return app
+
+
+def app_with_cors(app: fastapi.FastAPI) -> fastapi.FastAPI:
     origins = ["*"]
     app.add_middleware(
         fastapi_mw_cors.CORSMiddleware,
@@ -61,21 +64,39 @@ def create_app(
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    return app
 
+
+def app_with_session(app: fastapi.FastAPI) -> fastapi.FastAPI:
     app.add_middleware(
         starlette_mw_sessions.SessionMiddleware,
         # Deliberately not an envvar
         secret_key=authn._get_session_secret_key(),
     )
+    return app
 
-    current_git_hash = util.get_git_hash_for_file(__file__)
 
-    @app.middleware("http")
-    async def add_custom_header(request: fastapi.Request, call_next):
-        response: fastapi.Response = await call_next(request)
-        response.headers["X-Git-Hash"] = current_git_hash
-        return response
+current_git_hash = None
 
+
+async def add_custom_header(request: fastapi.Request, call_next):
+    global current_git_hash
+
+    if current_git_hash is None:
+        current_git_hash = util.get_git_hash_for_file(__file__)
+
+    response: fastapi.Response = await call_next(request)
+    response.headers["X-Git-Hash"] = current_git_hash
+    return response
+
+
+def app_with_git_hash(app: fastapi.FastAPI) -> fastapi.FastAPI:
+    app.middleware("http")(add_custom_header)
+
+    return app
+
+
+def app_with_soliplex_routers(app: fastapi.FastAPI) -> fastapi.FastAPI:
     app.include_router(agui_views.router, prefix="/api")
     app.include_router(authn_views.router, prefix="/api")
     app.include_router(authz_views.router, prefix="/api")
@@ -85,12 +106,45 @@ def create_app(
     app.include_router(rooms_views.router, prefix="/api")
     app.include_router(views.router, prefix="/api")
 
-    # pragma: NO COVER
+    return app
+
+
+def app_with_logfire_config(app: fastapi.FastAPI) -> fastapi.FastAPI:
     # 'if-token-present' means nothing will be sent (and the example will work)
     # if you don't have logfire configured
     logfire.configure(send_to_logfire="if-token-present")
     logfire.instrument_pydantic_ai()
     logfire.instrument_fastapi(app, capture_headers=True)
+
+    return app
+
+
+def create_app(
+    installation_path: pathlib.Path = None,
+    no_auth_mode: bool = None,
+    curry_lifespan=curry_lifespan,
+    app_with_lifespan=app_with_lifespan,
+    app_with_cors=app_with_cors,
+    app_with_session=app_with_session,
+    app_with_git_hash=app_with_git_hash,
+    app_with_soliplex_routers=app_with_soliplex_routers,
+    app_with_logfire_config=app_with_logfire_config,
+):  # pragma: NO COVER
+    """Construct the Soliplex FastAPI application
+
+    Callers may override any of the component functions in this module
+    via parameters.
+    """
+    curried_lifespan = curry_lifespan(
+        installation_path=installation_path,
+        no_auth_mode=no_auth_mode,
+    )
+    app = app_with_lifespan(curried_lifespan)
+    app = app_with_cors(app)
+    app = app_with_session(app)
+    app = app_with_git_hash(app)
+    app = app_with_soliplex_routers(app)
+    app = app_with_logfire_config(app)
 
     return app
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -3,8 +3,17 @@ import pathlib
 from unittest import mock
 
 import pytest
+from fastapi.middleware import cors as fastapi_mw_cors
+from starlette.middleware import sessions as starlette_mw_sessions
 
 from soliplex import main
+from soliplex.views import agui as agui_views
+from soliplex.views import authn as authn_views
+from soliplex.views import authz as authz_views
+from soliplex.views import completions as completions_views
+from soliplex.views import installation as installation_views
+from soliplex.views import quizzes as quizzes_views
+from soliplex.views import rooms as rooms_views
 
 EXPLICIT_INST_PATH = "/explicit"
 ENVIRON_INST_PATH = "/environ"
@@ -27,13 +36,35 @@ def no_auth_mode_kwargs(request):
 
 
 @pytest.mark.parametrize(
-    "env_patch",
+    "env_patch, path_from_env, no_auth_from_env",
     [
-        {},
-        {"SOLIPLEX_INSTALLATION_PATH": ENVIRON_INST_PATH},
+        ({}, "./example", False),
+        (
+            {"SOLIPLEX_INSTALLATION_PATH": ENVIRON_INST_PATH},
+            ENVIRON_INST_PATH,
+            False,
+        ),
+        ({"SOLIPLEX_NO_AUTH_MODE": "Y"}, "./example", True),
+        ({"SOLIPLEX_NO_AUTH_MODE": "N"}, "./example", False),
     ],
 )
-def test_curry_lifespan(inst_path_kwargs, no_auth_mode_kwargs, env_patch):
+def test_curry_lifespan(
+    inst_path_kwargs,
+    no_auth_mode_kwargs,
+    env_patch,
+    path_from_env,
+    no_auth_from_env,
+):
+    if inst_path_kwargs:
+        exp_path = EXPLICIT_INST_PATH
+    else:
+        exp_path = path_from_env
+
+    if no_auth_mode_kwargs:
+        exp_no_auth_mode = no_auth_mode_kwargs["no_auth_mode"]
+    else:
+        exp_no_auth_mode = no_auth_from_env
+
     with mock.patch.dict("os.environ", clear=True, **env_patch):
         found = main.curry_lifespan(
             **inst_path_kwargs,
@@ -42,16 +73,125 @@ def test_curry_lifespan(inst_path_kwargs, no_auth_mode_kwargs, env_patch):
 
     assert isinstance(found, functools.partial)
 
-    if inst_path_kwargs:
-        expected_path = EXPLICIT_INST_PATH
-
-    elif env_patch:
-        expected_path = ENVIRON_INST_PATH
-
-    else:
-        expected_path = "./example"
-
     assert found.keywords == {
-        "installation_path": pathlib.Path(expected_path),
-        "no_auth_mode": no_auth_mode_kwargs.get("no_auth_mode", False),
+        "installation_path": pathlib.Path(exp_path),
+        "no_auth_mode": exp_no_auth_mode,
     }
+
+
+@mock.patch("fastapi.FastAPI")
+@mock.patch("contextlib.asynccontextmanager")
+def test_app_with_lifespan(acm, fapi):
+    lifespan = mock.Mock(spec_set=())
+
+    found = main.app_with_lifespan(lifespan)
+
+    assert found is fapi.return_value
+
+    fapi.assert_called_once_with(lifespan=acm.return_value)
+    acm.assert_called_once_with(lifespan)
+
+
+def test_app_with_cors():
+    app = mock.Mock(spec_set=["add_middleware"])
+
+    found = main.app_with_cors(app)
+
+    assert found is app
+
+    app.add_middleware.assert_called_once_with(
+        fastapi_mw_cors.CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+
+@mock.patch("soliplex.main.authn")
+def test_app_with_session(authn):
+    app = mock.Mock(spec_set=["add_middleware"])
+
+    found = main.app_with_session(app)
+
+    assert found is app
+
+    app.add_middleware.assert_called_once_with(
+        starlette_mw_sessions.SessionMiddleware,
+        secret_key=authn._get_session_secret_key.return_value,
+    )
+
+    authn._get_session_secret_key.assert_called_once_with()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("hash_patch", [{}, {"current_git_hash": "DEADBEEF"}])
+@mock.patch("soliplex.main.util")
+async def test_add_custom_header(util, hash_patch):
+    if hash_patch:
+        exp_hash = "DEADBEEF"
+    else:
+        exp_hash = util.get_git_hash_for_file.return_value
+
+    request = object()
+    call_next = mock.AsyncMock(spec_set=())
+    exp_response = call_next.return_value = mock.Mock(
+        spec_set=["headers"],
+        headers={},
+    )
+
+    with mock.patch.dict("soliplex.main.__dict__", **hash_patch):
+        response = await main.add_custom_header(request, call_next)
+
+    assert response is exp_response
+    assert response.headers["X-Git-Hash"] == exp_hash
+    call_next.assert_awaited_once_with(request)
+
+    if hash_patch:
+        util.get_git_hash_for_file.assert_not_called()
+    else:
+        util.get_git_hash_for_file.assert_called_once_with(main.__file__)
+
+
+def test_app_with_git_hash():
+    app = mock.Mock(spec_set=["middleware"])
+
+    found = main.app_with_git_hash(app)
+
+    assert found is app
+
+    app.middleware.assert_called_once_with("http")
+    (called,) = app.middleware.return_value.call_args_list
+    assert called.kwargs == {}
+    (mw_func,) = called.args
+    assert mw_func is main.add_custom_header
+
+
+def test_app_with_soliplex_routers():
+    app = mock.Mock(spec_set=["include_router"])
+
+    found = main.app_with_soliplex_routers(app)
+
+    assert found is app
+
+    air_calls = app.include_router.mock_calls
+    assert mock.call(agui_views.router, prefix="/api") in air_calls
+    assert mock.call(authn_views.router, prefix="/api") in air_calls
+    assert mock.call(authz_views.router, prefix="/api") in air_calls
+    assert mock.call(completions_views.router, prefix="/api") in air_calls
+    assert mock.call(installation_views.router, prefix="/api") in air_calls
+    assert mock.call(quizzes_views.router, prefix="/api") in air_calls
+    assert mock.call(rooms_views.router, prefix="/api") in air_calls
+
+
+@mock.patch("soliplex.main.logfire")
+def test_app_with_logfire_config(logfire):
+    app = mock.Mock(spec_set=())
+
+    found = main.app_with_logfire_config(app)
+
+    assert found is app
+
+    logfire.configure.assert_called_with(send_to_logfire="if-token-present")
+    logfire.instrument_pydantic_ai.assert_called_with()
+    logfire.instrument_fastapi.assert_called_with(app, capture_headers=True)


### PR DESCRIPTION
Allow callers to substitute implementations of component functions to extend / modify startup policy.