### PR TITLE
fix: missing room authz endpoints

### DIFF
--- a/src/soliplex/views/authz.py
+++ b/src/soliplex/views/authz.py
@@ -41,3 +41,49 @@ async def get_room_authz(
         ) from None
 
     return room_policy
+
+
+@util.logfire_span("POST /v1/rooms/{room_id}/authz")
+@router.post(
+    "/v1/rooms/{room_id}/authz",
+    summary="Update authorization policy for a room",
+)
+async def post_room_authz(
+    request: fastapi.Request,
+    room_id: str,
+    room_policy: models.RoomPolicy,
+    the_installation: installation.Installation = depend_the_installation,
+    the_room_authz: authz_package.RoomAuthorization = depend_the_room_authz,
+    token: security.HTTPAuthorizationCredentials = authn.oauth2_predicate,
+) -> models.RoomPolicy | None:
+    user = authn.authenticate(the_installation, token)
+
+    await the_room_authz.update_room_policy(
+        room_id=room_id,
+        room_policy=room_policy,
+        user_token=user,
+    )
+
+    return fastapi.Response(status_code=204)
+
+
+@util.logfire_span("DELTE /v1/rooms/{room_id}/authz")
+@router.delete(
+    "/v1/rooms/{room_id}/authz",
+    summary="Delete authorization policy for a room",
+)
+async def delete_room_authz(
+    request: fastapi.Request,
+    room_id: str,
+    the_installation: installation.Installation = depend_the_installation,
+    the_room_authz: authz_package.RoomAuthorization = depend_the_room_authz,
+    token: security.HTTPAuthorizationCredentials = authn.oauth2_predicate,
+) -> models.RoomPolicy | None:
+    user = authn.authenticate(the_installation, token)
+
+    await the_room_authz.delete_room_policy(
+        room_id=room_id,
+        user_token=user,
+    )
+
+    return fastapi.Response(status_code=204)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -2,6 +2,9 @@ from unittest import mock  # s.b. only for the 'auth_module.authenticate' call
 
 import pytest
 
+USER_NAME = "Phreddy Phlyntstone"
+EMAIL = "phreddy@example.com"
+
 
 def test_health_check(client_no_llm):
     response = client_no_llm.get("/api/ok")
@@ -32,11 +35,62 @@ def test_rooms_endpoints(auth_fn, client_no_llm):
 
 
 @mock.patch("soliplex.authn.authenticate")
+def test_room_authz_endpoints(auth_fn, client_no_llm):
+    auth_fn.return_value = {
+        "name": USER_NAME,
+        "email": EMAIL,
+    }
+
+    get_authz_response = client_no_llm.get("/api/v1/rooms/functest/authz")
+    assert get_authz_response.status_code == 200
+    room_policy = get_authz_response.json()
+
+    assert room_policy is None
+
+    NEW_POLICY = {
+        "room_id": "functest",
+        "default_allow_deny": "deny",
+        "acl_entries": [
+            {
+                "allow_deny": "allow",
+                "everyone": False,
+                "authenticated": False,
+                "preferred_username": None,
+                "email": EMAIL,
+            },
+        ],
+    }
+
+    post_authz_response = client_no_llm.post(
+        "/api/v1/rooms/functest/authz",
+        json=NEW_POLICY,
+    )
+    assert post_authz_response.status_code == 204
+
+    after_post_response = client_no_llm.get("/api/v1/rooms/functest/authz")
+    assert after_post_response.status_code == 200
+    after_post_room_policy = after_post_response.json()
+
+    assert after_post_room_policy == NEW_POLICY
+
+    delete_authz_response = client_no_llm.delete(
+        "/api/v1/rooms/functest/authz",
+    )
+    assert delete_authz_response.status_code == 204
+
+    after_delete_response = client_no_llm.get("/api/v1/rooms/functest/authz")
+    assert after_delete_response.status_code == 200
+    after_delete_room_policy = after_delete_response.json()
+
+    assert after_delete_room_policy is None
+
+
+@mock.patch("soliplex.authn.authenticate")
 @pytest.mark.needs_llm
 def test_get_quiz_post_quiz_question(auth_fn, client):
     auth_fn.return_value = {
-        "name": "Phreddy Phlyntstone",
-        "email": "phreddy@example.com",
+        "name": USER_NAME,
+        "email": EMAIL,
     }
 
     get_room_response = client.get("/api/v1/rooms/quiztest")

--- a/tests/unit/views/test_authz_views.py
+++ b/tests/unit/views/test_authz_views.py
@@ -16,6 +16,17 @@ ROOM_POLICY = models.RoomPolicy(
     default_allow_deny=authz_package.AllowDeny.ALLOW,
 )
 
+NEW_ROOM_POLICY = models.RoomPolicy(
+    room_id=ROOM_ID,
+    default_allow_deny=authz_package.AllowDeny.DENY,
+    acl_entries=[
+        models.ACLEntry(
+            allow_deny=authz_package.AllowDeny.ALLOW,
+            email="phreddy@example.com",
+        ),
+    ],
+)
+
 
 def raises_httpexc(*, match, code) -> pytest.raises:
     def _check(exc):
@@ -39,7 +50,8 @@ def raises_httpexc(*, match, code) -> pytest.raises:
         ),
     ],
 )
-async def test_get_room_authz(w_policy, expectation):
+@mock.patch("soliplex.authn.authenticate")
+async def test_get_room_authz(auth_fn, w_policy, expectation):
     request = fastapi.Request(scope={"type": "http"})
     the_installation = mock.create_autospec(installation.Installation)
     the_room_authz = mock.create_autospec(authz_package.RoomAuthorization)
@@ -62,3 +74,74 @@ async def test_get_room_authz(w_policy, expectation):
 
     if not isinstance(expected, pytest.ExceptionInfo):
         assert found == expected
+
+        the_room_authz.get_room_policy.assert_awaited_once_with(
+            room_id=ROOM_ID,
+            user_token=auth_fn.return_value,
+        )
+
+    auth_fn.assert_called_once_with(the_installation, token)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("w_existing", [False, True])
+@mock.patch("soliplex.authn.authenticate")
+async def test_post_room_authz(auth_fn, w_existing):
+    request = fastapi.Request(scope={"type": "http"})
+    the_installation = mock.create_autospec(installation.Installation)
+    the_room_authz = mock.create_autospec(authz_package.RoomAuthorization)
+    token = object()
+
+    if w_existing:
+        the_room_authz.get_room_policy.return_value = ROOM_POLICY
+
+    found = await authz_views.post_room_authz(
+        request=request,
+        room_id=ROOM_ID,
+        room_policy=NEW_ROOM_POLICY,
+        the_installation=the_installation,
+        the_room_authz=the_room_authz,
+        token=token,
+    )
+
+    assert isinstance(found, fastapi.Response)
+    assert found.status_code == 204
+
+    the_room_authz.update_room_policy.assert_awaited_once_with(
+        room_id=ROOM_ID,
+        room_policy=NEW_ROOM_POLICY,
+        user_token=auth_fn.return_value,
+    )
+
+    auth_fn.assert_called_once_with(the_installation, token)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("w_existing", [False, True])
+@mock.patch("soliplex.authn.authenticate")
+async def test_delete_room_authz(auth_fn, w_existing):
+    request = fastapi.Request(scope={"type": "http"})
+    the_installation = mock.create_autospec(installation.Installation)
+    the_room_authz = mock.create_autospec(authz_package.RoomAuthorization)
+    token = object()
+
+    if w_existing:
+        the_room_authz.get_room_policy.return_value = ROOM_POLICY
+
+    found = await authz_views.delete_room_authz(
+        request=request,
+        room_id=ROOM_ID,
+        the_installation=the_installation,
+        the_room_authz=the_room_authz,
+        token=token,
+    )
+
+    assert isinstance(found, fastapi.Response)
+    assert found.status_code == 204
+
+    the_room_authz.delete_room_policy.assert_awaited_once_with(
+        room_id=ROOM_ID,
+        user_token=auth_fn.return_value,
+    )
+
+    auth_fn.assert_called_once_with(the_installation, token)


### PR DESCRIPTION
- 'POST /api/vi/rooms/{room_id}/authz'
- 'DELETE /api/vi/rooms/{room_id}/authz'

tests: functest for room authz endpoints

Closes #476.