### PR TITLE
feat: extract binary attachments from 'agui_core.RunAgentInput'

### DIFF
--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -32,6 +32,9 @@ class AgentDependencies:
     user: models.UserProfile = None  # TBD make required
     tool_configs: ToolConfigMap = None
     state: agui.AGUI_State = dataclasses.field(default_factory=dict)
+    binary_attachments: agui.AGUI_BinaryAttachments = dataclasses.field(
+        default_factory=list
+    )
 
 
 SoliplexAgent = ai_agent.AbstractAgent[AgentDependencies, typing.Any]

--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -12,12 +12,27 @@ from sqlalchemy.ext import asyncio as sqla_asyncio
 AGUI_Events = list[agui_core.Event]
 AGUI_EventStream = collections.abc.AsyncIterator[agui_core.Event]
 AGUI_State = dict[str, typing.Any]
+AGUI_BinaryAttachments = list[agui_core.BinaryInputContent]
 
 
 _COMPACTIBLE_TYPES = {
     agui_core.EventType.TEXT_MESSAGE_CONTENT,
     agui_core.EventType.THINKING_TEXT_MESSAGE_CONTENT,
 }
+
+
+def extract_binary_attachments(
+    run_input: agui_core.RunAgentInput,
+) -> AGUI_BinaryAttachments:
+    """Return binary attachments in a given run's user messages"""
+    result = []
+    for message in run_input.messages:
+        if message.role == "user":
+            if isinstance(message.content, list):
+                for input_content in message.content:
+                    if input_content.type == "binary":
+                        result.append(input_content)
+    return result
 
 
 async def compact_event_stream(stream: AGUI_EventStream):

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -11,6 +11,7 @@ from sqlalchemy import sql as sqla_sql
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agents
+from soliplex import agui
 from soliplex import authz as authz_package
 from soliplex import config
 from soliplex import mcp_server
@@ -265,6 +266,11 @@ class Installation:
         )
 
         kwargs = {}
+
+        if room_config.enable_attachments and run_agent_input is not None:
+            kwargs["binary_attachments"] = agui.extract_binary_attachments(
+                run_input=run_agent_input,
+            )
 
         return agents.AgentDependencies(
             the_installation=self,

--- a/tests/unit/agui/test_agui_package.py
+++ b/tests/unit/agui/test_agui_package.py
@@ -6,8 +6,44 @@ from ag_ui import core as agui_core
 
 from soliplex import agui as agui_package
 
+TEST_THREAD_ID = "thread-123"
+TEST_RUN_ID = "run-345"
+
+MESSAGE_ID_0 = "message-id-0"
 MESSAGE_ID_1 = "message-id-1"
 MESSAGE_ID_2 = "message-id-2"
+MESSAGE_ID_3 = "message-id-3"
+MESSAGE_ID_4 = "message-id-4"
+
+SYSTEM_MESSAGE_W_STR_CONTENT = agui_core.SystemMessage(
+    id=MESSAGE_ID_0,
+    content="system content",
+)
+TEXT_CONTENT_1 = agui_core.TextInputContent(text="string content")
+BINARY_CONTENT_1 = agui_core.BinaryInputContent(
+    mime_type="application/binary",
+    data="DEADBEEF",
+)
+BINARY_CONTENT_2 = agui_core.BinaryInputContent(
+    mime_type="application/binary",
+    data="FACEDACE",
+)
+USER_MESSAGE_W_STR_CONTENT = agui_core.UserMessage(
+    id=MESSAGE_ID_1,
+    content="string content",
+)
+USER_MESSAGE_W_TEXT_CONTENT = agui_core.UserMessage(
+    id=MESSAGE_ID_2,
+    content=[TEXT_CONTENT_1],
+)
+USER_MESSAGE_W_BINARY_CONTENT = agui_core.UserMessage(
+    id=MESSAGE_ID_3,
+    content=[BINARY_CONTENT_1],
+)
+USER_MESSAGE_W_MIXED_CONTENT = agui_core.UserMessage(
+    id=MESSAGE_ID_4,
+    content=[TEXT_CONTENT_1, BINARY_CONTENT_2],
+)
 
 TEXT_START_1 = agui_core.TextMessageStartEvent(message_id=MESSAGE_ID_1)
 TEXT_CONTENT_1_A = agui_core.TextMessageContentEvent(
@@ -57,6 +93,51 @@ TEXT_CONTENT_2_D = agui_core.TextMessageContentEvent(
 )
 
 OTHER = agui_core.RawEvent(event=None, source="test-raw")
+
+
+@pytest.fixture
+def run_input():
+    return agui_core.RunAgentInput(
+        thread_id=TEST_THREAD_ID,
+        run_id=TEST_RUN_ID,
+        state={},
+        messages=[],
+        tools=[],
+        context=[],
+        forwarded_props=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "messages, expected",
+    [
+        ([], []),
+        ([SYSTEM_MESSAGE_W_STR_CONTENT], []),
+        ([USER_MESSAGE_W_STR_CONTENT], []),
+        ([USER_MESSAGE_W_TEXT_CONTENT], []),
+        ([USER_MESSAGE_W_BINARY_CONTENT], [BINARY_CONTENT_1]),
+        ([USER_MESSAGE_W_MIXED_CONTENT], [BINARY_CONTENT_2]),
+        (
+            [
+                USER_MESSAGE_W_STR_CONTENT,
+                USER_MESSAGE_W_TEXT_CONTENT,
+                USER_MESSAGE_W_BINARY_CONTENT,
+                USER_MESSAGE_W_MIXED_CONTENT,
+                SYSTEM_MESSAGE_W_STR_CONTENT,
+            ],
+            [
+                BINARY_CONTENT_1,
+                BINARY_CONTENT_2,
+            ],
+        ),
+    ],
+)
+def test_extract_binary_attachments(run_input, messages, expected):
+    run_input.messages.extend(messages)
+
+    found = agui_package.extract_binary_attachments(run_input)
+
+    assert found == expected
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -838,21 +838,33 @@ async def test_installation_get_agent_for_completion(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("w_enable_attachments", [False, True])
 @pytest.mark.parametrize("w_run_agent_input", [False, True])
 @pytest.mark.parametrize(
     "w_room_id, raises", [("room_id", False), ("nonesuch", True)]
 )
+@mock.patch("soliplex.agui.extract_binary_attachments")
 async def test_installation_get_agent_deps_for_room(
+    eba,
     test_user,
     authz_kwargs,
     w_room_id,
     raises,
     w_run_agent_input,
+    w_enable_attachments,
 ):
     tc_config = mock.create_autospec(config.ToolConfig)
     sdtc_config = mock.create_autospec(config.SearchDocumentsToolConfig)
 
-    r_config = mock.create_autospec(config.RoomConfig)
+    if w_enable_attachments and w_run_agent_input:
+        exp_binary_attachments = eba.return_value
+    else:
+        exp_binary_attachments = []
+
+    r_config = mock.create_autospec(
+        config.RoomConfig,
+        enable_attachments=w_enable_attachments,
+    )
     t_configs = r_config.tool_configs = {
         "test_tool": tc_config,
         "test_sdtc": sdtc_config,
@@ -903,6 +915,8 @@ async def test_installation_get_agent_deps_for_room(
             assert found.the_installation is the_installation
             assert found.user == test_user
             assert found.tool_configs == t_configs
+
+            assert found.binary_attachments == exp_binary_attachments
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Expose them via 'agents.AgentDependencies.binary_attachments'.

Toward #517.