### PR TITLE
feat: 'GET /api/v1/installation/git_metadata' endpoint

### DIFF
--- a/src/soliplex/cli.py
+++ b/src/soliplex/cli.py
@@ -3,7 +3,7 @@ import json
 import os
 import pathlib
 import typing
-from importlib.metadata import version
+from importlib import metadata as importlib_metadata
 
 import requests
 import typer
@@ -20,6 +20,7 @@ from soliplex import main
 from soliplex import models
 from soliplex import ollama
 from soliplex import secrets
+from soliplex import util
 from soliplex.authz import schema as authz_schema
 
 
@@ -51,8 +52,12 @@ the_console = console.Console()
 
 def version_callback(value: bool):
     if value:
-        v = version("soliplex")
-        the_console.print(f"soliplex version {v}")
+        gitmeta = util.GitMetadata(pathlib.Path.cwd())
+        v = importlib_metadata.version("soliplex")
+        the_console.print(f"Installed soliplex version: {v}")
+        the_console.print(f"Soliplex git tag          : {gitmeta.git_tag}")
+        the_console.print(f"Soliplex git branch       : {gitmeta.git_branch}")
+        the_console.print(f"Soliplex git hash         : {gitmeta.git_hash}")
         raise typer.Exit()
 
 

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -397,6 +397,15 @@ InstalledPackages = dict[str, InstalledPackage]
 
 
 # ----------------------------------------------------------------------------
+#   Git metadata
+# ----------------------------------------------------------------------------
+class GitMetadata(pydantic.BaseModel):
+    git_hash: str | None
+    git_branch: str | None
+    git_tag: str | None
+
+
+# ----------------------------------------------------------------------------
 #   MCP auth-related models
 # ----------------------------------------------------------------------------
 class MCPToken(pydantic.BaseModel):

--- a/src/soliplex/util.py
+++ b/src/soliplex/util.py
@@ -40,6 +40,111 @@ def scrub_private_keys(
     return scrubbed
 
 
+class GitMetadata:
+    """Capture Git hash / branch / tag information for the repo
+
+
+    To override these values (e.g., when running in a container without
+    a git clone), put the relevant values in these files inside the directory
+    referenced by 'file_path':
+
+    - 'git-hash.txt'
+    - 'git-branch.txt'
+    - 'git-tag.txt'
+    """
+
+    _git_hash = None
+    _git_branch = None
+    _git_tag = None
+
+    def __init__(self, file_path: str | pathlib.Path):
+        self.file_path = pathlib.Path(file_path)
+        self.repo_dir = (
+            self.file_path.parent
+            if self.file_path.is_file()
+            else self.file_path
+        )
+
+        hash_path = self.repo_dir / "git-hash.txt"
+
+        if hash_path.is_file():
+            self._git_hash = hash_path.read_text().strip()
+
+        branch_path = self.repo_dir / "git-branch.txt"
+
+        if branch_path.is_file():
+            self._git_branch = branch_path.read_text().strip()
+
+        tag_path = self.repo_dir / "git-tag.txt"
+
+        if tag_path.is_file():
+            self._git_tag = tag_path.read_text().strip()
+
+    @property
+    def git_hash(self) -> str:
+        if self._git_hash is None:
+            repo_dir = str(self.repo_dir)
+            self._git_hash = (
+                subprocess.check_output(
+                    ["git", "-C", repo_dir, "rev-parse", "HEAD"]
+                )
+                .decode("utf-8")
+                .strip()
+            )
+
+        return self._git_hash
+
+    @property
+    def git_branch(self) -> str:
+        if self._git_branch is None:
+            repo_dir = str(self.repo_dir)
+            branches_lines = subprocess.check_output(
+                [
+                    "git",
+                    "-C",
+                    repo_dir,
+                    "branch",
+                    "--list",
+                ]
+            ).decode("ascii")
+
+            for branch_line in branches_lines.splitlines():
+                flag = branch_line[0]
+                branch_name = branch_line[2:]
+
+                if flag == "*":
+                    self._git_branch = branch_name
+                    break
+
+        return self._git_branch
+
+    @property
+    def git_tag(self) -> str:
+        if self._git_tag is None:
+            repo_dir = str(self.repo_dir)
+            tags_lines = subprocess.check_output(
+                [
+                    "git",
+                    "-C",
+                    repo_dir,
+                    "tag",
+                    "--list",
+                    "--sort=creatordate",
+                    "--format=%(objectname) %(refname:strip=2)",
+                ]
+            ).decode("ascii")
+
+            for tag_line in tags_lines.splitlines():
+                tag_line = tag_line.strip()
+                if tag_line:
+                    long_hash, tag_name = tag_line.split(" ", 1)
+                    if long_hash == self.git_hash:
+                        self._git_tag = tag_name
+                        break
+
+        return self._git_tag
+
+
 def get_git_hash_for_file(file_path: str):
     file_path = pathlib.Path(file_path)
     repo_dir = file_path.parent

--- a/src/soliplex/views/installation.py
+++ b/src/soliplex/views/installation.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 import subprocess
 import traceback
 
@@ -93,3 +94,22 @@ async def get_installation_providers(
         ) from None
 
     return the_installation.all_provider_info
+
+
+@util.logfire_span("GET /v1/installation/git_metadata")
+@router.get("/v1/installation/git_metadata")
+async def get_installation_git_metadata(
+    request: fastapi.Request,
+    the_installation: installation.Installation = depend_the_installation,
+    token: security.HTTPAuthorizationCredentials = authn.oauth2_predicate,
+) -> models.GitMetadata:
+    """Return the installation's top-level configuration"""
+    _user_token = authn.authenticate(the_installation, token)
+
+    git_metadata = util.GitMetadata(pathlib.Path.cwd())
+
+    return models.GitMetadata(
+        git_hash=git_metadata.git_hash,
+        git_branch=git_metadata.git_branch,
+        git_tag=git_metadata.git_tag,
+    )

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -8,6 +8,10 @@ from starlette import datastructures
 
 from soliplex import util
 
+GIT_HASH = "test-git-hash"
+GIT_BRANCH = "test-git-branch"
+GIT_TAG = "test-git-tag"
+
 
 @pytest.mark.parametrize(
     "to_scrub, expected",
@@ -38,6 +42,174 @@ def test_scrub_private_keys(to_scrub, expected):
     found = util.scrub_private_keys(to_scrub)
 
     assert found == expected
+
+
+@pytest.mark.parametrize("w_override_files", [False, True])
+@pytest.mark.parametrize("w_file_path_file", [False, True])
+def test_gitmetadata_ctor(temp_dir, w_file_path_file, w_override_files):
+    if w_file_path_file:
+        file_path = temp_dir / "filename.txt"
+        file_path.touch()
+    else:
+        file_path = temp_dir
+
+    if w_override_files:
+        hash_file = temp_dir / "git-hash.txt"
+        hash_file.write_text(GIT_HASH)
+        branch_file = temp_dir / "git-branch.txt"
+        branch_file.write_text(GIT_BRANCH)
+        tag_file = temp_dir / "git-tag.txt"
+        tag_file.write_text(GIT_TAG)
+
+    found = util.GitMetadata(file_path)
+
+    if w_override_files:
+        assert found._git_hash == GIT_HASH
+        assert found._git_branch == GIT_BRANCH
+        assert found._git_tag == GIT_TAG
+    else:
+        assert found._git_hash is None
+        assert found._git_branch is None
+        assert found._git_tag is None
+
+
+@pytest.mark.parametrize("w_already", [None, "already"])
+@mock.patch("soliplex.util.subprocess")
+def test_gitmetadata_git_hash(subp, temp_dir, w_already):
+    gitmeta = util.GitMetadata(temp_dir)
+
+    if w_already:
+        expected = gitmeta._git_hash = "already"
+    else:
+        subp.check_output.return_value = f"{GIT_HASH}\n".encode("ascii")
+        expected = GIT_HASH
+
+    found = gitmeta.git_hash
+
+    assert found == expected
+
+    if w_already:
+        subp.check_output.assert_not_called()
+    else:
+        subp.check_output.assert_called_once_with(
+            ["git", "-C", str(temp_dir), "rev-parse", "HEAD"],
+        )
+
+
+@pytest.mark.parametrize(
+    "w_lines, expected",
+    [
+        ([], None),
+        (
+            ["  other-branch"],
+            None,
+        ),
+        (
+            [
+                f"* {GIT_BRANCH}",
+            ],
+            GIT_BRANCH,
+        ),
+        (
+            [
+                "  other-branch",
+                f"* {GIT_BRANCH}",
+            ],
+            GIT_BRANCH,
+        ),
+        (
+            [
+                "  other-branch",
+                f"* {GIT_BRANCH}",
+                "  waaa-branch",
+            ],
+            GIT_BRANCH,
+        ),
+    ],
+)
+@pytest.mark.parametrize("w_already", [None, "already"])
+@mock.patch("soliplex.util.subprocess")
+def test_gitmetadata_git_branch(subp, temp_dir, w_already, w_lines, expected):
+    gitmeta = util.GitMetadata(temp_dir)
+
+    if w_already:
+        expected = gitmeta._git_branch = "already"
+    else:
+        subp.check_output.return_value = "\n".join(w_lines).encode("ascii")
+
+    found = gitmeta.git_branch
+
+    assert found == expected
+
+    if w_already:
+        subp.check_output.assert_not_called()
+    else:
+        subp.check_output.assert_called_once_with(
+            ["git", "-C", str(temp_dir), "branch", "--list"],
+        )
+
+
+@pytest.mark.parametrize(
+    "w_lines, expected",
+    [
+        ([], None),
+        (
+            ["DEADBEEF other-tag"],
+            None,
+        ),
+        (
+            [
+                f"{GIT_HASH} {GIT_TAG}",
+            ],
+            GIT_TAG,
+        ),
+        (
+            [
+                "DEADBEEF other-tag",
+                f"{GIT_HASH} {GIT_TAG}",
+            ],
+            GIT_TAG,
+        ),
+        (
+            [
+                "DEADBEEF other-tag",
+                "",
+                f"{GIT_HASH} {GIT_TAG}",
+                "FACEDACE waaa-tag",
+            ],
+            GIT_TAG,
+        ),
+    ],
+)
+@pytest.mark.parametrize("w_already", [None, "already"])
+@mock.patch("soliplex.util.subprocess")
+def test_gitmetadata_git_tag(subp, temp_dir, w_already, w_lines, expected):
+    gitmeta = util.GitMetadata(temp_dir)
+    gitmeta._git_hash = GIT_HASH
+
+    if w_already:
+        expected = gitmeta._git_tag = "already"
+    else:
+        subp.check_output.return_value = "\n".join(w_lines).encode("ascii")
+
+    found = gitmeta.git_tag
+
+    assert found == expected
+
+    if w_already:
+        subp.check_output.assert_not_called()
+    else:
+        subp.check_output.assert_called_once_with(
+            [
+                "git",
+                "-C",
+                str(temp_dir),
+                "tag",
+                "--list",
+                "--sort=creatordate",
+                "--format=%(objectname) %(refname:strip=2)",
+            ],
+        )
 
 
 def test_get_git_hash_for_file_w_override_text_file(temp_dir):

--- a/tests/unit/views/test_installation_views.py
+++ b/tests/unit/views/test_installation_views.py
@@ -7,11 +7,16 @@ import pytest
 from soliplex import authz
 from soliplex import config
 from soliplex import installation
+from soliplex import models
 from soliplex.views import installation as installation_views
 
 OLLAMA_BASE_URL = "http://ollama.example.com:11434"
 TEST_MODEL_ONE = "test-model-one:1.2.3"
 TEST_MODEL_TWO = "test-model-two:4.5.6"
+
+GIT_HASH = "test-git-hash"
+GIT_BRANCH = "test-git-branch"
+GIT_TAG = "test-git-tag"
 
 
 @pytest.mark.anyio
@@ -189,4 +194,32 @@ async def test_get_installation_providers(auth_fn, w_admin_access):
     the_authz_policy.check_admin_access.assert_awaited_once_with(
         auth_fn.return_value,
     )
+    auth_fn.assert_called_once_with(the_installation, token)
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.util.GitMetadata")
+@mock.patch("soliplex.authn.authenticate")
+async def test_get_installation_git_metadata(auth_fn, gm_klass):
+    gm = gm_klass.return_value
+    gm.git_hash = GIT_HASH
+    gm.git_branch = GIT_BRANCH
+    gm.git_tag = GIT_TAG
+
+    request = mock.create_autospec(fastapi.Request)
+    the_installation = mock.create_autospec(installation.Installation)
+    token = object()
+
+    found = await installation_views.get_installation_git_metadata(
+        request,
+        the_installation=the_installation,
+        token=token,
+    )
+
+    assert found == models.GitMetadata(
+        git_hash=GIT_HASH,
+        git_branch=GIT_BRANCH,
+        git_tag=GIT_TAG,
+    )
+
     auth_fn.assert_called_once_with(the_installation, token)


### PR DESCRIPTION
  Returns a mapping showing git hash / branch / tag.

  Override files in the working directory of the process:

  - 'git-hash.txt'
  - 'git-branch.txt'
  - 'git-tag.txt'

feat: 'soliplex-cli --version' now shows the same info