### PR TITLE
refactor: use 'the_git_metadata' for header value

### DIFF
--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -69,17 +69,18 @@ def app_with_session(app: fastapi.FastAPI) -> fastapi.FastAPI:
     return app
 
 
-current_git_hash = None
+the_git_metadata = None
 
 
 async def add_custom_header(request: fastapi.Request, call_next):
-    global current_git_hash
+    global the_git_metadata
 
-    if current_git_hash is None:
-        current_git_hash = util.get_git_hash_for_file(__file__)
+    if the_git_metadata is None:
+        cwd = pathlib.Path.cwd()
+        the_git_metadata = util.GitMetadata(cwd)
 
     response: fastapi.Response = await call_next(request)
-    response.headers["X-Git-Hash"] = current_git_hash
+    response.headers["X-Git-Hash"] = the_git_metadata.git_hash
     return response
 
 

--- a/src/soliplex/util.py
+++ b/src/soliplex/util.py
@@ -7,7 +7,6 @@ import logging
 import pathlib
 import re
 import subprocess
-import traceback
 import typing
 
 import logfire
@@ -143,27 +142,6 @@ class GitMetadata:
                         break
 
         return self._git_tag
-
-
-def get_git_hash_for_file(file_path: str):
-    file_path = pathlib.Path(file_path)
-    repo_dir = file_path.parent
-    hash_path = repo_dir / "git-hash.txt"
-
-    if hash_path.is_file():
-        return hash_path.read_text().strip()
-
-    try:
-        return (
-            subprocess.check_output(
-                ["git", "-C", repo_dir, "rev-parse", "HEAD"]
-            )
-            .decode("utf-8")
-            .strip()
-        )
-    except Exception:
-        traceback.print_exc()
-        return "unknown"
 
 
 def strip_default_port(url: datastructures.URL) -> datastructures.URL:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -107,13 +107,17 @@ def test_app_with_session(authn):
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("hash_patch", [{}, {"current_git_hash": "DEADBEEF"}])
-@mock.patch("soliplex.main.util")
-async def test_add_custom_header(util, hash_patch):
-    if hash_patch:
-        exp_hash = "DEADBEEF"
+@pytest.mark.parametrize("w_already_tgm", [None, mock.Mock()])
+@mock.patch("soliplex.util.GitMetadata")
+@mock.patch("pathlib.Path.cwd")
+async def test_add_custom_header(pp_cwd, gm_klass, w_already_tgm):
+    main_patch = {}
+
+    if w_already_tgm is not None:
+        main_patch["the_git_metadata"] = w_already_tgm
+        exp_hash = w_already_tgm.git_hash
     else:
-        exp_hash = util.get_git_hash_for_file.return_value
+        exp_hash = gm_klass.return_value.git_hash
 
     request = object()
     call_next = mock.AsyncMock(spec_set=())
@@ -122,17 +126,17 @@ async def test_add_custom_header(util, hash_patch):
         headers={},
     )
 
-    with mock.patch.dict("soliplex.main.__dict__", **hash_patch):
+    with mock.patch.dict("soliplex.main.__dict__", **main_patch):
         response = await main.add_custom_header(request, call_next)
 
     assert response is exp_response
     assert response.headers["X-Git-Hash"] == exp_hash
     call_next.assert_awaited_once_with(request)
 
-    if hash_patch:
-        util.get_git_hash_for_file.assert_not_called()
+    if w_already_tgm:
+        gm_klass.assert_not_called()
     else:
-        util.get_git_hash_for_file.assert_called_once_with(main.__file__)
+        gm_klass.assert_called_once_with(pp_cwd.return_value)
 
 
 def test_app_with_git_hash():

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -212,43 +212,6 @@ def test_gitmetadata_git_tag(subp, temp_dir, w_already, w_lines, expected):
         )
 
 
-def test_get_git_hash_for_file_w_override_text_file(temp_dir):
-    HASH = "abc9876543210"
-
-    override_file = temp_dir / "git-hash.txt"
-    override_file.write_text(HASH)
-
-    fake_module = temp_dir / "module.py"
-
-    found = util.get_git_hash_for_file(str(fake_module))
-
-    assert found == HASH
-
-
-@mock.patch("soliplex.util.traceback")
-@mock.patch("soliplex.util.subprocess")
-def test_get_git_hash_for_file_w_subprocess_miss(sp, tb):
-    sp.check_output.side_effect = ValueError("testing")
-
-    found = util.get_git_hash_for_file(__file__)
-
-    assert found == "unknown"
-
-    tb.print_exc.assert_called_once_with()
-
-
-@mock.patch("soliplex.util.subprocess")
-def test_get_git_hash_for_file_w_subprocess_hit(sp):
-    HASH = "abc9876543210"
-    get_rev_parse_head_output = f"{HASH}\n".encode("ascii")
-
-    sp.check_output.side_effect = [get_rev_parse_head_output]
-
-    found = util.get_git_hash_for_file(__file__)
-
-    assert found == HASH
-
-
 @pytest.mark.parametrize(
     "start_url, expected",
     [


### PR DESCRIPTION
Follow-on to PR #527.