### PR TITLE
fix: emit AG-UI stream status using logfire

### DIFF
--- a/src/soliplex/examples.py
+++ b/src/soliplex/examples.py
@@ -197,7 +197,7 @@ class FauxAgent:
                 if isinstance(part, ai_messages.UserPromptPart)
             ]
             if ups:
-                up = ups[0]
+                up = ups[-1]
                 delta = f"\n\nHmm, you asked {up.content}"
                 think_part.content += delta
                 yield ai_messages.PartDeltaEvent(
@@ -206,6 +206,8 @@ class FauxAgent:
                         content_delta=delta,
                     ),
                 )
+                if up.content == "fail":
+                    raise ValueError("failing on request")  # noqa: TRY003
 
             await asyncio.sleep(random.uniform(0.5, 2.0))
 

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 
 import fastapi
+import logfire
 import pydantic_ai
 from ag_ui import core as agui_core
 from fastapi import responses
@@ -22,10 +23,6 @@ router = fastapi.APIRouter(tags=["rooms"])
 depend_the_installation = installation.depend_the_installation
 depend_the_threads = agui_package.depend_the_threads
 depend_the_authz = authz_package.depend_the_authz_policy
-
-
-def _debug_print(msg):  # pragma: NO COVER
-    print(msg)
 
 
 async def _check_user_in_room(
@@ -419,23 +416,40 @@ async def tee_events(
     run_id: str,
 ):
     event_list = []
+    error_message = None
+    status = None
 
-    async for event in event_stream:
-        event_list.append(event)
-        yield event
+    with logfire.span(
+        "AG-UI event stream: {thread_id}/{run_id}",
+        thread_id=thread_id,
+        run_id=run_id,
+    ):
+        async for event in event_stream:
+            event_list.append(event)
+            yield event
 
-    if event_list:
-        last = event_list[-1]
+        if event_list:
+            last = event_list[-1]
 
-        if last.type == agui_core.EventType.RUN_FINISHED:
-            _debug_print(f"Stream {thread_id}/{run_id}: FINISHED")
+            if last.type == agui_core.EventType.RUN_FINISHED:
+                status = "FINISHED"
 
-        if last.type == agui_core.EventType.RUN_ERROR:
-            _debug_print(f"Stream {thread_id}/{run_id}: ERROR")
-            _debug_print(f"  {last.message}")
+            elif last.type == agui_core.EventType.RUN_ERROR:
+                status = "ERROR"
+                error_message = last.message
 
-    else:
-        _debug_print(f"Stream {thread_id}/{run_id}: EMPTY")
+            else:
+                status = "UNKNOWN"
+        else:
+            status = "EMPTY"
+
+        if error_message:
+            logfire.error(
+                "Stream error: {error_message}",
+                error_message=error_message,
+            )
+        else:
+            logfire.info("Stream status: {status}", status=status)
 
     await on_done(events=event_list)
 

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -832,8 +832,8 @@ async def test_post_room_agui_thread_id_meta(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("w_event_count", [0, 1, 10])
 @pytest.mark.parametrize("w_finished_error", [None, "finished", "error"])
-@mock.patch("soliplex.views.agui._debug_print")
-async def test_tee_events(dprint, w_finished_error, w_event_count):
+@mock.patch("soliplex.views.agui.logfire")
+async def test_tee_events(logfire, w_finished_error, w_event_count):
     on_done = mock.AsyncMock(spec_set=())
 
     finished_event = agui_core.events.RunFinishedEvent(
@@ -864,20 +864,27 @@ async def test_tee_events(dprint, w_finished_error, w_event_count):
 
     on_done.assert_awaited_once_with(events=expected)
 
+    logfire.span.assert_called_once_with(
+        "AG-UI event stream: {thread_id}/{run_id}",
+        thread_id=TEST_THREAD_ID,
+        run_id=TEST_RUN_ID,
+    )
+
     if len(expected) == 0:
-        dprint.assert_called_once_with(
-            f"Stream {TEST_THREAD_ID}/{TEST_RUN_ID}: EMPTY"
+        logfire.info.assert_called_once_with(
+            "Stream status: {status}",
+            status="EMPTY",
         )
     elif w_finished_error == "finished":
-        dprint.assert_called_once_with(
-            f"Stream {TEST_THREAD_ID}/{TEST_RUN_ID}: FINISHED"
+        logfire.info.assert_called_once_with(
+            "Stream status: {status}",
+            status="FINISHED",
         )
     elif w_finished_error == "error":
-        stat_call, msg_call = dprint.call_args_list
-        assert stat_call == mock.call(
-            f"Stream {TEST_THREAD_ID}/{TEST_RUN_ID}: ERROR"
+        logfire.error.assert_called_once_with(
+            "Stream error: {error_message}",
+            error_message="test error",
         )
-        assert msg_call == mock.call("  test error")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Each stream gets its own span, with a summary message at the end.

Update the 'faux' agent to fail on request if the user message is 'fail' (to ease testing this change manually in the TUI).

Closes #545.