### PR TITLE
fix: 'soliplex-cli serve --reload'

### DIFF
--- a/src/soliplex/cli.py
+++ b/src/soliplex/cli.py
@@ -268,13 +268,24 @@ Incompatible with '--no-auth-mode'.
     reload_dirs = [str(rd) for rd in reload_dirs]
 
     if reload or workers:
-        os.environ["SOLIPLEX_INSTALLATION_PATH"] = str(installation_path)
+        # Work around uvicorn's aversion to passing arguments to the app
+        # factory.
+        #
+        # N.B.:  The environment variables set here are a private contract
+        #        between this command and the
+        #        'soliplex.main.create_app_from_environment'
+        #        function:  do not try setting them yourself, either
+        #        directly or via a '.env' file.
+        os.environ["_SOLIPLEX_INSTALLATION_PATH"] = str(installation_path)
 
         if no_auth_mode:
-            os.environ["SOLIPLEX_NO_AUTH_MODE"] = "Y"
+            os.environ["_SOLIPLEX_NO_AUTH_MODE"] = "Y"
+
+        if add_admin_user is not None:
+            os.environ["_SOLIPLEX_ADD_ADMIN_USER"] = add_admin_user
 
         if app_factory_name is None:
-            app_factory_name = "soliplex.main:create_app"
+            app_factory_name = "soliplex.main:create_app_from_environment"
 
         uvicorn.run(
             app_factory_name,

--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import os
 import pathlib
 import sys
 import typing
@@ -120,7 +121,7 @@ def create_app(
     app_with_session=app_with_session,
     app_with_git_hash=app_with_git_hash,
     app_with_soliplex_routers=app_with_soliplex_routers,
-):  # pragma: NO COVER
+):
     """Construct the Soliplex FastAPI application
 
     Callers may override any of the component functions in this module
@@ -140,6 +141,25 @@ def create_app(
     app = app_with_soliplex_routers(app)
 
     return app
+
+
+def create_app_from_environment():
+    """Work around uvicorn's aversion to passing arguments to the app factory
+
+    N.B.:  The environment variables set here are a private contract between
+           the 'soliplex-cli serve' command and this function:  do not
+           try setting them yourself, either directly or via a '.env' file.
+    """
+    installation_path_str = os.environ["_SOLIPLEX_INSTALLATION_PATH"]
+    installation_path = pathlib.Path(installation_path_str)
+    no_auth_mode = os.environ.get("_SOLIPLEX_NO_AUTH_MODE") == "Y"
+    add_admin_user = os.environ.get("_SOLIPLEX_ADD_ADMIN_USER")
+
+    return create_app(
+        installation_path=installation_path,
+        no_auth_mode=no_auth_mode,
+        add_admin_user=add_admin_user,
+    )
 
 
 if __name__ == "__main__":  # pragma:  NO COVER

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -228,3 +228,34 @@ def test_create_app_with_explicit_overrides(
         no_auth_mode=w_no_auth_mode,
         add_admin_user=w_add_admin_user,
     )
+
+
+@pytest.mark.parametrize("w_add_admin_user", [None, ADMIN_USER_EMAIL])
+@pytest.mark.parametrize("w_no_auth_mode", [False, True])
+@mock.patch("soliplex.main.create_app")
+def test_create_app_from_environment(
+    create_app,
+    temp_dir,
+    w_no_auth_mode,
+    w_add_admin_user,
+):
+    i_path = temp_dir / "installation.yaml"
+
+    env_patch = {"_SOLIPLEX_INSTALLATION_PATH": str(i_path)}
+
+    if w_no_auth_mode:
+        env_patch["_SOLIPLEX_NO_AUTH_MODE"] = "Y"
+
+    if w_add_admin_user:
+        env_patch["_SOLIPLEX_ADD_ADMIN_USER"] = w_add_admin_user
+
+    with mock.patch.dict("os.environ", clear=True, **env_patch):
+        found = main.create_app_from_environment()
+
+    assert found is create_app.return_value
+
+    create_app.assert_called_once_with(
+        installation_path=i_path,
+        no_auth_mode=w_no_auth_mode,
+        add_admin_user=w_add_admin_user,
+    )


### PR DESCRIPTION
In the case where Uvicorn requires a string naming the app factory, it does not permit passing any arguments to the factory:  we must therefore allow a narrowly-limited use of environmen variables to communicate from the 'cli' app to the worker process(s).

Mark these env vars as private by prefixing them with '_', and by documenting them as so in both the 'cli' command and the factory function.

Closes #553.