### PR TITLE
feat: permit loading '.env' from working directory

### DIFF
--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -2328,6 +2328,37 @@ class InstallationConfig:
         return [feature for feature in AGUI_FEATURES_BY_NAME.values()]
 
     #
+    # Variables loaded via 'dotenv' library
+    #
+    disable_dotenv: bool = False
+
+    _from_dotenv: dict[str, str] = None
+
+    @staticmethod
+    def _load_dotenv(from_path: pathlib.Path) -> dict[str, str] | None:
+        if from_path.is_file():
+            with from_path.open() as stream:
+                return dotenv.dotenv_values(stream=stream)
+
+    @property
+    def from_dotenv(self) -> dict[str, str]:
+        if self.disable_dotenv:
+            return {}
+
+        if self._from_dotenv is None:
+            for from_path in [
+                self._config_path.parent / ".env",
+                pathlib.Path.cwd() / ".env",
+            ]:
+                values = self._load_dotenv(from_path)
+
+                if values is not None:
+                    self._from_dotenv = values
+                    break
+
+        return self._from_dotenv or {}
+
+    #
     # Secrets name values looked up from env vars or other sources.
     #
     secrets: list[SecretConfig] = dataclasses.field(
@@ -2389,21 +2420,11 @@ class InstallationConfig:
         default_factory=dict,
     )
 
-    disable_dotenv: bool = False
-
     def get_environment(self, key, default=None):
         """Find the configured value for a given quasi-envvar"""
         return self.environment.get(key, default)
 
     def resolve_environment(self):
-        dotenv_file = self._config_path.parent / ".env"
-
-        if not self.disable_dotenv and dotenv_file.is_file():
-            with dotenv_file.open() as stream:
-                dotenv_env = dotenv.dotenv_values(stream=stream)
-        else:
-            dotenv_env = {}
-
         resolved = {}
         failed = []
         excs = []
@@ -2413,7 +2434,7 @@ class InstallationConfig:
                 resolved[key] = resolve_environment_entry(
                     key,
                     value,
-                    dotenv_env,
+                    self.from_dotenv,
                 )
             except MissingEnvVar as exc:
                 excs.append(exc)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5322,6 +5322,70 @@ def test_installationconfigmeta_as_yaml(
     assert found == expected_dict
 
 
+@pytest.mark.parametrize("w_disable_dotenv", [False, True])
+def test_installationconfig_from_dotenv_already(w_disable_dotenv):
+    already = {"KEY": "value"}
+
+    i_config = config.InstallationConfig(
+        id="test-ic",
+        disable_dotenv=w_disable_dotenv,
+        _from_dotenv=already,
+    )
+
+    found = i_config.from_dotenv
+
+    if w_disable_dotenv:
+        assert found == {}
+
+    else:
+        assert found == already
+
+
+@pytest.mark.parametrize("w_cwd_dotenv", [None, "KEY=from_cwd_dotenv"])
+@pytest.mark.parametrize("w_inst_dotenv", [None, "KEY=from_inst_dotenv"])
+@pytest.mark.parametrize("w_disable_dotenv", [False, True])
+@mock.patch("pathlib.Path")
+def test_installationconfig_from_dotenv(
+    p_path,
+    temp_dir,
+    w_disable_dotenv,
+    w_inst_dotenv,
+    w_cwd_dotenv,
+):
+    inst_dir = temp_dir / "installation"
+    inst_dir.mkdir()
+    inst_config_file = inst_dir / "test.yaml"
+    inst_dot_env = inst_dir / ".env"
+    expected = {}
+
+    if w_inst_dotenv is not None:
+        inst_dot_env.write_text(w_inst_dotenv)
+        expected["KEY"] = "from_inst_dotenv"
+
+    cwd = temp_dir / "cwd"
+    cwd.mkdir()
+    p_path.cwd.return_value = cwd
+    cwd_dot_env = cwd / ".env"
+
+    if w_cwd_dotenv is not None:
+        cwd_dot_env.write_text(w_cwd_dotenv)
+        if "KEY" not in expected:  # inst dir wins over cwd
+            expected["KEY"] = "from_cwd_dotenv"
+
+    if w_disable_dotenv:
+        expected = {}
+
+    i_config = config.InstallationConfig(
+        id="test-ic",
+        disable_dotenv=w_disable_dotenv,
+        _config_path=inst_config_file,
+    )
+
+    found = i_config.from_dotenv
+
+    assert found == expected
+
+
 def test_installationconfig_secrets_map_wo_existing():
     secrets = [
         mock.create_autospec(
@@ -5503,35 +5567,35 @@ RESOLVED = {"name": "RESOLVED", "value": "resolved"}
         ),
         (
             [UNRESOLVED, UNRESOLVED_MOAR],
-            ("UNRESOLVED=via_dotenv", False),
+            ({"UNRESOLVED": "via_dotenv"}, False),
             pytest.raises(config.MissingEnvVars),
             "UNRESOLVED_MOAR",
             None,
         ),
         (
             [UNRESOLVED],
-            ("UNRESOLVED=via_dotenv", False),
+            ({"UNRESOLVED": "via_dotenv"}, False),
             contextlib.nullcontext(None),
             None,
             {"UNRESOLVED": "via_dotenv"},
         ),
         (
             [UNRESOLVED],
-            ("UNRESOLVED=via_dotenv", True),
+            ({"UNRESOLVED": "via_dotenv"}, True),
             pytest.raises(config.MissingEnvVars),
             "UNRESOLVED",
             None,
         ),
         (
             [RESOLVED],
-            ("RESOLVED=via_dotenv", False),
+            ({"RESOLVED": "via_dotenv"}, False),
             contextlib.nullcontext(None),
             None,
             {"RESOLVED": "resolved"},
         ),
         (
             [RESOLVED],
-            ("RESOLVED=via_dotenv", True),
+            ({"RESOLVED": "via_dotenv"}, True),
             contextlib.nullcontext(None),
             None,
             {"RESOLVED": "resolved"},
@@ -5548,17 +5612,18 @@ def test_installation_resolve_environment(
 ):
     environment = {entry["name"]: entry.get("value") for entry in env_entries}
 
-    dotenv_text, disable_dotenv = dotenv_opt
+    from_dotenv, disable_dotenv = dotenv_opt
 
-    if dotenv_text is not None:
-        dotenv_file = temp_dir / ".env"
-        dotenv_file.write_text(dotenv_text)
+    dotenv_kwargs = {"disable_dotenv": disable_dotenv}
+
+    if from_dotenv is not None:
+        dotenv_kwargs["_from_dotenv"] = from_dotenv
 
     i_config = config.InstallationConfig(
         id="test-ic",
         _config_path=temp_dir / "installation.yaml",
         environment=environment,
-        disable_dotenv=disable_dotenv,
+        **dotenv_kwargs,
     )
 
     with expectation as expected:


### PR DESCRIPTION
refactor: hoist 'InstallationConfig.from_dotenv' property

Closes #542.