### PR TITLE
chore: fire tracer bullet at CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,7 @@ dependencies = [
     "fastapi",
     "fastmcp >= 2.14.0, < 2.15",
     "greenlet",
-
-
     "haiku.rag-slim >= 0.28.0",
-
     "itsdangerous",
     "jsonpatch",
     "jwcrypto",


### PR DESCRIPTION
Meaningless change to 'pypproject.toml'.