### PR TITLE
fix: pass 'log_config' to Uvicorn as a string

### DIFF
--- a/src/soliplex/cli.py
+++ b/src/soliplex/cli.py
@@ -251,7 +251,7 @@ Incompatible with '--no-auth-mode'.
         uvicorn_kw["workers"] = workers
 
     if log_config is not None:
-        uvicorn_kw["log_config"] = log_config
+        uvicorn_kw["log_config"] = str(log_config)
 
     if log_level is not None:
         uvicorn_kw["log_level"] = log_level


### PR DESCRIPTION
Closes #573.