### PR TITLE
feat: 'InstallationConfig.logging_config'

### DIFF
--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -2533,6 +2533,24 @@ class InstallationConfig:
     quizzes_paths: list[pathlib.Path] = None
 
     #
+    # Console logging configuration
+    #
+    _logging_config_file: pathlib.Path = None
+
+    @property
+    def logging_config(self) -> dict[str, typing.Any] | None:
+        """Return a mapping for use in configuring the 'logging' module
+
+        If no file is configured, return None.
+        """
+        if self._logging_config_file is None:
+            return None
+
+        maybe_local = self._config_path.parent / self._logging_config_file
+
+        return _load_config_yaml(maybe_local)
+
+    #
     # Logfire configuration
     #
     logfire_config: LogfireConfig = None
@@ -2638,6 +2656,13 @@ class InstallationConfig:
             ]
             config_dict["agent_configs"] = agent_configs
 
+            logging_config_file = config_dict.pop("logging_config_file", None)
+
+            if logging_config_file is not None:
+                config_dict["_logging_config_file"] = pathlib.Path(
+                    logging_config_file
+                )
+
             logfire_cfg = config_dict.pop("logfire_config", None)
 
             if logfire_cfg is not None:
@@ -2701,6 +2726,7 @@ class InstallationConfig:
             )
             for agent_config in self.agent_configs
         ]
+
         if self.logfire_config is not None:
             self.logfire_config = dataclasses.replace(
                 self.logfire_config,
@@ -2755,6 +2781,7 @@ class InstallationConfig:
             "environment": self.environment,
             "haiku_rag_config_file": str(self._haiku_rag_config_file),
             "agent_configs": [ac.as_yaml for ac in self.agent_configs],
+            "logging_config_file": str(self._logging_config_file),
             "oidc_paths": [str(path) for path in self.oidc_paths],
             "room_paths": [str(path) for path in self.room_paths],
             "completion_paths": [str(path) for path in self.completion_paths],

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1680,6 +1680,16 @@ quizzes_paths:
     -
 """
 
+LOGGING_CONFIG_FILE = "/path/to/logging.yaml"
+W_LOGGING_CONFIG_FILE_INSTALLATION_CONFIG_KW = {
+    "id": INSTALLATION_ID,
+    "_logging_config_file": pathlib.Path(LOGGING_CONFIG_FILE),
+}
+W_LOGGING_CONFIG_FILE_INSTALLATION_CONFIG_YAML = f"""\
+id: "{INSTALLATION_ID}"
+logging_config_file: "{LOGGING_CONFIG_FILE}"
+"""
+
 W_LOGFIRE_CONFIG_INSTALLATION_CONFIG_KW = {
     "id": INSTALLATION_ID,
     "logfire_config": config.LogfireConfig(token=TEST_LOGFIRE_TOKEN),
@@ -5697,6 +5707,33 @@ def test_installationconfig_agent_configs_map_w_existing():
     assert found is already
 
 
+@pytest.mark.parametrize("w_filename", [False, True])
+def test_installationconfig_logging_config_file(temp_dir, w_filename):
+    logging_config_file = temp_dir / "logging.yaml"
+    logging_config_file.write_text("""\
+version: 1
+""")
+    kw = {}
+
+    if w_filename:
+        kw["_logging_config_file"] = logging_config_file
+
+    i_config = config.InstallationConfig(
+        id="test-ic",
+        _config_path=temp_dir / "installation.yaml",
+        **kw,
+    )
+
+    with mock.patch.dict("os.environ", clear=True):
+        logging_config = i_config.logging_config
+
+    if w_filename:
+        assert isinstance(logging_config, dict)
+        assert logging_config["version"] == 1
+    else:
+        assert logging_config is None
+
+
 def test_installationconfig_agui_features(the_agui_feature):
     i_config = config.InstallationConfig(id="test-ic")
 
@@ -5870,6 +5907,10 @@ def test_installationconfig_authorization_dburi_async(w_kw, expected):
         (
             W_QUIZZES_PATHS_ONLY_NULL_INSTALLATION_CONFIG_YAML,
             W_QUIZZES_PATHS_ONLY_NULL_INSTALLATION_CONFIG_KW.copy(),
+        ),
+        (
+            W_LOGGING_CONFIG_FILE_INSTALLATION_CONFIG_YAML,
+            W_LOGGING_CONFIG_FILE_INSTALLATION_CONFIG_KW.copy(),
         ),
         (
             W_LOGFIRE_CONFIG_INSTALLATION_CONFIG_YAML,
@@ -6078,6 +6119,7 @@ def test_installationconfig_as_yaml(w_logfire_config):
         },
         _haiku_rag_config_file=pathlib.Path(HAIKU_RAG_CONFIG_FILE),
         agent_configs=[agent_config],
+        _logging_config_file=pathlib.Path(LOGGING_CONFIG_FILE),
         oidc_paths=[pathlib.Path("./oidc-test")],
         room_paths=[
             pathlib.Path("/path/to/rooms"),
@@ -6102,6 +6144,7 @@ def test_installationconfig_as_yaml(w_logfire_config):
         "agent_configs": [
             agent_config.as_yaml,
         ],
+        "logging_config_file": LOGGING_CONFIG_FILE,
         "oidc_paths": ["oidc-test"],
         "room_paths": ["/path/to/rooms", "other/rooms"],
         "completion_paths": ["/path/to/completions"],


### PR DESCRIPTION
Alternative to passing '--log-config' to Uvicorn on the command line.

Closes ~~#577~~ #584.