### PR TITLE
fix: pass 'log_config' path to Uvicorn

### DIFF
--- a/src/soliplex/cli.py
+++ b/src/soliplex/cli.py
@@ -223,6 +223,10 @@ Incompatible with '--no-auth-mode'.
         )
         raise typer.Exit()
 
+    # Temporary, to permit updating logging config if not passed on CLI.
+    the_installation = get_installation(installation_path)
+    i_config = the_installation._config
+
     if reload in (ReloadOption.PYTHON, ReloadOption.BOTH):
         reload_dirs.extend(soliplex.__path__)
 
@@ -253,6 +257,11 @@ Incompatible with '--no-auth-mode'.
 
     if log_level is not None:
         uvicorn_kw["log_level"] = log_level
+
+    if log_config is not None:
+        uvicorn_kw["log_config"] = str(log_config)
+    elif i_config._logging_config_file is not None:
+        uvicorn_kw["log_config"] = str(i_config.logging_config_file)
 
     if access_log is not None:
         uvicorn_kw["access_log"] = access_log

--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -2538,17 +2538,23 @@ class InstallationConfig:
     _logging_config_file: pathlib.Path = None
 
     @property
+    def logging_config_file(self) -> pathlib.Path | None:
+        """Return the path to our logging config file"""
+        if self._logging_config_file is None:
+            return None
+
+        return self._config_path.parent / self._logging_config_file
+
+    @property
     def logging_config(self) -> dict[str, typing.Any] | None:
         """Return a mapping for use in configuring the 'logging' module
 
         If no file is configured, return None.
         """
-        if self._logging_config_file is None:
-            return None
+        config_file = self.logging_config_file
 
-        maybe_local = self._config_path.parent / self._logging_config_file
-
-        return _load_config_yaml(maybe_local)
+        if config_file is not None:
+            return _load_config_yaml(config_file)
 
     #
     # Logfire configuration

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5724,6 +5724,31 @@ version: 1
         **kw,
     )
 
+    found = i_config.logging_config_file
+
+    if w_filename:
+        assert found == logging_config_file
+    else:
+        assert found is None
+
+
+@pytest.mark.parametrize("w_filename", [False, True])
+def test_installationconfig_logging_config(temp_dir, w_filename):
+    logging_config_file = temp_dir / "logging.yaml"
+    logging_config_file.write_text("""\
+version: 1
+""")
+    kw = {}
+
+    if w_filename:
+        kw["_logging_config_file"] = logging_config_file
+
+    i_config = config.InstallationConfig(
+        id="test-ic",
+        _config_path=temp_dir / "installation.yaml",
+        **kw,
+    )
+
     with mock.patch.dict("os.environ", clear=True):
         logging_config = i_config.logging_config
 


### PR DESCRIPTION
Prefer the path from the CLI '--log-config', if passed.

Otherwise, fall back to the version in the installation config, defaulting to no value.

Closes #579.