### PR TITLE
chore: deprecate 'main.app_with_git_hash'

### DIFF
--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import sys
 import typing
+import warnings
 
 import fastapi
 import uvicorn
@@ -94,6 +95,14 @@ async def add_custom_header(request: fastapi.Request, call_next):
 
 
 def app_with_git_hash(app: fastapi.FastAPI) -> fastapi.FastAPI:
+    # The direct caller is likely 'create_app' below: use 'stacklevel=3'
+    # to get *its* caller.
+    warnings.warn(
+        "'soliplex.main.app_with_git_hash' is deprecated, and will be "
+        "removed after version 0.43.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
     app.middleware("http")(add_custom_header)
 
     return app
@@ -119,19 +128,32 @@ def create_app(
     no_auth_mode: bool,
     log_config_file: str = None,
     add_admin_user: str = None,
-    register_metaconfigs=register_metaconfigs,
-    curry_lifespan=curry_lifespan,
-    app_with_lifespan=app_with_lifespan,
-    app_with_cors=app_with_cors,
-    app_with_session=app_with_session,
-    app_with_git_hash=app_with_git_hash,
-    app_with_soliplex_routers=app_with_soliplex_routers,
+    register_metaconfigs=None,
+    curry_lifespan=None,
+    app_with_lifespan=None,
+    app_with_cors=None,
+    app_with_session=None,
+    app_with_git_hash=None,  # deprecated
+    app_with_soliplex_routers=None,
 ):
     """Construct the Soliplex FastAPI application
 
     Callers may override any of the component functions in this module
     via parameters.
     """
+    globs = globals()
+
+    register_metaconfigs = (
+        register_metaconfigs or globs["register_metaconfigs"]
+    )
+    curry_lifespan = curry_lifespan or globs["curry_lifespan"]
+    app_with_lifespan = app_with_lifespan or globs["app_with_lifespan"]
+    app_with_cors = app_with_cors or globs["app_with_cors"]
+    app_with_session = app_with_session or globs["app_with_session"]
+    app_with_soliplex_routers = (
+        app_with_soliplex_routers or globs["app_with_soliplex_routers"]
+    )
+
     register_metaconfigs()
 
     curried_lifespan = curry_lifespan(
@@ -143,7 +165,10 @@ def create_app(
     app = app_with_lifespan(curried_lifespan)
     app = app_with_cors(app)
     app = app_with_session(app)
-    app = app_with_git_hash(app)
+
+    if app_with_git_hash is not None:
+        app = app_with_git_hash(app)
+
     app = app_with_soliplex_routers(app)
 
     return app

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,6 @@
 import functools
 import pathlib
+import warnings
 from unittest import mock
 
 import pytest
@@ -165,9 +166,11 @@ async def test_add_custom_header(pp_cwd, gm_klass, w_already_tgm):
 def test_app_with_git_hash():
     app = mock.Mock(spec_set=["middleware"])
 
-    found = main.app_with_git_hash(app)
+    with warnings.catch_warnings(record=True) as logged:
+        found = main.app_with_git_hash(app)
 
     assert found is app
+    assert logged
 
     app.middleware.assert_called_once_with("http")
     (called,) = app.middleware.return_value.call_args_list
@@ -236,6 +239,69 @@ def test_create_app_with_explicit_overrides(
     app_with_git_hash.assert_called_once_with(
         app_with_session.return_value,
     )
+    app_with_session.assert_called_once_with(
+        app_with_cors.return_value,
+    )
+    app_with_cors.assert_called_once_with(
+        app_with_lifespan.return_value,
+    )
+    app_with_lifespan.assert_called_once_with(
+        curry_lifespan.return_value,
+    )
+    curry_lifespan.assert_called_once_with(
+        installation_path=EXPLICIT_INST_PATH,
+        no_auth_mode=w_no_auth_mode,
+        add_admin_user=w_add_admin_user,
+        log_config_file=w_log_config_file,
+    )
+
+
+@pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
+@pytest.mark.parametrize("w_add_admin_user", [None, ADMIN_USER_EMAIL])
+@pytest.mark.parametrize("w_no_auth_mode", [False, True])
+def test_create_app_wo_explicit_overrides(
+    w_no_auth_mode,
+    w_add_admin_user,
+    w_log_config_file,
+):
+    kwargs = {}
+
+    if w_add_admin_user is not None:
+        kwargs["add_admin_user"] = w_add_admin_user
+
+    if w_log_config_file is not None:
+        kwargs["log_config_file"] = w_log_config_file
+
+    curry_lifespan = mock.Mock(spec_set=())
+    app_with_lifespan = mock.Mock(spec_set=())
+    app_with_cors = mock.Mock(spec_set=())
+    app_with_session = mock.Mock(spec_set=())
+    app_with_git_hash = mock.Mock(spec_set=())
+    app_with_soliplex_routers = mock.Mock(spec_set=())
+
+    with mock.patch.multiple(
+        "soliplex.main",
+        curry_lifespan=curry_lifespan,
+        app_with_lifespan=app_with_lifespan,
+        app_with_cors=app_with_cors,
+        app_with_session=app_with_session,
+        app_with_git_hash=app_with_git_hash,
+        app_with_soliplex_routers=app_with_soliplex_routers,
+    ):
+        found = main.create_app(
+            installation_path=EXPLICIT_INST_PATH,
+            no_auth_mode=w_no_auth_mode,
+            **kwargs,
+        )
+
+    assert found is app_with_soliplex_routers.return_value
+
+    app_with_soliplex_routers.assert_called_once_with(
+        app_with_session.return_value,
+    )
+
+    app_with_git_hash.assert_not_called()
+
     app_with_session.assert_called_once_with(
         app_with_cors.return_value,
     )


### PR DESCRIPTION
No longer call it by default.

Closes #609.