### PR TITLE
fix: remove exception leaks from HTTP responses

### DIFF
--- a/src/soliplex/completions.py
+++ b/src/soliplex/completions.py
@@ -87,7 +87,7 @@ async def openai_chat_completion(
             ),
             media_type="text/event-stream",
         )
-    except Exception as e:
+    except Exception:
         raise fastapi.HTTPException(
-            status_code=500, detail=f"An internal server error occurred: {e}"
+            status_code=500, detail="Error streaming chat responses"
         ) from None

--- a/src/soliplex/views/authn.py
+++ b/src/soliplex/views/authn.py
@@ -104,10 +104,11 @@ async def get_auth_system(
 
     try:
         tokendict = await oauth_app.authorize_access_token(request)
-    except starlette_client.OAuthError as e:
+    except starlette_client.OAuthError:
         bound_logger.exception(loggers.AUTHN_JWT_INVALID)
         raise fastapi.HTTPException(
-            status_code=401, detail=f"{loggers.AUTHN_JWT_INVALID} {e}"
+            status_code=401,
+            detail=loggers.AUTHN_JWT_INVALID,
         ) from None
 
     access_token = tokendict["access_token"]

--- a/src/soliplex/views/installation.py
+++ b/src/soliplex/views/installation.py
@@ -1,7 +1,6 @@
 import json
 import pathlib
 import subprocess
-import traceback
 
 import fastapi
 
@@ -74,10 +73,9 @@ async def get_installation_versions(
         )
     except Exception:
         bound_logger.exception(loggers.INST_SUBPROCESS_PIP)
-        error = traceback.format_exc()
         raise fastapi.HTTPException(
             status_code=500,
-            detail=error,
+            detail=loggers.INST_SUBPROCESS_PIP,
         ) from None
 
     installed = json.loads(found)

--- a/src/soliplex/views/quizzes.py
+++ b/src/soliplex/views/quizzes.py
@@ -36,22 +36,22 @@ async def get_quiz(
             the_authz_policy=the_authz_policy,
             the_logger=the_logger,
         )
-    except KeyError as e:
+    except KeyError:
         # auth error logged in 'get_room_config'
         # but this could be just a missing room
         the_logger.exception(loggers.ROOM_UNKNOWN_ROOM_ID, room_id)
         raise fastapi.HTTPException(
             status_code=404,
-            detail=str(e),
+            detail=loggers.ROOM_UNKNOWN_ROOM_ID % room_id,
         ) from None
 
     try:
         quiz = room_config.quiz_map[quiz_id]
-    except KeyError as e:
+    except KeyError:
         the_logger.exception(loggers.QUIZ_UNKNOWN_QUIZ_ID, quiz_id)
         raise fastapi.HTTPException(
             status_code=404,
-            detail=str(e),
+            detail=loggers.QUIZ_UNKNOWN_QUIZ_ID % quiz_id,
         ) from None
 
     return models.Quiz.from_config(quiz)
@@ -79,29 +79,29 @@ async def post_quiz_question(
             the_authz_policy=the_authz_policy,
             the_logger=the_logger,
         )
-    except KeyError as e:
+    except KeyError:
         # auth error logged in 'get_room_config'
         # but this could be just a missing room
         the_logger.exception(loggers.ROOM_UNKNOWN_ROOM_ID, room_id)
         raise fastapi.HTTPException(
             status_code=404,
-            detail=str(e),
+            detail=loggers.ROOM_UNKNOWN_ROOM_ID % room_id,
         ) from None
 
     try:
         quiz = room_config.quiz_map[quiz_id]
-    except KeyError as e:
+    except KeyError:
         the_logger.exception(loggers.QUIZ_UNKNOWN_QUIZ_ID, quiz_id)
         raise fastapi.HTTPException(
             status_code=404,
-            detail=str(e),
+            detail=loggers.QUIZ_UNKNOWN_QUIZ_ID % quiz_id,
         ) from None
 
     try:
         return await quizzes.check_answer(quiz, question_uuid, answer.text)
-    except quizzes.QuestionNotFound as e:
+    except quizzes.QuestionNotFound:
         the_logger.exception(loggers.QUIZ_UNKNOWN_QUESTION_UUID, question_uuid)
         raise fastapi.HTTPException(
             status_code=404,
-            detail=str(e),
+            detail=loggers.QUIZ_UNKNOWN_QUESTION_UUID % question_uuid,
         ) from None

--- a/tests/unit/views/test_installation_views.py
+++ b/tests/unit/views/test_installation_views.py
@@ -72,9 +72,8 @@ async def test_get_installation(fc, w_admin_access):
 
 
 @pytest.mark.anyio
-@mock.patch("soliplex.views.installation.traceback")
 @mock.patch("soliplex.views.installation.subprocess")
-async def test_get_installation_versions_w_error(sp, tb):
+async def test_get_installation_versions_w_error(sp):
     sp.check_output.side_effect = ValueError("testing")
 
     request = mock.create_autospec(fastapi.Request)
@@ -96,13 +95,15 @@ async def test_get_installation_versions_w_error(sp, tb):
             the_logger=the_logger,
         )
 
-    assert exc.value.detail is tb.format_exc.return_value
+    assert exc.value.detail == loggers.INST_SUBPROCESS_PIP
 
-    tb.format_exc.assert_called_once_with()
     the_authz_policy.check_admin_access.assert_awaited_once_with(
         THE_USER_CLAIMS,
     )
 
+    bound_logger.exception.assert_called_once_with(
+        loggers.INST_SUBPROCESS_PIP,
+    )
     bound_logger.debug.assert_called_once_with(
         loggers.INST_GET_INSTALLATION_VERSIONS,
     )


### PR DESCRIPTION
- 'GET /api/v1/auth/system' stringified exception as detail.
- 'POST /api/v1/chat/completions/{completion_id}'
   stringified exception as detail
   (via 'soliplex.completions.openai_chat_completion').
- 'GET /api/v1/installation/versions'
   returned traceback from 'subprocess.check_output' as detail.
- 'GET /api/v1/rooms/{room_id}/quiz/{quiz_id}'
   stringified exceptions as detail.
- 'POST /api/v1/rooms/{room_id}/quiz/{quiz_id}/{question_uuid}'
   stringified exceptions as detail.

Closes #630.