### PR TITLE
Automatic thread title generation

### DIFF
--- a/docs/config/installation.md
+++ b/docs/config/installation.md
@@ -86,6 +86,28 @@ Please see [this page](agents.md) for details on configuring agents.
 In addition to the values described there, note that the `id` element is
 required here.
 
+## Thread Title Generation
+
+Soliplex can automatically generate a short title for new conversation
+threads using an LLM.  After a run completes, if the thread does not
+already have a title, a background task calls the configured agent to
+produce one.
+
+To enable this feature, define an agent config at the top level and
+reference it via `title_agent_config_id`:
+
+```yaml
+agent_configs:
+  - id: "title"
+    model_name: "gpt-oss:latest"
+
+title_agent_config_id: "title"
+```
+
+The title agent does not need a `system_prompt` — it uses its own
+built-in prompt.  If `title_agent_config_id` is not set, automatic
+title generation is disabled.
+
 ## Thread Persistence DBURI
 
 An installation can define two DBURIs for the database used to store

--- a/example/functest_no_llm.yaml
+++ b/example/functest_no_llm.yaml
@@ -98,6 +98,11 @@ agent_configs:
 
       Always provide code or examples in Markdown blocks.
 
+  - id: "title"
+    model_name: "gpt-oss:latest"
+
+title_agent_config_id: "title"
+
 #==========================================================================
 # OIDC authentication provider configuration
 #==========================================================================

--- a/example/functest_no_llm.yaml
+++ b/example/functest_no_llm.yaml
@@ -98,11 +98,6 @@ agent_configs:
 
       Always provide code or examples in Markdown blocks.
 
-  - id: "title"
-    model_name: "gpt-oss:latest"
-
-title_agent_config_id: "title"
-
 #==========================================================================
 # OIDC authentication provider configuration
 #==========================================================================

--- a/example/installation-openai.yaml
+++ b/example/installation-openai.yaml
@@ -256,6 +256,14 @@ agent_configs:
 
       Always provide code or examples in Markdown blocks.
 
+  - id: "title"
+    model_name: "gpt-4o-mini"
+    provider_type: "openai"
+    provider_base_url: "https://api.openai.com"
+    provider_key: "secret:OPENAI_API_KEY"
+
+title_agent_config_id: "title"
+
 #==========================================================================
 # Thread peristence:  SQLAlchemy DBURIs
 #==========================================================================

--- a/example/installation.yaml
+++ b/example/installation.yaml
@@ -248,6 +248,11 @@ agent_configs:
 
       Always provide code or examples in Markdown blocks.
 
+  - id: "title"
+    model_name: "gpt-oss:latest"
+
+title_agent_config_id: "title"
+
 #==========================================================================
 # Thread peristence:  SQLAlchemy DBURIs
 #==========================================================================

--- a/example/minimal-openai.yaml
+++ b/example/minimal-openai.yaml
@@ -209,6 +209,14 @@ agent_configs:
 
       Always provide code or examples in Markdown blocks.
 
+  - id: "title"
+    model_name: "gpt-4o-mini"
+    provider_type: "openai"
+    provider_base_url: "https://api.openai.com"
+    provider_key: "secret:OPENAI_API_KEY"
+
+title_agent_config_id: "title"
+
 #==========================================================================
 # Thread peristence:  SQLAlchemy DBURIs
 #==========================================================================

--- a/example/minimal.yaml
+++ b/example/minimal.yaml
@@ -193,6 +193,11 @@ agent_configs:
 
       Always provide code or examples in Markdown blocks.
 
+  - id: "title"
+    model_name: "gpt-oss:latest"
+
+title_agent_config_id: "title"
+
 #==========================================================================
 # Thread peristence:  SQLAlchemy DBURIs
 #==========================================================================

--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -65,34 +65,41 @@ def make_mcp_client_toolset(
     return toolset_klass(**toolset_config.tool_kwargs)
 
 
+def make_model(
+    agent_config: config.AgentConfig,
+) -> google_models.GoogleModel | openai_models.OpenAIChatModel:
+    """Create a pydantic-ai model from an agent config."""
+    provider_kw = agent_config.llm_provider_kw
+
+    if agent_config.provider_type == config.LLMProviderType.GOOGLE:
+        provider = google_providers.GoogleProvider(**provider_kw)
+        return google_models.GoogleModel(
+            model_name=agent_config.model_name,
+            provider=provider,
+        )
+
+    if agent_config.provider_type == config.LLMProviderType.OLLAMA:
+        provider_kw["api_key"] = "dummy"
+        provider = ollama_providers.OllamaProvider(**provider_kw)
+        return openai_models.OpenAIChatModel(
+            model_name=agent_config.model_name,
+            provider=provider,
+        )
+
+    provider = openai_providers.OpenAIProvider(**provider_kw)
+    return openai_models.OpenAIChatModel(
+        model_name=agent_config.model_name,
+        provider=provider,
+    )
+
+
 def _get_default_agent_from_configs(
     agent_config: config.AgentConfig,
     tool_configs: ToolConfigMap,
     mcp_client_toolset_configs: config.MCP_ClientToolsetConfigMap,
 ) -> SoliplexAgent:
     """Build a Pydantic AI agent from a config"""
-    provider_kw = agent_config.llm_provider_kw
-
-    if agent_config.provider_type == config.LLMProviderType.GOOGLE:
-        provider = google_providers.GoogleProvider(**provider_kw)
-        model = google_models.GoogleModel(
-            model_name=agent_config.model_name,
-            provider=provider,
-        )
-
-    elif agent_config.provider_type == config.LLMProviderType.OLLAMA:
-        provider_kw["api_key"] = "dummy"
-        provider = ollama_providers.OllamaProvider(**provider_kw)
-        model = openai_models.OpenAIChatModel(
-            model_name=agent_config.model_name,
-            provider=provider,
-        )
-    else:
-        provider = openai_providers.OpenAIProvider(**provider_kw)
-        model = openai_models.OpenAIChatModel(
-            model_name=agent_config.model_name,
-            provider=provider,
-        )
+    model = make_model(agent_config)
 
     tools = [
         make_ai_tool(tool_config) for tool_config in tool_configs.values()

--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -2372,6 +2372,8 @@ class InstallationConfig:
     )
     _agent_configs_map: AgentConfigMap = None
 
+    title_agent_config_id: str | None = None
+
     @property
     def agent_configs_map(self) -> AgentConfigMap:
         if self._agent_configs_map is None:
@@ -2733,6 +2735,9 @@ class InstallationConfig:
 
         if self.logfire_config is not None:
             result["logfire_config"] = self.logfire_config.as_yaml
+
+        if self.title_agent_config_id is not None:
+            result["title_agent_config_id"] = self.title_agent_config_id
 
         return result
 

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -235,6 +235,15 @@ class Installation:
     ) -> config.CompletionConfig:
         return self._config.completion_configs[completion_id]
 
+    def get_title_agent_config(
+        self,
+        room_id: str,
+    ) -> config.AgentConfig:
+        title_agent_config_id = self._config.title_agent_config_id
+        if title_agent_config_id is not None:
+            return self._config.agent_configs_map[title_agent_config_id]
+        return self._config.room_configs[room_id].agent_config
+
     def get_agent_by_id(
         self,
         agent_id: str,

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -235,14 +235,11 @@ class Installation:
     ) -> config.CompletionConfig:
         return self._config.completion_configs[completion_id]
 
-    def get_title_agent_config(
-        self,
-        room_id: str,
-    ) -> config.AgentConfig:
+    def get_title_agent_config(self) -> config.AgentConfig | None:
         title_agent_config_id = self._config.title_agent_config_id
-        if title_agent_config_id is not None:
-            return self._config.agent_configs_map[title_agent_config_id]
-        return self._config.room_configs[room_id].agent_config
+        if title_agent_config_id is None:
+            return None
+        return self._config.agent_configs_map[title_agent_config_id]
 
     def get_agent_by_id(
         self,

--- a/src/soliplex/titles.py
+++ b/src/soliplex/titles.py
@@ -4,9 +4,13 @@ import logfire
 import pydantic
 import pydantic_ai
 from ag_ui import core as agui_core
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agents
 from soliplex import config
+from soliplex.agui import persistence as agui_persistence
+
+DEFAULT_THREAD_NAME = "New Thread"
 
 TITLE_PROMPT = """\
 Generate a short, concise title (max 8 words) for this conversation.
@@ -55,7 +59,7 @@ async def generate_title(
 
 async def maybe_generate_title(
     *,
-    the_threads,
+    threads_engine: sqla_asyncio.AsyncEngine,
     the_installation,
     room_id: str,
     thread_id: str,
@@ -63,12 +67,21 @@ async def maybe_generate_title(
     messages: list[agui_core.Message],
 ):
     try:
-        thread = await the_threads.get_thread(
-            user_name=user_name,
-            room_id=room_id,
-            thread_id=thread_id,
-        )
-        if thread.thread_metadata is not None:
+        async with sqla_asyncio.AsyncSession(
+            bind=threads_engine,
+        ) as session:
+            the_threads = agui_persistence.ThreadStorage(session)
+            thread = await the_threads.get_thread(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+            )
+            thread_metadata = await thread.awaitable_attrs.thread_metadata
+
+        if thread_metadata is not None and thread_metadata.name not in (
+            None,
+            DEFAULT_THREAD_NAME,
+        ):
             return
 
         agent_config = the_installation.get_title_agent_config(
@@ -78,11 +91,15 @@ async def maybe_generate_title(
         if title is None:
             return
 
-        await the_threads.update_thread_metadata(
-            user_name=user_name,
-            room_id=room_id,
-            thread_id=thread_id,
-            thread_metadata={"name": title},
-        )
+        async with sqla_asyncio.AsyncSession(
+            bind=threads_engine,
+        ) as session:
+            the_threads = agui_persistence.ThreadStorage(session)
+            await the_threads.update_thread_metadata(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                thread_metadata={"name": title},
+            )
     except Exception:
         logfire.exception("Failed to generate thread title")

--- a/src/soliplex/titles.py
+++ b/src/soliplex/titles.py
@@ -59,18 +59,14 @@ async def generate_title(
 
 async def maybe_generate_title(
     *,
+    title_agent_config: config.AgentConfig,
     threads_engine: sqla_asyncio.AsyncEngine,
-    the_installation,
     room_id: str,
     thread_id: str,
     user_name: str,
     messages: list[agui_core.Message],
 ):
     try:
-        agent_config = the_installation.get_title_agent_config()
-        if agent_config is None:
-            return
-
         async with sqla_asyncio.AsyncSession(
             bind=threads_engine,
         ) as session:
@@ -88,7 +84,7 @@ async def maybe_generate_title(
         ):
             return
 
-        title = await generate_title(agent_config, messages)
+        title = await generate_title(title_agent_config, messages)
         if title is None:
             return
 

--- a/src/soliplex/titles.py
+++ b/src/soliplex/titles.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logfire
+import pydantic
+import pydantic_ai
+from ag_ui import core as agui_core
+
+from soliplex import agents
+from soliplex import config
+
+TITLE_PROMPT = """\
+Generate a short, concise title (max 8 words) for this conversation.
+The title should capture the main topic or intent.
+Return null if there isn't enough context to generate a meaningful title.\
+"""
+
+
+class ThreadTitle(pydantic.BaseModel):
+    title: str | None = None
+
+
+def format_messages(messages: list[agui_core.Message]) -> str:
+    lines = []
+    for msg in messages:
+        if msg.role not in ("user", "assistant"):
+            continue
+        content = msg.content
+        if content is None:
+            continue
+        if isinstance(content, list):
+            parts = [
+                part.text
+                for part in content
+                if isinstance(part, agui_core.TextInputContent)
+            ]
+            content = "\n".join(parts)
+        lines.append(f"{msg.role}: {content}")
+    return "\n".join(lines)
+
+
+async def generate_title(
+    agent_config: config.AgentConfig,
+    messages: list[agui_core.Message],
+) -> str | None:
+    model = agents.make_model(agent_config)
+    agent = pydantic_ai.Agent(
+        model=model,
+        output_type=ThreadTitle,
+        instructions=TITLE_PROMPT,
+    )
+    formatted = format_messages(messages)
+    result = await agent.run(formatted)
+    return result.output.title
+
+
+async def maybe_generate_title(
+    *,
+    the_threads,
+    the_installation,
+    room_id: str,
+    thread_id: str,
+    user_name: str,
+    messages: list[agui_core.Message],
+):
+    try:
+        thread = await the_threads.get_thread(
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+        )
+        if thread.thread_metadata is not None:
+            return
+
+        agent_config = the_installation.get_title_agent_config(
+            room_id,
+        )
+        title = await generate_title(agent_config, messages)
+        if title is None:
+            return
+
+        await the_threads.update_thread_metadata(
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            thread_metadata={"name": title},
+        )
+    except Exception:
+        logfire.exception("Failed to generate thread title")

--- a/src/soliplex/titles.py
+++ b/src/soliplex/titles.py
@@ -67,6 +67,10 @@ async def maybe_generate_title(
     messages: list[agui_core.Message],
 ):
     try:
+        agent_config = the_installation.get_title_agent_config()
+        if agent_config is None:
+            return
+
         async with sqla_asyncio.AsyncSession(
             bind=threads_engine,
         ) as session:
@@ -84,9 +88,6 @@ async def maybe_generate_title(
         ):
             return
 
-        agent_config = the_installation.get_title_agent_config(
-            room_id,
-        )
         title = await generate_title(agent_config, messages)
         if title is None:
             return

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import functools
 
 import fastapi
@@ -8,6 +9,7 @@ import pydantic_ai
 from ag_ui import core as agui_core
 from fastapi import responses
 from pydantic_ai.ui import ag_ui as ai_ag_ui
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agui as agui_package
 from soliplex import authn
@@ -16,6 +18,7 @@ from soliplex import config
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
+from soliplex import titles
 from soliplex import util
 from soliplex import views
 from soliplex.agui import persistence as agui_persistence
@@ -590,9 +593,31 @@ async def post_room_agui_thread_id_run_id(
         run_id=run_id,
     )
 
+    async def save_events_and_maybe_title(*, events):
+        await save_events(events=events)
+
+        async def _do_title():
+            threads_engine = request.state.threads_engine
+            async with sqla_asyncio.AsyncSession(
+                bind=threads_engine,
+            ) as session:
+                bg_threads = agui_persistence.ThreadStorage(
+                    session,
+                )
+                await titles.maybe_generate_title(
+                    the_threads=bg_threads,
+                    the_installation=the_installation,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    user_name=user_name,
+                    messages=agui_adapter.run_input.messages,
+                )
+
+        asyncio.create_task(_do_title())
+
     db_stream = tee_events(
         compacted_stream,
-        on_done=save_events,
+        on_done=save_events_and_maybe_title,
         thread_id=thread_id,
         run_id=run_id,
     )

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -594,27 +594,34 @@ async def post_room_agui_thread_id_run_id(
         run_id=run_id,
     )
 
-    async def save_events_and_maybe_title(*, events):
-        await save_events(events=events)
+    title_agent_config = the_installation.get_title_agent_config()
 
-        async def _do_title():
-            threads_engine = request.state.threads_engine
-            await titles.maybe_generate_title(
-                threads_engine=threads_engine,
-                the_installation=the_installation,
-                room_id=room_id,
-                thread_id=thread_id,
-                user_name=user_name,
-                messages=agui_adapter.run_input.messages,
-            )
+    if title_agent_config is not None:
 
-        task = asyncio.create_task(_do_title())
-        _background_tasks.add(task)
-        task.add_done_callback(_background_tasks.discard)
+        async def on_done(*, events):
+            await save_events(events=events)
+
+            async def _do_title():
+                threads_engine = request.state.threads_engine
+                await titles.maybe_generate_title(
+                    title_agent_config=title_agent_config,
+                    threads_engine=threads_engine,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    user_name=user_name,
+                    messages=agui_adapter.run_input.messages,
+                )
+
+            task = asyncio.create_task(_do_title())
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+
+    else:
+        on_done = save_events
 
     db_stream = tee_events(
         compacted_stream,
-        on_done=save_events_and_maybe_title,
+        on_done=on_done,
         thread_id=thread_id,
         run_id=run_id,
     )

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -9,7 +9,6 @@ import pydantic_ai
 from ag_ui import core as agui_core
 from fastapi import responses
 from pydantic_ai.ui import ag_ui as ai_ag_ui
-from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agui as agui_package
 from soliplex import authn
@@ -24,6 +23,8 @@ from soliplex import views
 from soliplex.agui import persistence as agui_persistence
 
 router = fastapi.APIRouter(tags=["rooms"])
+
+_background_tasks: set[asyncio.Task] = set()
 
 depend_the_installation = installation.depend_the_installation
 depend_the_threads = agui_package.depend_the_threads
@@ -598,22 +599,18 @@ async def post_room_agui_thread_id_run_id(
 
         async def _do_title():
             threads_engine = request.state.threads_engine
-            async with sqla_asyncio.AsyncSession(
-                bind=threads_engine,
-            ) as session:
-                bg_threads = agui_persistence.ThreadStorage(
-                    session,
-                )
-                await titles.maybe_generate_title(
-                    the_threads=bg_threads,
-                    the_installation=the_installation,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    user_name=user_name,
-                    messages=agui_adapter.run_input.messages,
-                )
+            await titles.maybe_generate_title(
+                threads_engine=threads_engine,
+                the_installation=the_installation,
+                room_id=room_id,
+                thread_id=thread_id,
+                user_name=user_name,
+                messages=agui_adapter.run_input.messages,
+            )
 
-        asyncio.create_task(_do_title())
+        task = asyncio.create_task(_do_title())
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     db_stream = tee_events(
         compacted_stream,

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -236,6 +236,69 @@ def test_get_agent_from_configs_wo_hit_w_python_kind():
     )
 
 
+@pytest.mark.parametrize(
+    "provider_type, llm_provider_kw",
+    [
+        (config.LLMProviderType.OLLAMA, OLLAMA_PROVIDER_KW),
+        (config.LLMProviderType.OPENAI, OPENAI_PROVIDER_KW),
+        (config.LLMProviderType.GOOGLE, GOOGLE_PROVIDER_KW),
+    ],
+)
+@mock.patch("pydantic_ai.providers.google.GoogleProvider")
+@mock.patch("pydantic_ai.providers.ollama.OllamaProvider")
+@mock.patch("pydantic_ai.providers.openai.OpenAIProvider")
+@mock.patch("pydantic_ai.models.google.GoogleModel")
+@mock.patch("pydantic_ai.models.openai.OpenAIChatModel")
+def test_make_model(
+    oai_model_klass,
+    google_model_klass,
+    oai_provider_klass,
+    oll_provider_klass,
+    google_provider_klass,
+    provider_type,
+    llm_provider_kw,
+):
+    agent_config = mock.create_autospec(config.AgentConfig)
+    agent_config.model_name = MODEL
+    agent_config.provider_type = provider_type
+    agent_config.llm_provider_kw = llm_provider_kw
+
+    model = agents.make_model(agent_config)
+
+    if provider_type == config.LLMProviderType.GOOGLE:
+        assert model is google_model_klass.return_value
+        google_model_klass.assert_called_once_with(
+            model_name=MODEL,
+            provider=google_provider_klass.return_value,
+        )
+        google_provider_klass.assert_called_once_with(**llm_provider_kw)
+        oai_model_klass.assert_not_called()
+        oai_provider_klass.assert_not_called()
+        oll_provider_klass.assert_not_called()
+
+    elif provider_type == config.LLMProviderType.OPENAI:
+        assert model is oai_model_klass.return_value
+        oai_model_klass.assert_called_once_with(
+            model_name=MODEL,
+            provider=oai_provider_klass.return_value,
+        )
+        oai_provider_klass.assert_called_once_with(**llm_provider_kw)
+        oll_provider_klass.assert_not_called()
+        google_model_klass.assert_not_called()
+        google_provider_klass.assert_not_called()
+
+    else:
+        assert model is oai_model_klass.return_value
+        oai_model_klass.assert_called_once_with(
+            model_name=MODEL,
+            provider=oll_provider_klass.return_value,
+        )
+        oll_provider_klass.assert_called_once_with(**llm_provider_kw)
+        oai_provider_klass.assert_not_called()
+        google_model_klass.assert_not_called()
+        google_provider_klass.assert_not_called()
+
+
 def test_get_agent_from_configs_w_hit():
     expected = object()
     a_config = mock.create_autospec(config.AgentConfig)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1630,6 +1630,17 @@ authorization_dburi:
     async: {RA_DBURI_ASYNC}
 """
 
+TITLE_AGENT_CONFIG_ID = "title-agent"
+
+W_TITLE_AGENT_CONFIG_ID_INSTALLATION_CONFIG_KW = {
+    "id": INSTALLATION_ID,
+    "title_agent_config_id": TITLE_AGENT_CONFIG_ID,
+}
+W_TITLE_AGENT_CONFIG_ID_INSTALLATION_CONFIG_YAML = f"""\
+id: "{INSTALLATION_ID}"
+title_agent_config_id: "{TITLE_AGENT_CONFIG_ID}"
+"""
+
 
 @pytest.fixture
 def installation_config():
@@ -5397,6 +5408,10 @@ def test_installationconfig_authorization_dburi_async(w_kw, expected):
             W_RA_DBURI_W_SECRET_INSTALLATION_CONFIG_YAML,
             W_RA_DBURI_W_SECRET_INSTALLATION_CONFIG_KW.copy(),
         ),
+        (
+            W_TITLE_AGENT_CONFIG_ID_INSTALLATION_CONFIG_YAML,
+            W_TITLE_AGENT_CONFIG_ID_INSTALLATION_CONFIG_KW.copy(),
+        ),
     ],
 )
 def test_installationconfig_from_yaml(
@@ -5556,8 +5571,12 @@ def test_installationconfig_from_yaml_environ_wo_value(temp_dir, config_yaml):
     assert found == expected
 
 
+@pytest.mark.parametrize("w_title_agent_config_id", [False, True])
 @pytest.mark.parametrize("w_logfire_config", [False, True])
-def test_installationconfig_as_yaml(w_logfire_config):
+def test_installationconfig_as_yaml(
+    w_logfire_config,
+    w_title_agent_config_id,
+):
     meta = mock.create_autospec(config.InstallationConfigMeta)
     secret_1 = config.SecretConfig(secret_name="SECRET_ONE")
     secret_2 = config.SecretConfig(secret_name="SECRET_TWO")
@@ -5574,6 +5593,9 @@ def test_installationconfig_as_yaml(w_logfire_config):
         kwargs["logfire_config"] = config.LogfireConfig(
             token="secret:LOGFIRE_TOKEN",
         )
+
+    if w_title_agent_config_id:
+        kwargs["title_agent_config_id"] = TITLE_AGENT_CONFIG_ID
 
     installation_config = config.InstallationConfig(
         id=INSTALLATION_ID,
@@ -5618,6 +5640,9 @@ def test_installationconfig_as_yaml(w_logfire_config):
 
     if w_logfire_config:
         expected["logfire_config"] = W_TOKEN_ONLY_LOGFIRE_CONFIG_AS_YAML
+
+    if w_title_agent_config_id:
+        expected["title_agent_config_id"] = TITLE_AGENT_CONFIG_ID
 
     found = installation_config.as_yaml
 

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -784,6 +784,42 @@ def test_installation_get_agent_by_id(gafc, w_agent_id, raises):
         gafc.assert_called_once_with(a_config, {}, {})
 
 
+def test_installation_get_title_agent_config_w_config_id():
+    title_a_config = mock.create_autospec(config.AgentConfig)
+    room_a_config = mock.create_autospec(config.AgentConfig)
+
+    r_config = mock.create_autospec(config.RoomConfig)
+    r_config.agent_config = room_a_config
+
+    i_config = mock.create_autospec(config.InstallationConfig)
+    i_config.title_agent_config_id = "title-agent"
+    i_config.agent_configs_map = {"title-agent": title_a_config}
+    i_config.room_configs = {"room_id": r_config}
+
+    the_installation = installation.Installation(i_config)
+
+    found = the_installation.get_title_agent_config("room_id")
+
+    assert found is title_a_config
+
+
+def test_installation_get_title_agent_config_wo_config_id():
+    room_a_config = mock.create_autospec(config.AgentConfig)
+
+    r_config = mock.create_autospec(config.RoomConfig)
+    r_config.agent_config = room_a_config
+
+    i_config = mock.create_autospec(config.InstallationConfig)
+    i_config.title_agent_config_id = None
+    i_config.room_configs = {"room_id": r_config}
+
+    the_installation = installation.Installation(i_config)
+
+    found = the_installation.get_title_agent_config("room_id")
+
+    assert found is room_a_config
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize("w_the_logger", [False, True])
 @pytest.mark.parametrize(

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -786,38 +786,27 @@ def test_installation_get_agent_by_id(gafc, w_agent_id, raises):
 
 def test_installation_get_title_agent_config_w_config_id():
     title_a_config = mock.create_autospec(config.AgentConfig)
-    room_a_config = mock.create_autospec(config.AgentConfig)
-
-    r_config = mock.create_autospec(config.RoomConfig)
-    r_config.agent_config = room_a_config
 
     i_config = mock.create_autospec(config.InstallationConfig)
     i_config.title_agent_config_id = "title-agent"
     i_config.agent_configs_map = {"title-agent": title_a_config}
-    i_config.room_configs = {"room_id": r_config}
 
     the_installation = installation.Installation(i_config)
 
-    found = the_installation.get_title_agent_config("room_id")
+    found = the_installation.get_title_agent_config()
 
     assert found is title_a_config
 
 
 def test_installation_get_title_agent_config_wo_config_id():
-    room_a_config = mock.create_autospec(config.AgentConfig)
-
-    r_config = mock.create_autospec(config.RoomConfig)
-    r_config.agent_config = room_a_config
-
     i_config = mock.create_autospec(config.InstallationConfig)
     i_config.title_agent_config_id = None
-    i_config.room_configs = {"room_id": r_config}
 
     the_installation = installation.Installation(i_config)
 
-    found = the_installation.get_title_agent_config("room_id")
+    found = the_installation.get_title_agent_config()
 
-    assert found is room_a_config
+    assert found is None
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_titles.py
+++ b/tests/unit/test_titles.py
@@ -3,8 +3,51 @@ from unittest import mock
 import pydantic
 import pytest
 from ag_ui import core as agui_core
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import titles
+
+
+def _awaitable(value):
+    async def getter():
+        return value
+
+    return getter()
+
+
+@pytest.fixture
+def threads_engine():
+    return mock.create_autospec(sqla_asyncio.AsyncEngine)
+
+
+@pytest.fixture
+def the_threads():
+    return mock.AsyncMock()
+
+
+@pytest.fixture
+def mock_async_session(the_threads):
+    """Patch AsyncSession to yield our mock ThreadStorage."""
+
+    class FakeSession:
+        async def __aenter__(self):
+            return mock.MagicMock()
+
+        async def __aexit__(self, *args):
+            pass
+
+    return mock.patch(
+        "soliplex.titles.sqla_asyncio.AsyncSession",
+        return_value=FakeSession(),
+    )
+
+
+@pytest.fixture
+def mock_thread_storage(the_threads):
+    return mock.patch(
+        "soliplex.titles.agui_persistence.ThreadStorage",
+        return_value=the_threads,
+    )
 
 
 class TestThreadTitle:
@@ -142,6 +185,10 @@ class TestMaybeGenerateTitle:
     async def test_generates_and_updates(
         self,
         gen_title,
+        threads_engine,
+        the_threads,
+        mock_async_session,
+        mock_thread_storage,
     ):
         gen_title.return_value = "My Chat Title"
 
@@ -150,23 +197,22 @@ class TestMaybeGenerateTitle:
         the_installation.get_title_agent_config.return_value = agent_config
 
         thread = mock.MagicMock()
-        thread.thread_metadata = None
-
-        the_threads = mock.AsyncMock()
+        thread.awaitable_attrs.thread_metadata = _awaitable(None)
         the_threads.get_thread.return_value = thread
 
         messages = [
             agui_core.UserMessage(id="1", content="Hello"),
         ]
 
-        await titles.maybe_generate_title(
-            the_threads=the_threads,
-            the_installation=the_installation,
-            room_id="room1",
-            thread_id="thread1",
-            user_name="user1",
-            messages=messages,
-        )
+        with mock_async_session, mock_thread_storage:
+            await titles.maybe_generate_title(
+                threads_engine=threads_engine,
+                the_installation=the_installation,
+                room_id="room1",
+                thread_id="thread1",
+                user_name="user1",
+                messages=messages,
+            )
 
         the_threads.get_thread.assert_awaited_once_with(
             user_name="user1",
@@ -186,39 +232,89 @@ class TestMaybeGenerateTitle:
 
     @pytest.mark.anyio
     @mock.patch("soliplex.titles.generate_title")
-    async def test_skips_when_metadata_exists(
+    async def test_skips_when_title_already_set(
         self,
         gen_title,
+        threads_engine,
+        the_threads,
+        mock_async_session,
+        mock_thread_storage,
     ):
         the_installation = mock.MagicMock()
 
+        metadata = mock.MagicMock()
+        metadata.name = "Existing Title"
         thread = mock.MagicMock()
-        thread.thread_metadata = mock.MagicMock()
-
-        the_threads = mock.AsyncMock()
+        thread.awaitable_attrs.thread_metadata = _awaitable(metadata)
         the_threads.get_thread.return_value = thread
 
         messages = [
             agui_core.UserMessage(id="1", content="Hello"),
         ]
 
-        await titles.maybe_generate_title(
-            the_threads=the_threads,
-            the_installation=the_installation,
-            room_id="room1",
-            thread_id="thread1",
-            user_name="user1",
-            messages=messages,
-        )
+        with mock_async_session, mock_thread_storage:
+            await titles.maybe_generate_title(
+                threads_engine=threads_engine,
+                the_installation=the_installation,
+                room_id="room1",
+                thread_id="thread1",
+                user_name="user1",
+                messages=messages,
+            )
 
         gen_title.assert_not_awaited()
         the_threads.update_thread_metadata.assert_not_awaited()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("name", [None, titles.DEFAULT_THREAD_NAME])
+    @mock.patch("soliplex.titles.generate_title")
+    async def test_generates_when_no_title_set(
+        self,
+        gen_title,
+        name,
+        threads_engine,
+        the_threads,
+        mock_async_session,
+        mock_thread_storage,
+    ):
+        gen_title.return_value = "New Title"
+
+        agent_config = mock.MagicMock()
+        the_installation = mock.MagicMock()
+        the_installation.get_title_agent_config.return_value = agent_config
+
+        metadata = mock.MagicMock()
+        metadata.name = name
+        thread = mock.MagicMock()
+        thread.awaitable_attrs.thread_metadata = _awaitable(metadata)
+        the_threads.get_thread.return_value = thread
+
+        messages = [
+            agui_core.UserMessage(id="1", content="Hello"),
+        ]
+
+        with mock_async_session, mock_thread_storage:
+            await titles.maybe_generate_title(
+                threads_engine=threads_engine,
+                the_installation=the_installation,
+                room_id="room1",
+                thread_id="thread1",
+                user_name="user1",
+                messages=messages,
+            )
+
+        gen_title.assert_awaited_once()
+        the_threads.update_thread_metadata.assert_awaited_once()
 
     @pytest.mark.anyio
     @mock.patch("soliplex.titles.generate_title")
     async def test_skips_update_when_title_is_none(
         self,
         gen_title,
+        threads_engine,
+        the_threads,
+        mock_async_session,
+        mock_thread_storage,
     ):
         gen_title.return_value = None
 
@@ -227,23 +323,22 @@ class TestMaybeGenerateTitle:
         the_installation.get_title_agent_config.return_value = agent_config
 
         thread = mock.MagicMock()
-        thread.thread_metadata = None
-
-        the_threads = mock.AsyncMock()
+        thread.awaitable_attrs.thread_metadata = _awaitable(None)
         the_threads.get_thread.return_value = thread
 
         messages = [
             agui_core.UserMessage(id="1", content="Hello"),
         ]
 
-        await titles.maybe_generate_title(
-            the_threads=the_threads,
-            the_installation=the_installation,
-            room_id="room1",
-            thread_id="thread1",
-            user_name="user1",
-            messages=messages,
-        )
+        with mock_async_session, mock_thread_storage:
+            await titles.maybe_generate_title(
+                threads_engine=threads_engine,
+                the_installation=the_installation,
+                room_id="room1",
+                thread_id="thread1",
+                user_name="user1",
+                messages=messages,
+            )
 
         gen_title.assert_awaited_once()
         the_threads.update_thread_metadata.assert_not_awaited()
@@ -255,6 +350,10 @@ class TestMaybeGenerateTitle:
         self,
         gen_title,
         logfire_exception,
+        threads_engine,
+        the_threads,
+        mock_async_session,
+        mock_thread_storage,
     ):
         gen_title.side_effect = RuntimeError("LLM error")
 
@@ -263,22 +362,21 @@ class TestMaybeGenerateTitle:
         the_installation.get_title_agent_config.return_value = agent_config
 
         thread = mock.MagicMock()
-        thread.thread_metadata = None
-
-        the_threads = mock.AsyncMock()
+        thread.awaitable_attrs.thread_metadata = _awaitable(None)
         the_threads.get_thread.return_value = thread
 
         messages = [
             agui_core.UserMessage(id="1", content="Hello"),
         ]
 
-        await titles.maybe_generate_title(
-            the_threads=the_threads,
-            the_installation=the_installation,
-            room_id="room1",
-            thread_id="thread1",
-            user_name="user1",
-            messages=messages,
-        )
+        with mock_async_session, mock_thread_storage:
+            await titles.maybe_generate_title(
+                threads_engine=threads_engine,
+                the_installation=the_installation,
+                room_id="room1",
+                thread_id="thread1",
+                user_name="user1",
+                messages=messages,
+            )
 
         logfire_exception.assert_called_once()

--- a/tests/unit/test_titles.py
+++ b/tests/unit/test_titles.py
@@ -1,0 +1,284 @@
+from unittest import mock
+
+import pydantic
+import pytest
+from ag_ui import core as agui_core
+
+from soliplex import titles
+
+
+class TestThreadTitle:
+    def test_title_none_by_default(self):
+        tt = titles.ThreadTitle()
+        assert tt.title is None
+
+    def test_title_with_value(self):
+        tt = titles.ThreadTitle(title="My Title")
+        assert tt.title == "My Title"
+
+    def test_is_pydantic_model(self):
+        assert issubclass(titles.ThreadTitle, pydantic.BaseModel)
+
+
+class TestFormatMessages:
+    def test_empty_messages(self):
+        assert titles.format_messages([]) == ""
+
+    def test_user_message_with_str_content(self):
+        msg = agui_core.UserMessage(
+            id="1",
+            content="Hello there",
+        )
+        result = titles.format_messages([msg])
+        assert result == "user: Hello there"
+
+    def test_assistant_message(self):
+        msg = agui_core.AssistantMessage(
+            id="1",
+            content="Hi! How can I help?",
+        )
+        result = titles.format_messages([msg])
+        assert result == "assistant: Hi! How can I help?"
+
+    def test_mixed_messages(self):
+        msgs = [
+            agui_core.UserMessage(id="1", content="Hello"),
+            agui_core.AssistantMessage(id="2", content="Hi!"),
+            agui_core.UserMessage(id="3", content="How are you?"),
+        ]
+        result = titles.format_messages(msgs)
+        expected = "user: Hello\nassistant: Hi!\nuser: How are you?"
+        assert result == expected
+
+    def test_skips_non_user_assistant_messages(self):
+        msgs = [
+            agui_core.SystemMessage(id="0", content="System prompt"),
+            agui_core.UserMessage(id="1", content="Hello"),
+            agui_core.ToolMessage(
+                id="2",
+                content="tool result",
+                tool_call_id="tc1",
+            ),
+            agui_core.AssistantMessage(id="3", content="Response"),
+        ]
+        result = titles.format_messages(msgs)
+        assert result == "user: Hello\nassistant: Response"
+
+    def test_skips_messages_with_none_content(self):
+        msgs = [
+            agui_core.AssistantMessage(id="1", content=None),
+            agui_core.UserMessage(id="2", content="Hello"),
+        ]
+        result = titles.format_messages([msgs[0], msgs[1]])
+        assert result == "user: Hello"
+
+    def test_user_message_with_list_content(self):
+        msg = agui_core.UserMessage(
+            id="1",
+            content=[
+                agui_core.TextInputContent(text="Part one"),
+                agui_core.BinaryInputContent(
+                    mime_type="image/png",
+                    data="abc",
+                ),
+                agui_core.TextInputContent(text="Part two"),
+            ],
+        )
+        result = titles.format_messages([msg])
+        assert result == "user: Part one\nPart two"
+
+
+class TestGenerateTitle:
+    @pytest.mark.anyio
+    @mock.patch("pydantic_ai.Agent")
+    @mock.patch("soliplex.agents.make_model")
+    async def test_returns_title(self, make_model, agent_klass):
+        agent_config = mock.MagicMock()
+        messages = [
+            agui_core.UserMessage(id="1", content="Hello"),
+            agui_core.AssistantMessage(id="2", content="Hi!"),
+        ]
+
+        run_result = mock.MagicMock()
+        run_result.output = titles.ThreadTitle(title="Greeting")
+        agent_klass.return_value.run = mock.AsyncMock(
+            return_value=run_result,
+        )
+
+        result = await titles.generate_title(agent_config, messages)
+
+        assert result == "Greeting"
+        make_model.assert_called_once_with(agent_config)
+        agent_klass.assert_called_once_with(
+            model=make_model.return_value,
+            output_type=titles.ThreadTitle,
+            instructions=titles.TITLE_PROMPT,
+        )
+        agent_klass.return_value.run.assert_awaited_once()
+
+    @pytest.mark.anyio
+    @mock.patch("pydantic_ai.Agent")
+    @mock.patch("soliplex.agents.make_model")
+    async def test_returns_none(self, make_model, agent_klass):
+        agent_config = mock.MagicMock()
+        messages = [
+            agui_core.UserMessage(id="1", content="Hi"),
+        ]
+
+        run_result = mock.MagicMock()
+        run_result.output = titles.ThreadTitle(title=None)
+        agent_klass.return_value.run = mock.AsyncMock(
+            return_value=run_result,
+        )
+
+        result = await titles.generate_title(agent_config, messages)
+
+        assert result is None
+
+
+class TestMaybeGenerateTitle:
+    @pytest.mark.anyio
+    @mock.patch("soliplex.titles.generate_title")
+    async def test_generates_and_updates(
+        self,
+        gen_title,
+    ):
+        gen_title.return_value = "My Chat Title"
+
+        agent_config = mock.MagicMock()
+        the_installation = mock.MagicMock()
+        the_installation.get_title_agent_config.return_value = agent_config
+
+        thread = mock.MagicMock()
+        thread.thread_metadata = None
+
+        the_threads = mock.AsyncMock()
+        the_threads.get_thread.return_value = thread
+
+        messages = [
+            agui_core.UserMessage(id="1", content="Hello"),
+        ]
+
+        await titles.maybe_generate_title(
+            the_threads=the_threads,
+            the_installation=the_installation,
+            room_id="room1",
+            thread_id="thread1",
+            user_name="user1",
+            messages=messages,
+        )
+
+        the_threads.get_thread.assert_awaited_once_with(
+            user_name="user1",
+            room_id="room1",
+            thread_id="thread1",
+        )
+        the_installation.get_title_agent_config.assert_called_once_with(
+            "room1",
+        )
+        gen_title.assert_awaited_once_with(agent_config, messages)
+        the_threads.update_thread_metadata.assert_awaited_once_with(
+            user_name="user1",
+            room_id="room1",
+            thread_id="thread1",
+            thread_metadata={"name": "My Chat Title"},
+        )
+
+    @pytest.mark.anyio
+    @mock.patch("soliplex.titles.generate_title")
+    async def test_skips_when_metadata_exists(
+        self,
+        gen_title,
+    ):
+        the_installation = mock.MagicMock()
+
+        thread = mock.MagicMock()
+        thread.thread_metadata = mock.MagicMock()
+
+        the_threads = mock.AsyncMock()
+        the_threads.get_thread.return_value = thread
+
+        messages = [
+            agui_core.UserMessage(id="1", content="Hello"),
+        ]
+
+        await titles.maybe_generate_title(
+            the_threads=the_threads,
+            the_installation=the_installation,
+            room_id="room1",
+            thread_id="thread1",
+            user_name="user1",
+            messages=messages,
+        )
+
+        gen_title.assert_not_awaited()
+        the_threads.update_thread_metadata.assert_not_awaited()
+
+    @pytest.mark.anyio
+    @mock.patch("soliplex.titles.generate_title")
+    async def test_skips_update_when_title_is_none(
+        self,
+        gen_title,
+    ):
+        gen_title.return_value = None
+
+        agent_config = mock.MagicMock()
+        the_installation = mock.MagicMock()
+        the_installation.get_title_agent_config.return_value = agent_config
+
+        thread = mock.MagicMock()
+        thread.thread_metadata = None
+
+        the_threads = mock.AsyncMock()
+        the_threads.get_thread.return_value = thread
+
+        messages = [
+            agui_core.UserMessage(id="1", content="Hello"),
+        ]
+
+        await titles.maybe_generate_title(
+            the_threads=the_threads,
+            the_installation=the_installation,
+            room_id="room1",
+            thread_id="thread1",
+            user_name="user1",
+            messages=messages,
+        )
+
+        gen_title.assert_awaited_once()
+        the_threads.update_thread_metadata.assert_not_awaited()
+
+    @pytest.mark.anyio
+    @mock.patch("logfire.exception")
+    @mock.patch("soliplex.titles.generate_title")
+    async def test_logs_exception_on_error(
+        self,
+        gen_title,
+        logfire_exception,
+    ):
+        gen_title.side_effect = RuntimeError("LLM error")
+
+        agent_config = mock.MagicMock()
+        the_installation = mock.MagicMock()
+        the_installation.get_title_agent_config.return_value = agent_config
+
+        thread = mock.MagicMock()
+        thread.thread_metadata = None
+
+        the_threads = mock.AsyncMock()
+        the_threads.get_thread.return_value = thread
+
+        messages = [
+            agui_core.UserMessage(id="1", content="Hello"),
+        ]
+
+        await titles.maybe_generate_title(
+            the_threads=the_threads,
+            the_installation=the_installation,
+            room_id="room1",
+            thread_id="thread1",
+            user_name="user1",
+            messages=messages,
+        )
+
+        logfire_exception.assert_called_once()

--- a/tests/unit/test_titles.py
+++ b/tests/unit/test_titles.py
@@ -192,9 +192,7 @@ class TestMaybeGenerateTitle:
     ):
         gen_title.return_value = "My Chat Title"
 
-        agent_config = mock.MagicMock()
-        the_installation = mock.MagicMock()
-        the_installation.get_title_agent_config.return_value = agent_config
+        title_agent_config = mock.MagicMock()
 
         thread = mock.MagicMock()
         thread.awaitable_attrs.thread_metadata = _awaitable(None)
@@ -206,8 +204,8 @@ class TestMaybeGenerateTitle:
 
         with mock_async_session, mock_thread_storage:
             await titles.maybe_generate_title(
+                title_agent_config=title_agent_config,
                 threads_engine=threads_engine,
-                the_installation=the_installation,
                 room_id="room1",
                 thread_id="thread1",
                 user_name="user1",
@@ -219,44 +217,16 @@ class TestMaybeGenerateTitle:
             room_id="room1",
             thread_id="thread1",
         )
-        the_installation.get_title_agent_config.assert_called_once_with()
-        gen_title.assert_awaited_once_with(agent_config, messages)
+        gen_title.assert_awaited_once_with(
+            title_agent_config,
+            messages,
+        )
         the_threads.update_thread_metadata.assert_awaited_once_with(
             user_name="user1",
             room_id="room1",
             thread_id="thread1",
             thread_metadata={"name": "My Chat Title"},
         )
-
-    @pytest.mark.anyio
-    @mock.patch("soliplex.titles.generate_title")
-    async def test_skips_when_not_configured(
-        self,
-        gen_title,
-        threads_engine,
-        the_threads,
-        mock_async_session,
-        mock_thread_storage,
-    ):
-        the_installation = mock.MagicMock()
-        the_installation.get_title_agent_config.return_value = None
-
-        messages = [
-            agui_core.UserMessage(id="1", content="Hello"),
-        ]
-
-        with mock_async_session, mock_thread_storage:
-            await titles.maybe_generate_title(
-                threads_engine=threads_engine,
-                the_installation=the_installation,
-                room_id="room1",
-                thread_id="thread1",
-                user_name="user1",
-                messages=messages,
-            )
-
-        the_threads.get_thread.assert_not_awaited()
-        gen_title.assert_not_awaited()
 
     @pytest.mark.anyio
     @mock.patch("soliplex.titles.generate_title")
@@ -268,8 +238,6 @@ class TestMaybeGenerateTitle:
         mock_async_session,
         mock_thread_storage,
     ):
-        the_installation = mock.MagicMock()
-
         metadata = mock.MagicMock()
         metadata.name = "Existing Title"
         thread = mock.MagicMock()
@@ -282,8 +250,8 @@ class TestMaybeGenerateTitle:
 
         with mock_async_session, mock_thread_storage:
             await titles.maybe_generate_title(
+                title_agent_config=mock.MagicMock(),
                 threads_engine=threads_engine,
-                the_installation=the_installation,
                 room_id="room1",
                 thread_id="thread1",
                 user_name="user1",
@@ -307,10 +275,6 @@ class TestMaybeGenerateTitle:
     ):
         gen_title.return_value = "New Title"
 
-        agent_config = mock.MagicMock()
-        the_installation = mock.MagicMock()
-        the_installation.get_title_agent_config.return_value = agent_config
-
         metadata = mock.MagicMock()
         metadata.name = name
         thread = mock.MagicMock()
@@ -323,8 +287,8 @@ class TestMaybeGenerateTitle:
 
         with mock_async_session, mock_thread_storage:
             await titles.maybe_generate_title(
+                title_agent_config=mock.MagicMock(),
                 threads_engine=threads_engine,
-                the_installation=the_installation,
                 room_id="room1",
                 thread_id="thread1",
                 user_name="user1",
@@ -346,10 +310,6 @@ class TestMaybeGenerateTitle:
     ):
         gen_title.return_value = None
 
-        agent_config = mock.MagicMock()
-        the_installation = mock.MagicMock()
-        the_installation.get_title_agent_config.return_value = agent_config
-
         thread = mock.MagicMock()
         thread.awaitable_attrs.thread_metadata = _awaitable(None)
         the_threads.get_thread.return_value = thread
@@ -360,8 +320,8 @@ class TestMaybeGenerateTitle:
 
         with mock_async_session, mock_thread_storage:
             await titles.maybe_generate_title(
+                title_agent_config=mock.MagicMock(),
                 threads_engine=threads_engine,
-                the_installation=the_installation,
                 room_id="room1",
                 thread_id="thread1",
                 user_name="user1",
@@ -385,10 +345,6 @@ class TestMaybeGenerateTitle:
     ):
         gen_title.side_effect = RuntimeError("LLM error")
 
-        agent_config = mock.MagicMock()
-        the_installation = mock.MagicMock()
-        the_installation.get_title_agent_config.return_value = agent_config
-
         thread = mock.MagicMock()
         thread.awaitable_attrs.thread_metadata = _awaitable(None)
         the_threads.get_thread.return_value = thread
@@ -399,8 +355,8 @@ class TestMaybeGenerateTitle:
 
         with mock_async_session, mock_thread_storage:
             await titles.maybe_generate_title(
+                title_agent_config=mock.MagicMock(),
                 threads_engine=threads_engine,
-                the_installation=the_installation,
                 room_id="room1",
                 thread_id="thread1",
                 user_name="user1",

--- a/tests/unit/test_titles.py
+++ b/tests/unit/test_titles.py
@@ -219,9 +219,7 @@ class TestMaybeGenerateTitle:
             room_id="room1",
             thread_id="thread1",
         )
-        the_installation.get_title_agent_config.assert_called_once_with(
-            "room1",
-        )
+        the_installation.get_title_agent_config.assert_called_once_with()
         gen_title.assert_awaited_once_with(agent_config, messages)
         the_threads.update_thread_metadata.assert_awaited_once_with(
             user_name="user1",
@@ -229,6 +227,36 @@ class TestMaybeGenerateTitle:
             thread_id="thread1",
             thread_metadata={"name": "My Chat Title"},
         )
+
+    @pytest.mark.anyio
+    @mock.patch("soliplex.titles.generate_title")
+    async def test_skips_when_not_configured(
+        self,
+        gen_title,
+        threads_engine,
+        the_threads,
+        mock_async_session,
+        mock_thread_storage,
+    ):
+        the_installation = mock.MagicMock()
+        the_installation.get_title_agent_config.return_value = None
+
+        messages = [
+            agui_core.UserMessage(id="1", content="Hello"),
+        ]
+
+        with mock_async_session, mock_thread_storage:
+            await titles.maybe_generate_title(
+                threads_engine=threads_engine,
+                the_installation=the_installation,
+                room_id="room1",
+                thread_id="thread1",
+                user_name="user1",
+                messages=messages,
+            )
+
+        the_threads.get_thread.assert_not_awaited()
+        gen_title.assert_not_awaited()
 
     @pytest.mark.anyio
     @mock.patch("soliplex.titles.generate_title")

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1,11 +1,11 @@
 import contextlib
 import datetime
-import functools
 from unittest import mock
 
 import fastapi
 import pytest
 from ag_ui import core as agui_core
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agui as agui_package
 from soliplex import authz as authz_package
@@ -963,7 +963,12 @@ async def test_tee_events(logfire, w_finished_error, w_event_count):
 @mock.patch("soliplex.agui.compact_event_stream")
 @mock.patch("soliplex.views.agui._check_user_room_agent")
 @mock.patch("soliplex.views.agui.tee_events")
+@mock.patch(
+    "soliplex.views.agui.titles.maybe_generate_title",
+    new_callable=mock.AsyncMock,
+)
 async def test_post_room_agui_thread_id_run_id(
+    maybe_gen_title,
     tee,
     cura,
     ces,
@@ -981,6 +986,10 @@ async def test_post_room_agui_thread_id_run_id(
     cura.return_value = (USER_PROFILE, agent)
 
     request = fastapi.Request(scope={"type": "http"})
+    threads_engine = mock.create_autospec(
+        sqla_asyncio.AsyncEngine,
+    )
+    request.state.threads_engine = threads_engine
 
     the_installation = mock.create_autospec(installation.Installation)
     the_installation.get_agent_for_room.return_value = agent
@@ -1034,14 +1043,31 @@ async def test_post_room_agui_thread_id_run_id(
         assert event_stream is ces.return_value
 
         on_done = tee.call_args_list[0].kwargs["on_done"]
-        assert isinstance(on_done, functools.partial)
-        assert on_done.func is the_threads.save_run_events
-        assert on_done.keywords == {
-            "user_name": USER_NAME,
-            "room_id": TEST_ROOM_ID,
-            "thread_id": TEST_THREAD_ID,
-            "run_id": TEST_RUN_ID,
-        }
+
+        test_events = [object()]
+        with mock.patch("asyncio.create_task") as ct:
+            await on_done(events=test_events)
+
+        the_threads.save_run_events.assert_awaited_once_with(
+            events=test_events,
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            run_id=TEST_RUN_ID,
+        )
+
+        ct.assert_called_once()
+        title_coro = ct.call_args[0][0]
+        await title_coro
+
+        maybe_gen_title.assert_awaited_once_with(
+            the_threads=mock.ANY,
+            the_installation=the_installation,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            user_name=USER_NAME,
+            messages=exp_adapter.run_input.messages,
+        )
 
         ces.assert_called_once_with(exp_agent_stream)
 

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -958,6 +958,7 @@ async def test_tee_events(logfire, w_finished_error, w_event_count):
     ],
 )
 @pytest.mark.parametrize("w_usage", [False, True])
+@pytest.mark.parametrize("w_title_config", [False, True])
 @mock.patch("fastapi.responses.StreamingResponse")
 @mock.patch("pydantic_ai.ui.ag_ui.AGUIAdapter")
 @mock.patch("soliplex.agui.compact_event_stream")
@@ -977,6 +978,7 @@ async def test_post_room_agui_thread_id_run_id(
     the_threads,
     test_run,
     run_input,
+    w_title_config,
     w_usage,
     ari_side_effect,
     expectation,
@@ -993,6 +995,8 @@ async def test_post_room_agui_thread_id_run_id(
 
     the_installation = mock.create_autospec(installation.Installation)
     the_installation.get_agent_for_room.return_value = agent
+    if not w_title_config:
+        the_installation.get_title_agent_config.return_value = None
     the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
     the_logger = mock.create_autospec(loggers.LogWrapper)
 
@@ -1056,18 +1060,25 @@ async def test_post_room_agui_thread_id_run_id(
             run_id=TEST_RUN_ID,
         )
 
-        ct.assert_called_once()
-        title_coro = ct.call_args[0][0]
-        await title_coro
+        if w_title_config:
+            ct.assert_called_once()
+            title_coro = ct.call_args[0][0]
+            await title_coro
 
-        maybe_gen_title.assert_awaited_once_with(
-            threads_engine=threads_engine,
-            the_installation=the_installation,
-            room_id=TEST_ROOM_ID,
-            thread_id=TEST_THREAD_ID,
-            user_name=USER_NAME,
-            messages=exp_adapter.run_input.messages,
-        )
+            exp_title_config = (
+                the_installation.get_title_agent_config.return_value
+            )
+            maybe_gen_title.assert_awaited_once_with(
+                title_agent_config=exp_title_config,
+                threads_engine=threads_engine,
+                room_id=TEST_ROOM_ID,
+                thread_id=TEST_THREAD_ID,
+                user_name=USER_NAME,
+                messages=exp_adapter.run_input.messages,
+            )
+        else:
+            ct.assert_not_called()
+            maybe_gen_title.assert_not_awaited()
 
         ces.assert_called_once_with(exp_agent_stream)
 

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1061,7 +1061,7 @@ async def test_post_room_agui_thread_id_run_id(
         await title_coro
 
         maybe_gen_title.assert_awaited_once_with(
-            the_threads=mock.ANY,
+            threads_engine=threads_engine,
             the_installation=the_installation,
             room_id=TEST_ROOM_ID,
             thread_id=TEST_THREAD_ID,


### PR DESCRIPTION
- Generate thread titles automatically using an LLM after each agui run completes
- Title generation runs as a background task
- Configurable via title_agent_config_id in the installation config; disabled when not set

Title will be visible to the client after a refresh of the conversation, since when the title is generated the run has already ended and we cannot emit ag-ui events.

