### PR TITLE
feat: 'config.LogfireConfig.send_to_logfire'

### DIFF
--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -1684,6 +1684,7 @@ class LogfireInstrumentFastAPI:
 
 @dataclasses.dataclass(kw_only=True)
 class LogfireConfig:
+    send_to_logfire: bool | None = None
     token: str  # "secret:LOGFIRE_TOKEN" or similar
     service_name: str = "env:LOGFIRE_SERVICE_NAME"
     service_version: str = "env:LOGFIRE_SERVICE_VERSION"
@@ -1728,6 +1729,8 @@ class LogfireConfig:
             "min_level": maybe_getenv(self.min_level),
             "add_baggage_to_attributes": self.add_baggage_to_attributes,
         }
+        if self.send_to_logfire is not None:
+            kwargs["send_to_logfire"] = self.send_to_logfire
 
         if self.inspect_arguments is not None:
             kwargs["inspect_arguments"] = self.inspect_arguments
@@ -1759,6 +1762,9 @@ class LogfireConfig:
             "min_level": self.min_level,
             "add_baggage_to_attributes": self.add_baggage_to_attributes,
         }
+
+        if self.send_to_logfire is not None:
+            result["send_to_logfire"] = self.send_to_logfire
 
         if self.inspect_arguments is not None:
             result["inspect_arguments"] = self.inspect_arguments

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -827,6 +827,37 @@ TEST_LOGFIRE_IC_DEFAULT_ENV = {
     "LOGFIRE_MIN_LEVEL": TEST_LOGFIRE_MIN_LEVEL,
 }
 
+W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_INIT_KW = {
+    "send_to_logfire": False,
+    "token": "secret:LOGFIRE_TOKEN",
+}
+W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_YAML = """\
+send_to_logfire: false
+token: "secret:LOGFIRE_TOKEN"
+"""
+W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_EXP_LC_KWARGS = {
+    "send_to_logfire": False,
+    "token": TEST_LOGFIRE_TOKEN,
+    "service_name": TEST_LOGFIRE_SERVICE_NAME,
+    "service_version": TEST_LOGFIRE_SERVICE_VERSION,
+    "environment": TEST_LOGFIRE_ENVIRONMENT,
+    "config_dir": TEST_LOGFIRE_CONFIG_DIR,
+    "data_dir": TEST_LOGFIRE_DATA_DIR,
+    "min_level": TEST_LOGFIRE_MIN_LEVEL,
+    "add_baggage_to_attributes": True,
+}
+W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_AS_YAML = {
+    "send_to_logfire": False,
+    "token": "secret:LOGFIRE_TOKEN",
+    "service_name": "env:LOGFIRE_SERVICE_NAME",
+    "service_version": "env:LOGFIRE_SERVICE_VERSION",
+    "environment": "env:LOGFIRE_ENVIRONMENT",
+    "config_dir": "env:LOGFIRE_CONFIG_DIR",
+    "data_dir": "env:LOGFIRE_DATA_DIR",
+    "min_level": "env:LOGFIRE_MIN_LEVEL",
+    "add_baggage_to_attributes": True,
+}
+
 W_TOKEN_ONLY_LOGFIRE_CONFIG_INIT_KW = {
     "token": "secret:LOGFIRE_TOKEN",
 }
@@ -4067,6 +4098,12 @@ def test_lfifapi_from_yaml(
     "init_kw, ic_secrets, ic_env, expected",
     [
         (
+            W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_INIT_KW,
+            TEST_LOGFIRE_IC_DEFAULT_SECRETS,
+            TEST_LOGFIRE_IC_DEFAULT_ENV,
+            W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_EXP_LC_KWARGS,
+        ),
+        (
             W_TOKEN_ONLY_LOGFIRE_CONFIG_INIT_KW,
             TEST_LOGFIRE_IC_DEFAULT_SECRETS,
             TEST_LOGFIRE_IC_DEFAULT_ENV,
@@ -4124,6 +4161,10 @@ def test_logfireconfig_logfire_config_kwargs(
     "init_kw, expected",
     [
         (
+            W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_INIT_KW,
+            W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_AS_YAML,
+        ),
+        (
             W_TOKEN_ONLY_LOGFIRE_CONFIG_INIT_KW,
             W_TOKEN_ONLY_LOGFIRE_CONFIG_AS_YAML,
         ),
@@ -4172,6 +4213,10 @@ def test_logfireconfig_logfire_as_yaml(
     "config_yaml, expected_kw",
     [
         (EMPTY_LOGFIRE_CONFIG_YAML, None),
+        (
+            W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_YAML,
+            W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_INIT_KW,
+        ),
         (
             W_TOKEN_ONLY_LOGFIRE_CONFIG_YAML,
             W_TOKEN_ONLY_LOGFIRE_CONFIG_INIT_KW,


### PR DESCRIPTION
Allow explicitly disabling send to Logfire, even when the 'LOGFIRE_TOKEN' secret is present in the environment / config.

Closes #652.