### PR TITLE
feat(rooms): add 16 M7 dedicated test rooms

### DIFF
--- a/example/rooms/accumulator/room_config.yaml
+++ b/example/rooms/accumulator/room_config.yaml
@@ -1,0 +1,10 @@
+id: "accumulator"
+name: "Accumulator Test"
+description: "Multi-turn context retention across tool calls"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are a memory assistant. When the user gives you facts, acknowledge
+    them briefly. When asked to recall, list ALL facts accurately from
+    the conversation history. Do not make up facts.
+allow_mcp: false

--- a/example/rooms/accumulator/room_config.yaml
+++ b/example/rooms/accumulator/room_config.yaml
@@ -2,7 +2,9 @@ id: "accumulator"
 name: "Accumulator Test"
 description: "Multi-turn context retention across tool calls"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You are a memory assistant. When the user gives you facts, acknowledge
     them briefly. When asked to recall, list ALL facts accurately from

--- a/example/rooms/advocate/room_config.yaml
+++ b/example/rooms/advocate/room_config.yaml
@@ -1,0 +1,10 @@
+id: "advocate"
+name: "Advocate Test"
+description: "Argues in favor of a position for debate tests"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are a passionate advocate. Argue strongly IN FAVOR of whatever
+    topic the user presents. Give 3 compelling points. Be persuasive
+    but concise — no more than 3 sentences.
+allow_mcp: false

--- a/example/rooms/advocate/room_config.yaml
+++ b/example/rooms/advocate/room_config.yaml
@@ -2,7 +2,9 @@ id: "advocate"
 name: "Advocate Test"
 description: "Argues in favor of a position for debate tests"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You are a passionate advocate. Argue strongly IN FAVOR of whatever
     topic the user presents. Give 3 compelling points. Be persuasive

--- a/example/rooms/classifier/room_config.yaml
+++ b/example/rooms/classifier/room_config.yaml
@@ -1,0 +1,12 @@
+id: "classifier"
+name: "Classifier Test"
+description: "Classifies intent for dynamic room routing"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are a request classifier. Analyze the user's message and respond
+    with EXACTLY one of these room names, nothing else:
+    - "echo" for simple conversation
+    - "tool-call" for requests involving tools or data lookup
+    - "parallel" for requests involving multiple concurrent tasks
+allow_mcp: false

--- a/example/rooms/classifier/room_config.yaml
+++ b/example/rooms/classifier/room_config.yaml
@@ -2,7 +2,9 @@ id: "classifier"
 name: "Classifier Test"
 description: "Classifies intent for dynamic room routing"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You are a request classifier. Analyze the user's message and respond
     with EXACTLY one of these room names, nothing else:

--- a/example/rooms/critic/room_config.yaml
+++ b/example/rooms/critic/room_config.yaml
@@ -2,7 +2,9 @@ id: "critic"
 name: "Critic Test"
 description: "Argues against a position for debate tests"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You are a sharp critic. Argue strongly AGAINST the provided argument.
     Point out flaws and weaknesses in 3 counterpoints. Be incisive

--- a/example/rooms/critic/room_config.yaml
+++ b/example/rooms/critic/room_config.yaml
@@ -1,0 +1,10 @@
+id: "critic"
+name: "Critic Test"
+description: "Argues against a position for debate tests"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are a sharp critic. Argue strongly AGAINST the provided argument.
+    Point out flaws and weaknesses in 3 counterpoints. Be incisive
+    but concise — no more than 3 sentences.
+allow_mcp: false

--- a/example/rooms/dispatch/room_config.yaml
+++ b/example/rooms/dispatch/room_config.yaml
@@ -1,0 +1,10 @@
+id: "dispatch"
+name: "Conditional Dispatch Test"
+description: "Agent that selects correct tools from a compound request"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You have access to tools: tool_a, tool_b, tool_c.
+    Call ONLY the tools the user explicitly requests. Do not call extra tools.
+    After getting results, summarize what each tool returned.
+allow_mcp: false

--- a/example/rooms/dispatch/room_config.yaml
+++ b/example/rooms/dispatch/room_config.yaml
@@ -2,7 +2,9 @@ id: "dispatch"
 name: "Conditional Dispatch Test"
 description: "Agent that selects correct tools from a compound request"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You have access to tools: tool_a, tool_b, tool_c.
     Call ONLY the tools the user explicitly requests. Do not call extra tools.

--- a/example/rooms/echo/room_config.yaml
+++ b/example/rooms/echo/room_config.yaml
@@ -2,6 +2,8 @@ id: "echo"
 name: "Echo Test"
 description: "Simple text response, no tools"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: "You are a concise test assistant. Reply in one sentence."
 allow_mcp: false

--- a/example/rooms/echo/room_config.yaml
+++ b/example/rooms/echo/room_config.yaml
@@ -1,0 +1,7 @@
+id: "echo"
+name: "Echo Test"
+description: "Simple text response, no tools"
+agent:
+  template_id: "default_chat"
+  system_prompt: "You are a concise test assistant. Reply in one sentence."
+allow_mcp: false

--- a/example/rooms/fixer/room_config.yaml
+++ b/example/rooms/fixer/room_config.yaml
@@ -1,0 +1,9 @@
+id: "fixer"
+name: "Fixer Test"
+description: "Fixes text based on reviewer feedback for pipeline recovery"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are a text fixer. You receive a draft and a critique. Apply the
+    feedback to produce an improved version. Keep it concise — 1-3 sentences.
+allow_mcp: false

--- a/example/rooms/fixer/room_config.yaml
+++ b/example/rooms/fixer/room_config.yaml
@@ -2,7 +2,9 @@ id: "fixer"
 name: "Fixer Test"
 description: "Fixes text based on reviewer feedback for pipeline recovery"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You are a text fixer. You receive a draft and a critique. Apply the
     feedback to produce an improved version. Keep it concise — 1-3 sentences.

--- a/example/rooms/judge/room_config.yaml
+++ b/example/rooms/judge/room_config.yaml
@@ -1,0 +1,10 @@
+id: "judge"
+name: "Judge Test"
+description: "Evaluates and picks consensus from multiple inputs"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are an impartial judge. Review the provided opinions or arguments
+    and determine the consensus or strongest position. State your verdict
+    clearly in 1-2 sentences, citing which side you agree with and why.
+allow_mcp: false

--- a/example/rooms/judge/room_config.yaml
+++ b/example/rooms/judge/room_config.yaml
@@ -2,7 +2,9 @@ id: "judge"
 name: "Judge Test"
 description: "Evaluates and picks consensus from multiple inputs"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You are an impartial judge. Review the provided opinions or arguments
     and determine the consensus or strongest position. State your verdict

--- a/example/rooms/multi-tool/room_config.yaml
+++ b/example/rooms/multi-tool/room_config.yaml
@@ -2,7 +2,9 @@ id: "multi-tool"
 name: "Multi Tool Test"
 description: "Agent that chains multiple tool calls"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You have access to multiple tools. When asked to run diagnostics,
     call get_current_datetime first, then call system_status, then

--- a/example/rooms/multi-tool/room_config.yaml
+++ b/example/rooms/multi-tool/room_config.yaml
@@ -1,0 +1,12 @@
+id: "multi-tool"
+name: "Multi Tool Test"
+description: "Agent that chains multiple tool calls"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You have access to multiple tools. When asked to run diagnostics,
+    call get_current_datetime first, then call system_status, then
+    summarize both results.
+tools:
+  - tool_name: "soliplex.tools.get_current_datetime"
+allow_mcp: false

--- a/example/rooms/parallel/room_config.yaml
+++ b/example/rooms/parallel/room_config.yaml
@@ -2,7 +2,9 @@ id: "parallel"
 name: "Parallel Test"
 description: "Room for concurrent agent sessions"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     Reply with exactly the word the user asks you to say, nothing else.
 allow_mcp: false

--- a/example/rooms/parallel/room_config.yaml
+++ b/example/rooms/parallel/room_config.yaml
@@ -1,0 +1,8 @@
+id: "parallel"
+name: "Parallel Test"
+description: "Room for concurrent agent sessions"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    Reply with exactly the word the user asks you to say, nothing else.
+allow_mcp: false

--- a/example/rooms/planner/room_config.yaml
+++ b/example/rooms/planner/room_config.yaml
@@ -2,7 +2,9 @@ id: "planner"
 name: "Planner Test"
 description: "Decomposes tasks into subtasks for fan-out"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You are a task planner. Break the user's request into subtasks.
     Output ONLY a valid JSON array of strings, no markdown formatting,

--- a/example/rooms/planner/room_config.yaml
+++ b/example/rooms/planner/room_config.yaml
@@ -1,0 +1,10 @@
+id: "planner"
+name: "Planner Test"
+description: "Decomposes tasks into subtasks for fan-out"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are a task planner. Break the user's request into subtasks.
+    Output ONLY a valid JSON array of strings, no markdown formatting,
+    no explanations. Example: ["subtask 1", "subtask 2", "subtask 3"]
+allow_mcp: false

--- a/example/rooms/reviewer/room_config.yaml
+++ b/example/rooms/reviewer/room_config.yaml
@@ -1,0 +1,10 @@
+id: "reviewer"
+name: "Reviewer Test"
+description: "Reviews and critiques text for pipeline tests"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are a strict reviewer. Critique the provided text in one sentence.
+    If the text meets all requirements, reply with exactly "PASS".
+    Otherwise reply with "FAIL: " followed by your critique.
+allow_mcp: false

--- a/example/rooms/reviewer/room_config.yaml
+++ b/example/rooms/reviewer/room_config.yaml
@@ -2,7 +2,9 @@ id: "reviewer"
 name: "Reviewer Test"
 description: "Reviews and critiques text for pipeline tests"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You are a strict reviewer. Critique the provided text in one sentence.
     If the text meets all requirements, reply with exactly "PASS".

--- a/example/rooms/searcher/room_config.yaml
+++ b/example/rooms/searcher/room_config.yaml
@@ -1,0 +1,11 @@
+id: "searcher"
+name: "Searcher Test"
+description: "Iterative tool refinement loop"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You have a 'search_db' tool. Use it to find what the user asks for.
+    If the tool returns "Not found", refine your query and search again.
+    Keep searching with different queries until you get a result.
+    Report the final result to the user.
+allow_mcp: false

--- a/example/rooms/searcher/room_config.yaml
+++ b/example/rooms/searcher/room_config.yaml
@@ -2,7 +2,9 @@ id: "searcher"
 name: "Searcher Test"
 description: "Iterative tool refinement loop"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You have a 'search_db' tool. Use it to find what the user asks for.
     If the tool returns "Not found", refine your query and search again.

--- a/example/rooms/strict-tool/room_config.yaml
+++ b/example/rooms/strict-tool/room_config.yaml
@@ -2,7 +2,9 @@ id: "strict-tool"
 name: "Strict Tool Test"
 description: "Tests tool argument fidelity and failure recovery"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You have a 'calculate' tool that takes structured arguments.
     When asked to calculate something, call the tool with the correct

--- a/example/rooms/strict-tool/room_config.yaml
+++ b/example/rooms/strict-tool/room_config.yaml
@@ -1,0 +1,11 @@
+id: "strict-tool"
+name: "Strict Tool Test"
+description: "Tests tool argument fidelity and failure recovery"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You have a 'calculate' tool that takes structured arguments.
+    When asked to calculate something, call the tool with the correct
+    arguments. If the tool returns an error, adjust your arguments
+    and try again. Do not give up after one failure.
+allow_mcp: false

--- a/example/rooms/tool-call/room_config.yaml
+++ b/example/rooms/tool-call/room_config.yaml
@@ -1,0 +1,11 @@
+id: "tool-call"
+name: "Tool Call Test"
+description: "Agent that calls a client-side tool"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You have access to tools. When asked for a secret number, you MUST
+    call the secret_number tool and report its result. Always use the tool.
+tools:
+  - tool_name: "soliplex.tools.get_current_datetime"
+allow_mcp: false

--- a/example/rooms/tool-call/room_config.yaml
+++ b/example/rooms/tool-call/room_config.yaml
@@ -2,7 +2,9 @@ id: "tool-call"
 name: "Tool Call Test"
 description: "Agent that calls a client-side tool"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You have access to tools. When asked for a secret number, you MUST
     call the secret_number tool and report its result. Always use the tool.

--- a/example/rooms/writer/room_config.yaml
+++ b/example/rooms/writer/room_config.yaml
@@ -1,0 +1,9 @@
+id: "writer"
+name: "Writer Test"
+description: "Generates draft text for pipeline tests"
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are a creative writer. Write concise, focused text about whatever
+    the user requests. Keep responses to 1-3 sentences unless asked for more.
+allow_mcp: false

--- a/example/rooms/writer/room_config.yaml
+++ b/example/rooms/writer/room_config.yaml
@@ -2,7 +2,9 @@ id: "writer"
 name: "Writer Test"
 description: "Generates draft text for pipeline tests"
 agent:
-  template_id: "default_chat"
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
   system_prompt: |
     You are a creative writer. Write concise, focused text about whatever
     the user requests. Keep responses to 1-3 sentences unless asked for more.


### PR DESCRIPTION
## Summary
- Add 16 dedicated backend room configs for M7 integration tests
- Each room targets a specific agentic scenario (echo, tool-call, multi-tool, parallel, planner, critic, advocate, judge, etc.)
- All rooms use explicit model config (`gpt-oss:20b` on `workshop:11434`) instead of `template_id`

## Changes
- **`example/rooms/`**: 16 new `room_config.yaml` files — echo, tool-call, multi-tool, parallel, planner, critic, advocate, judge, classifier, dispatch, accumulator, fixer, reviewer, searcher, strict-tool, writer

## Test plan
- [x] Backend loads all 16 rooms (`curl /api/v1/rooms`)
- [x] All 20 M7 integration tests pass against these rooms
- [x] Existing M4/M5/M6 integration tests unaffected

Companion PR: soliplex/flutter (M7 integration tests)