### PR TITLE
feat: CLI 'list-environment --verbose'

### DIFF
--- a/src/soliplex/cli.py
+++ b/src/soliplex/cli.py
@@ -566,6 +566,14 @@ def list_secrets(
 def list_environment(
     ctx: typer.Context,
     installation_path: installation_path_type,
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="""\
+Show available sources, and which is selected.
+""",
+    ),
 ):
     """List environment variables defined in the installation"""
     the_installation = get_installation(installation_path)
@@ -585,6 +593,17 @@ def list_environment(
             value = "MISSING"
 
         the_console.print(f"- {key:25}: {value}")
+
+        if verbose:
+            for i_source, source in enumerate(
+                the_installation.get_environment_sources(key)
+            ):
+                mark = " " if i_source else "*"
+                the_console.print(
+                    f"  {mark}{str(source.source_type):24}: {source.value}"
+                )
+
+        the_console.print()
 
     the_console.print()
 

--- a/src/soliplex/config.py
+++ b/src/soliplex/config.py
@@ -257,6 +257,10 @@ def _no_repr_no_compare_none(**kw):
     return _no_repr_no_compare(default=None, **kw)
 
 
+def _no_repr_no_compare_dict(**kw):
+    return _no_repr_no_compare(default_factory=dict, **kw)
+
+
 def _default_list_field() -> dataclasses.field:
     return dataclasses.field(default_factory=list)
 
@@ -2867,6 +2871,18 @@ def _load_entrypoint_skill_configs() -> SkillConfigMap:
     return ep_skill_configs
 
 
+class EnvironmentSourceType(enum.StrEnum):
+    CONFIG_YAML = "config-yaml"
+    DOT_ENV = "dot-env"
+    OS_ENV = "os-environment"
+
+
+@dataclasses.dataclass
+class EnvironmentSource:
+    source_type: EnvironmentSourceType
+    value: str | None
+
+
 @dataclasses.dataclass(kw_only=True)
 class InstallationConfig:
     """Configuration for a set of rooms, completion, etc."""
@@ -2972,7 +2988,41 @@ class InstallationConfig:
     #
     # Map values similar to 'os.environ'.
     #
+
+    # Values from installation config file.
+    _environment_from_config: dict[str, str] = _no_repr_no_compare_dict()
+
     environment: dict[str, typing.Any] = _default_dict_field()
+
+    def get_environment_sources(self, key) -> list[EnvironmentSource]:
+        """Return sources available for an environment key
+
+        First in the list will be the source whose value is used.
+        """
+        EST = EnvironmentSourceType
+        ES = EnvironmentSource
+
+        result = []
+
+        from_config = self._environment_from_config.get(key)
+
+        if from_config is not None:
+            result.append(ES(EST.CONFIG_YAML, from_config))
+
+        if self._from_dotenv is not None:
+            from_dotenv = self._from_dotenv.get(key)
+
+            if from_dotenv is not None:
+                result.append(ES(EST.DOT_ENV, from_dotenv))
+            else:  # pragma: NO COVER
+                pass
+
+        from_osenv = os.getenv(key)
+
+        if from_osenv is not None:
+            result.append(ES(EST.OS_ENV, from_osenv))
+
+        return result
 
     def get_environment(self, key, default=None):
         """Find the configured value for a given quasi-envvar"""
@@ -3258,6 +3308,8 @@ class InstallationConfig:
                     entry["name"]: entry.get("value") for entry in environment
                 }
 
+            # Preserve values as read for later introspection.
+            config_dict["_environment_from_config"] = environment
             config_dict["environment"] = environment
 
             hr_config_file = config_dict.pop(
@@ -3445,6 +3497,7 @@ class InstallationConfig:
             "id": self.id,
             "meta": self.meta.as_yaml,
             "secrets": [secret.as_yaml for secret in self.secrets],
+            # Dump the resolved version, not the original config
             "environment": self.environment,
             "haiku_rag_config_file": str(self._haiku_rag_config_file),
             "agent_configs": [ac.as_yaml for ac in self.agent_configs],

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -44,6 +44,9 @@ class Installation:
     def resolve_secrets(self):
         secrets.resolve_secrets(self._config.secrets)
 
+    def get_environment_sources(self, key) -> list[config.EnvironmentSource]:
+        return self._config.get_environment_sources(key)
+
     def get_environment(self, key, default=None) -> str:
         return self._config.get_environment(key, default)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6010,6 +6010,57 @@ def test_installationconfig_interpolate_secret(
         gs.assert_not_called()
 
 
+EST = config.EnvironmentSourceType
+
+
+@pytest.mark.parametrize(
+    "w_yaml, w_dotenv, w_osenv, exp_first",
+    [
+        (None, None, None, None),
+        ("YAML", None, None, EST.CONFIG_YAML),
+        ("YAML", "DOTENV", None, EST.CONFIG_YAML),
+        ("YAML", None, "OSENV", EST.CONFIG_YAML),
+        (None, "DOTENV", None, EST.DOT_ENV),
+        (None, "DOTENV", "OSENV", EST.DOT_ENV),
+        (None, None, "OSENV", EST.OS_ENV),
+    ],
+)
+@mock.patch("os.getenv")
+def test_installationconfig_get_environment_sources(
+    os_getenv,
+    w_yaml,
+    w_dotenv,
+    w_osenv,
+    exp_first,
+):
+    KEY = "TEST_KEY"
+    kwargs = {"id": "test-ic"}
+    candidates = []
+
+    if w_yaml is not None:
+        kwargs["_environment_from_config"] = {KEY: w_yaml}
+        candidates.append(EST.CONFIG_YAML)
+    else:
+        kwargs["_environment_from_config"] = {}
+
+    if w_dotenv is not None:
+        kwargs["_from_dotenv"] = {KEY: w_dotenv}
+        candidates.append(EST.DOT_ENV)
+
+    if w_osenv is not None:
+        os_getenv.return_value = "OSENV"
+        candidates.append(EST.OS_ENV)
+    else:
+        os_getenv.return_value = None
+
+    i_config = config.InstallationConfig(**kwargs)
+
+    found = i_config.get_environment_sources(KEY)
+
+    for f_item, candidate in zip(found, candidates, strict=True):
+        assert f_item.source_type == candidate
+
+
 @pytest.mark.parametrize("w_default", [False, True])
 @pytest.mark.parametrize("w_hit", [False, True])
 def test_installationconfig_get_environment(w_hit, w_default):
@@ -6609,6 +6660,11 @@ def test_installationconfig_from_yaml(
                     )
                 )
             expected = dataclasses.replace(expected, secrets=replaced_secrets)
+
+        if "environment" in expected_kw:
+            expected = dataclasses.replace(
+                expected, _environment_from_config=expected_kw["environment"]
+            )
 
         if "agent_configs" in expected_kw:
             # Assign '_installation_config' after found is constructed.

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -125,6 +125,17 @@ def test_installation_get_environment(w_default):
         i_config.get_environment.assert_called_once_with(KEY, None)
 
 
+def test_installation_get_environment_sources():
+    i_config = mock.create_autospec(config.InstallationConfig)
+    the_installation = installation.Installation(i_config)
+
+    found = the_installation.get_environment_sources(KEY)
+
+    assert found is i_config.get_environment_sources.return_value
+
+    i_config.get_environment_sources.assert_called_once_with(KEY)
+
+
 @pytest.mark.parametrize("w_raise", [False, True])
 def test_installation_resolve_environment(w_raise):
     i_config = mock.create_autospec(config.InstallationConfig)


### PR DESCRIPTION
Displays sources with values, flagging the one used.

Closes #666.


Example output:

```
$ export OLLAMA_BASE_URL=foo
$ soliplex-cli list-environment --verbose example/minimal.yaml 

───────────────────────────────────────────────── Configured environment variables ─────────────────────────────────────────────────

- OLLAMA_BASE_URL          : http://biggysmalls:11434
  *dot-env                 : http://biggysmalls:11434
   os-environment          : foo

- INSTALLATION_PATH        : <...>/src/soliplex/example
  *config-yaml             : file:.

- RAG_LANCE_DB_PATH        : <...>/soliplex/db/rag
  *config-yaml             : file:../db/rag

- MCP_TOKEN_MAX_AGE        : 3600
  *config-yaml             : 3600

```