### PR TITLE
fix: update DB for thread persistence/usage in background

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "soliplex"
-version = "0.44dev0"
+version = "0.45dev0"
 description = "An AI-powered Retrieval-Augmented Generation (RAG) system with a modern web interface."
 authors = [{ name = "Enfold", email = "info@enfoldsystems.net" }]
 readme = "README.md"

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import functools
+import asyncio
 
 import fastapi
 import logfire
@@ -8,6 +8,7 @@ import pydantic_ai
 from ag_ui import core as agui_core
 from fastapi import responses
 from pydantic_ai.ui import ag_ui as ai_ag_ui
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agui as agui_package
 from soliplex import authn
@@ -462,49 +463,103 @@ async def post_room_agui_thread_id_meta(
     return fastapi.Response(status_code=205)
 
 
-async def tee_events(
-    event_stream: agui_package.AGUI_EventStream,
-    on_done,
+async def save_thread_run_events(
+    sqla_engine,
+    event_list,
+    user_name: str,
+    room_id: str,
     thread_id: str,
     run_id: str,
 ):
-    event_list = []
-    error_message = None
-    status = None
+    """Save the run events to the database.
 
+    This function needs to build its own session, because the one bound
+    to the request lifetime in the `the_threads` dependency might have
+    been closed (e.g., with an early connection reset).
+    """
+    async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
+        the_threads = agui_persistence.ThreadStorage(session)
+
+        await the_threads.save_run_events(
+            events=event_list,
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+        )
+
+
+async def drive_llm_stream(
+    llm_stream,
+    sqla_engine,
+    event_queue: asyncio.Queue,
+    user_name: str,
+    room_id: str,
+    thread_id: str,
+    run_id: str,
+):
+    """Primary consumer of LLM event stream
+
+    Always runs to completion.
+    """
     with logfire.span(
         "AG-UI event stream: {thread_id}/{run_id}",
         thread_id=thread_id,
         run_id=run_id,
     ):
-        async for event in event_stream:
-            event_list.append(event)
-            yield event
+        event_list = []
+        error_message = None
+        status = None
+        try:
+            async for event in llm_stream:
+                event_list.append(event)
+                await event_queue.put(event)
+        finally:
+            await event_queue.put(None)  # sentinel
 
-        if event_list:
-            last = event_list[-1]
-
-            if last.type == agui_core.EventType.RUN_FINISHED:
-                status = "FINISHED"
-
-            elif last.type == agui_core.EventType.RUN_ERROR:
-                status = "ERROR"
-                error_message = last.message
-
-            else:
-                status = "UNKNOWN"
-        else:
-            status = "EMPTY"
-
-        if error_message:
-            logfire.error(
-                "Stream error: {error_message}",
-                error_message=error_message,
+            await save_thread_run_events(
+                event_list=event_list,
+                sqla_engine=sqla_engine,
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
             )
-        else:
-            logfire.info("Stream status: {status}", status=status)
 
-    await on_done(events=event_list)
+            if event_list:
+                last = event_list[-1]
+
+                if last.type == agui_core.EventType.RUN_FINISHED:
+                    status = "FINISHED"
+
+                elif last.type == agui_core.EventType.RUN_ERROR:
+                    status = "ERROR"
+                    error_message = last.message
+
+                else:
+                    status = "UNKNOWN"
+            else:
+                status = "EMPTY"
+
+            if error_message:
+                logfire.error(
+                    "Stream error: {error_message}",
+                    error_message=error_message,
+                )
+            else:
+                logfire.info("Stream status: {status}", status=status)
+
+
+async def stream_llm_events(event_queue: asyncio.Queue):
+    """Read/yield events from queue
+
+    Stop if client disconnects.
+    """
+    while True:
+        event = await event_queue.get()
+        if event is None:
+            break
+        yield event
 
 
 @util.logfire_span("POST /v1/rooms/{room_id}/agui/{thread_id}/{run_id}")
@@ -562,7 +617,7 @@ async def post_room_agui_thread_id_run_id(
         the_logger=the_logger,
     )
 
-    async def finish_stream(result):
+    async def capture_usage_after_stream(result):
         usage = getattr(result, "usage", None)
 
         if usage is not None:
@@ -580,27 +635,33 @@ async def post_room_agui_thread_id_run_id(
 
     agent_stream = agui_adapter.run_stream(
         deps=agent_deps,
-        on_complete=finish_stream,
+        on_complete=capture_usage_after_stream,
     )
 
     compacted_stream = agui_package.compact_event_stream(agent_stream)
 
-    save_events = functools.partial(
-        the_threads.save_run_events,
-        user_name=user_name,
-        room_id=room_id,
-        thread_id=thread_id,
-        run_id=run_id,
+    event_queue = asyncio.Queue()
+
+    # Drive the LLM stream in a background task, in order to save
+    # the thread persistence and usage at the end.
+    asyncio.create_task(
+        # No 'await' here:  'create_task' *wants* a coroutine
+        drive_llm_stream(
+            llm_stream=compacted_stream,
+            sqla_engine=request.state.threads_engine,
+            event_queue=event_queue,
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+        )
     )
 
-    db_stream = tee_events(
-        compacted_stream,
-        on_done=save_events,
-        thread_id=thread_id,
-        run_id=run_id,
+    # Stream events to the client from the queue, as pushed from
+    # the driver.
+    sse_stream = agui_adapter.encode_stream(
+        stream_llm_events(event_queue),
     )
-
-    sse_stream = agui_adapter.encode_stream(db_stream)
 
     return responses.StreamingResponse(
         sse_stream,

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1,6 +1,6 @@
+import asyncio
 import contextlib
 import datetime
-import functools
 from unittest import mock
 
 import fastapi
@@ -901,11 +901,50 @@ async def test_post_room_agui_thread_id_meta(
 
 
 @pytest.mark.asyncio
+@mock.patch("soliplex.agui.persistence.ThreadStorage")
+@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
+async def test_save_thread_run_events(a_session, t_storage):
+    w_session = a_session.return_value.__aenter__.return_value
+    the_threads = t_storage.return_value
+    the_threads.save_run_events = mock.AsyncMock(spec_set=())
+    sqla_engine = object()
+    event_list = [object()]
+
+    await agui_views.save_thread_run_events(
+        sqla_engine=sqla_engine,
+        event_list=event_list,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID,
+        run_id=TEST_RUN_ID,
+    )
+
+    the_threads.save_run_events.assert_called_once_with(
+        events=event_list,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID,
+        run_id=TEST_RUN_ID,
+    )
+
+    t_storage.assert_called_once_with(w_session)
+
+    a_session.assert_called_once_with(bind=sqla_engine)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("w_event_count", [0, 1, 10])
 @pytest.mark.parametrize("w_finished_error", [None, "finished", "error"])
+@mock.patch("soliplex.views.agui.save_thread_run_events")
 @mock.patch("soliplex.views.agui.logfire")
-async def test_tee_events(logfire, w_finished_error, w_event_count):
-    on_done = mock.AsyncMock(spec_set=())
+async def test_drive_llm_stream(
+    logfire,
+    stre,
+    w_finished_error,
+    w_event_count,
+):
+    sqla_engine = mock.AsyncMock(spec_set=())
+    event_queue = asyncio.Queue()
 
     finished_event = agui_core.events.RunFinishedEvent(
         thread_id=TEST_THREAD_ID,
@@ -923,17 +962,34 @@ async def test_tee_events(logfire, w_finished_error, w_event_count):
         elif w_finished_error == "error":
             yield error_event
 
-    expected = [
-        event
-        async for event in agui_views.tee_events(
-            event_iter(),
-            on_done=on_done,
-            thread_id=TEST_THREAD_ID,
-            run_id=TEST_RUN_ID,
-        )
-    ]
+    expected = [event async for event in event_iter()]
 
-    on_done.assert_awaited_once_with(events=expected)
+    await agui_views.drive_llm_stream(
+        event_iter(),
+        sqla_engine=sqla_engine,
+        event_queue=event_queue,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID,
+        run_id=TEST_RUN_ID,
+    )
+
+    assert event_queue.qsize() == len(expected) + 1
+
+    for expected_event in expected:
+        found_event = await event_queue.get()
+        assert found_event == expected_event
+
+    assert await event_queue.get() is None  # sentinel
+
+    stre.assert_called_once_with(
+        event_list=expected,
+        sqla_engine=sqla_engine,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID,
+        run_id=TEST_RUN_ID,
+    )
 
     logfire.span.assert_called_once_with(
         "AG-UI event stream: {thread_id}/{run_id}",
@@ -959,6 +1015,28 @@ async def test_tee_events(logfire, w_finished_error, w_event_count):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("num_events", [0, 1, 10, 100])
+async def test_stream_llm_events(num_events):
+    expected = [
+        agui_core.events.RawEvent(event=i_event)
+        for i_event in range(num_events)
+    ]
+
+    event_queue = asyncio.Queue()
+
+    for event in expected:
+        event_queue.put_nowait(event)
+
+    event_queue.put_nowait(None)
+
+    found = [
+        event async for event in agui_views.stream_llm_events(event_queue)
+    ]
+
+    assert found == expected
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "ari_side_effect, expectation",
     [
@@ -971,16 +1049,18 @@ async def test_tee_events(logfire, w_finished_error, w_event_count):
 )
 @pytest.mark.parametrize("w_usage", [False, True])
 @mock.patch("fastapi.responses.StreamingResponse")
-@mock.patch("pydantic_ai.ui.ag_ui.AGUIAdapter")
+@mock.patch("soliplex.views.agui.stream_llm_events")
+@mock.patch("soliplex.views.agui.drive_llm_stream")
 @mock.patch("soliplex.agui.compact_event_stream")
+@mock.patch("pydantic_ai.ui.ag_ui.AGUIAdapter")
 @mock.patch("soliplex.views.agui._check_user_room_agent")
-@mock.patch("soliplex.views.agui.tee_events")
 async def test_post_room_agui_thread_id_run_id(
-    tee,
     cura,
-    ces,
     aga,
-    sr,
+    ces,
+    dls,
+    sle,
+    frsr,
     the_threads,
     test_run,
     run_input,
@@ -993,6 +1073,7 @@ async def test_post_room_agui_thread_id_run_id(
     cura.return_value = (USER_PROFILE, agent)
 
     request = fastapi.Request(scope={"type": "http"})
+    sqla_engine = request.state.threads_engine = object()
 
     the_installation = mock.create_autospec(installation.Installation)
     the_installation.get_agent_for_room.return_value = agent
@@ -1015,6 +1096,7 @@ async def test_post_room_agui_thread_id_run_id(
     exp_adapter.encode_stream = mock.MagicMock()
     exp_adapter.run_stream = mock.MagicMock()
     exp_agent_stream = exp_adapter.run_stream.return_value
+
     exp_sse_stream = exp_adapter.encode_stream.return_value
 
     with expectation as expected:
@@ -1031,30 +1113,29 @@ async def test_post_room_agui_thread_id_run_id(
         )
 
     if expected is None:
-        assert found is sr.return_value
+        assert found is frsr.return_value
 
-        sr.assert_called_once_with(
+        frsr.assert_called_once_with(
             exp_sse_stream,
             media_type=exp_adapter.accept,
             headers=views.HEADERS_DO_NOT_BUFFER_SSE,
         )
 
-        exp_adapter.encode_stream.assert_called_once_with(tee.return_value)
+        exp_adapter.encode_stream.assert_called_once_with(sle.return_value)
 
-        tee.assert_called_once()
-        (event_stream,) = tee.call_args_list[0].args
+        sle.assert_called_once()
+        assert sle.call_args_list[0].kwargs == {}
+        (event_queue,) = sle.call_args_list[0].args
 
-        assert event_stream is ces.return_value
-
-        on_done = tee.call_args_list[0].kwargs["on_done"]
-        assert isinstance(on_done, functools.partial)
-        assert on_done.func is the_threads.save_run_events
-        assert on_done.keywords == {
-            "user_name": USER_NAME,
-            "room_id": TEST_ROOM_ID,
-            "thread_id": TEST_THREAD_ID,
-            "run_id": TEST_RUN_ID,
-        }
+        dls.assert_called_once_with(
+            llm_stream=ces.return_value,
+            sqla_engine=sqla_engine,
+            event_queue=event_queue,
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            run_id=TEST_RUN_ID,
+        )
 
         ces.assert_called_once_with(exp_agent_stream)
 
@@ -1062,6 +1143,8 @@ async def test_post_room_agui_thread_id_run_id(
         (rs_call_0,) = exp_adapter.run_stream.call_args_list
         assert rs_call_0.args == ()
         assert rs_call_0.kwargs["deps"] is exp_deps
+        capture = rs_call_0.kwargs["on_complete"]
+        assert capture.__name__ == "capture_usage_after_stream"
 
         the_threads.save_run_usage.assert_not_awaited()
 


### PR DESCRIPTION
Drive LLM event stream, making DB updates in a task, dispatching events to the 'FastAPI.StreamingResponse' via a queue.

Closes #677.