### PR TITLE
fix: headers to prevent buffering SSE response streams

### DIFF
--- a/src/soliplex/completions.py
+++ b/src/soliplex/completions.py
@@ -1,13 +1,10 @@
 import json
 import time
 
-import fastapi
 import pydantic_ai
-from fastapi import responses
 from pydantic_ai import messages as ai_messages
 
 from soliplex import agents
-from soliplex import models
 
 
 def openai_chunk_repr(model, i_chunk, chunk):
@@ -63,31 +60,3 @@ async def stream_chat_responses(
             i_chunk += 1
 
     yield "data: [DONE]\n\n"
-
-
-async def openai_chat_completion(
-    agent: pydantic_ai.Agent,
-    agent_deps: agents.AgentDependencies,
-    chat_request: models.ChatCompletionRequest,
-) -> responses.StreamingResponse:
-    openai_payload = chat_request.model_dump(exclude_unset=True)
-    user_question = openai_payload["messages"][-1]["content"]
-    # TODO: figure out how to convert message history to PydanticAI's
-    #       format.
-    # message_history = munge(openai_payload["messages"][:-1])
-    message_history = []
-
-    try:
-        return responses.StreamingResponse(
-            stream_chat_responses(
-                agent,
-                agent_deps,
-                user_question,
-                message_history,
-            ),
-            media_type="text/event-stream",
-        )
-    except Exception:
-        raise fastapi.HTTPException(
-            status_code=500, detail="Error streaming chat responses"
-        ) from None

--- a/src/soliplex/views/__init__.py
+++ b/src/soliplex/views/__init__.py
@@ -15,6 +15,11 @@ depend_the_installation = installation_module.depend_the_installation
 Installation = installation_module.Installation
 HTTPAuthorizationCredentials = security.HTTPAuthorizationCredentials
 
+HEADERS_DO_NOT_BUFFER_SSE = {
+    "Cache-Control": "no-cache, no-store",
+    "X-Accel-Buffering": "no",
+}
+
 
 async def get_the_unauth_logger(
     request: fastapi.Request,

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -605,6 +605,7 @@ async def post_room_agui_thread_id_run_id(
     return responses.StreamingResponse(
         sse_stream,
         media_type=agui_adapter.accept,
+        headers=views.HEADERS_DO_NOT_BUFFER_SSE,
     )
 
 

--- a/src/soliplex/views/completions.py
+++ b/src/soliplex/views/completions.py
@@ -1,6 +1,8 @@
 import fastapi
+import pydantic_ai
 from fastapi import responses
 
+from soliplex import agents
 from soliplex import authn
 from soliplex import completions
 from soliplex import installation
@@ -61,6 +63,35 @@ async def get_chat_completion(
     return models.Completion.from_config(completion_config)
 
 
+async def openai_chat_completion(
+    agent: pydantic_ai.Agent,
+    agent_deps: agents.AgentDependencies,
+    chat_request: models.ChatCompletionRequest,
+) -> responses.StreamingResponse:
+    openai_payload = chat_request.model_dump(exclude_unset=True)
+    user_question = openai_payload["messages"][-1]["content"]
+    # TODO: figure out how to convert message history to PydanticAI's
+    #       format.
+    # message_history = munge(openai_payload["messages"][:-1])
+    message_history = []
+
+    try:
+        return responses.StreamingResponse(
+            completions.stream_chat_responses(
+                agent,
+                agent_deps,
+                user_question,
+                message_history,
+            ),
+            media_type="text/event-stream",
+            headers=views.HEADERS_DO_NOT_BUFFER_SSE,
+        )
+    except Exception:
+        raise fastapi.HTTPException(
+            status_code=500, detail="Error streaming chat responses"
+        ) from None
+
+
 @util.logfire_span("POST /v1/chat/completions/{completion_id}")
 @router.post(
     "/v1/chat/completions/{completion_id}",
@@ -90,7 +121,7 @@ async def post_chat_completion(
         user=user_profile,
     )
 
-    return await completions.openai_chat_completion(
+    return await openai_chat_completion(
         agent,
         agent_deps,
         chat_request,

--- a/tests/unit/test_completions.py
+++ b/tests/unit/test_completions.py
@@ -1,11 +1,9 @@
 import json
 from unittest import mock
 
-import fastapi
 import pytest
 
 from soliplex import completions
-from soliplex import models
 from soliplex.config import agents as config_agents
 from soliplex.config import completions as config_completions
 from soliplex.config import tools as config_tools
@@ -139,62 +137,3 @@ async def test_stream_chat_responses(ocr, n_chunks):
         message_history=HISTORY,
         deps=agent_deps,
     )
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize("w_exception", [False, True])
-@pytest.mark.parametrize("w_history", [False, True])
-@mock.patch("soliplex.completions.stream_chat_responses")
-@mock.patch("fastapi.responses.StreamingResponse")
-async def test_openai_chat_completion(sr_class, scp, w_history, w_exception):
-    CR_MESSAGES = [
-        {
-            "role": "user",
-            "content": "Why is blue?",
-        },
-    ]
-    agent = mock.Mock(spec_set=["model", "run_stream"])
-    agent_deps = mock.Mock(spec_set=())
-
-    if w_history:
-        CR_MESSAGES.insert(
-            0,
-            {
-                "role": "model",
-                "content": "hello",
-            },
-        )
-
-    chat_request = mock.create_autospec(models.ChatCompletionRequest)
-    chat_request.model_dump.return_value = {
-        "model": "NOT USED",
-        "messages": CR_MESSAGES,
-    }
-
-    if w_exception:
-        scp.side_effect = ValueError("testing-stream_chat_responses")
-
-    if w_exception:
-        with pytest.raises(fastapi.HTTPException):
-            await completions.openai_chat_completion(
-                agent,
-                agent_deps,
-                chat_request,
-            )
-        return
-    else:
-        response = await completions.openai_chat_completion(
-            agent,
-            agent_deps,
-            chat_request,
-        )
-
-    assert response is sr_class.return_value
-
-    sr_class.assert_called_once_with(
-        scp.return_value,
-        media_type="text/event-stream",
-    )
-
-    # TODO not passing history
-    scp.assert_called_once_with(agent, agent_deps, "Why is blue?", [])

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -12,6 +12,7 @@ from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
+from soliplex import views
 from soliplex.agui import features as agui_features
 from soliplex.config import agui as config_agui
 from soliplex.config import rooms as config_rooms
@@ -1035,6 +1036,7 @@ async def test_post_room_agui_thread_id_run_id(
         sr.assert_called_once_with(
             exp_sse_stream,
             media_type=exp_adapter.accept,
+            headers=views.HEADERS_DO_NOT_BUFFER_SSE,
         )
 
         exp_adapter.encode_stream.assert_called_once_with(tee.return_value)

--- a/tests/unit/views/test_completions_views.py
+++ b/tests/unit/views/test_completions_views.py
@@ -5,6 +5,7 @@ import pytest
 
 from soliplex import installation
 from soliplex import models
+from soliplex import views
 from soliplex.config import completions as config_completions
 from soliplex.views import completions as completions_views
 
@@ -118,6 +119,66 @@ async def test_get_chat_completion(fc, completion_configs):
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("w_exception", [False, True])
+@pytest.mark.parametrize("w_history", [False, True])
+@mock.patch("soliplex.completions.stream_chat_responses")
+@mock.patch("fastapi.responses.StreamingResponse")
+async def test_openai_chat_completion(sr_class, scp, w_history, w_exception):
+    CR_MESSAGES = [
+        {
+            "role": "user",
+            "content": "Why is blue?",
+        },
+    ]
+    agent = mock.Mock(spec_set=["model", "run_stream"])
+    agent_deps = mock.Mock(spec_set=())
+
+    if w_history:
+        CR_MESSAGES.insert(
+            0,
+            {
+                "role": "model",
+                "content": "hello",
+            },
+        )
+
+    chat_request = mock.create_autospec(models.ChatCompletionRequest)
+    chat_request.model_dump.return_value = {
+        "model": "NOT USED",
+        "messages": CR_MESSAGES,
+    }
+
+    if w_exception:
+        scp.side_effect = ValueError("testing-stream_chat_responses")
+
+    if w_exception:
+        with pytest.raises(fastapi.HTTPException):
+            await completions_views.openai_chat_completion(
+                agent,
+                agent_deps,
+                chat_request,
+            )
+        return
+    else:
+        response = await completions_views.openai_chat_completion(
+            agent,
+            agent_deps,
+            chat_request,
+        )
+
+    assert response is sr_class.return_value
+
+    sr_class.assert_called_once_with(
+        scp.return_value,
+        media_type="text/event-stream",
+        headers=views.HEADERS_DO_NOT_BUFFER_SSE,
+    )
+
+    # TODO not passing history
+    scp.assert_called_once_with(agent, agent_deps, "Why is blue?", [])
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     "w_auth_user, exp_user",
     [
@@ -154,7 +215,7 @@ async def test_post_chat_completion_miss(w_auth_user, exp_user):
     ],
 )
 @pytest.mark.parametrize("w_msg", [False, True])
-@mock.patch("soliplex.completions.openai_chat_completion")
+@mock.patch("soliplex.views.completions.openai_chat_completion")
 async def test_post_chat_completion_hit(
     occ,
     w_msg,


### PR DESCRIPTION
refactor: move 'completions.openai_chat_completion' to 'views.completions'

It is entirely wrapped up in FastAPI.

Closes #682.