### PR TITLE
feat: wrap SSE streams

### DIFF
--- a/src/soliplex/tui/main.py
+++ b/src/soliplex/tui/main.py
@@ -1000,6 +1000,9 @@ class RoomView(t_screen.Screen):
             if line:
                 decoded = line.decode("utf-8")
 
+                if decoded.startswith(":"):  # comment, i.e., keepalive
+                    continue
+
                 if decoded.startswith("data: "):
                     decoded = decoded[len("data: ") :]
 

--- a/src/soliplex/views/__init__.py
+++ b/src/soliplex/views/__init__.py
@@ -15,11 +15,6 @@ depend_the_installation = installation_module.depend_the_installation
 Installation = installation_module.Installation
 HTTPAuthorizationCredentials = security.HTTPAuthorizationCredentials
 
-HEADERS_DO_NOT_BUFFER_SSE = {
-    "Cache-Control": "no-cache, no-store",
-    "X-Accel-Buffering": "no",
-}
-
 
 async def get_the_unauth_logger(
     request: fastapi.Request,

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -21,6 +21,7 @@ from soliplex import views
 from soliplex.agui import persistence as agui_persistence
 from soliplex.config import agui as config_agui
 from soliplex.config import rooms as config_rooms
+from soliplex.views import streaming as streaming_views
 
 router = fastapi.APIRouter(tags=["rooms"])
 
@@ -663,10 +664,17 @@ async def post_room_agui_thread_id_run_id(
         stream_llm_events(event_queue),
     )
 
-    return responses.StreamingResponse(
+    # Wrap the response stream w/ keepalives, cancellation detection
+    w_keepalive_stream = streaming_views.stream_sse_with_keepalive(
         sse_stream,
+        request=request,
+        log_info=logfire.info,
+    )
+
+    return responses.StreamingResponse(
+        w_keepalive_stream,
         media_type=agui_adapter.accept,
-        headers=views.HEADERS_DO_NOT_BUFFER_SSE,
+        headers=streaming_views.HEADERS_DO_NOT_BUFFER_SSE,
     )
 
 

--- a/src/soliplex/views/completions.py
+++ b/src/soliplex/views/completions.py
@@ -9,6 +9,7 @@ from soliplex import installation
 from soliplex import models
 from soliplex import util
 from soliplex import views
+from soliplex.views import streaming as streaming_views
 
 # -----------------------------------------------------------------------------
 #   Completions endpoints
@@ -64,6 +65,7 @@ async def get_chat_completion(
 
 
 async def openai_chat_completion(
+    request: fastapi.Request,
     agent: pydantic_ai.Agent,
     agent_deps: agents.AgentDependencies,
     chat_request: models.ChatCompletionRequest,
@@ -76,15 +78,21 @@ async def openai_chat_completion(
     message_history = []
 
     try:
+        completion_stream = completions.stream_chat_responses(
+            agent,
+            agent_deps,
+            user_question,
+            message_history,
+        )
+        # Wrap the response stream w/ keepalives, cancellation detection
+        w_keepalive_stream = streaming_views.stream_sse_with_keepalive(
+            completion_stream,
+            request=request,
+        )
         return responses.StreamingResponse(
-            completions.stream_chat_responses(
-                agent,
-                agent_deps,
-                user_question,
-                message_history,
-            ),
+            w_keepalive_stream,
             media_type="text/event-stream",
-            headers=views.HEADERS_DO_NOT_BUFFER_SSE,
+            headers=streaming_views.HEADERS_DO_NOT_BUFFER_SSE,
         )
     except Exception:
         raise fastapi.HTTPException(
@@ -122,6 +130,7 @@ async def post_chat_completion(
     )
 
     return await openai_chat_completion(
+        request,
         agent,
         agent_deps,
         chat_request,

--- a/src/soliplex/views/streaming.py
+++ b/src/soliplex/views/streaming.py
@@ -4,7 +4,11 @@ This module provides Server-Sent Events (SSE) and WebSocket endpoints
 for real-time streaming communication.
 """
 
+from __future__ import annotations
+
 import asyncio
+import time
+import typing
 
 import fastapi
 from fastapi import WebSocket
@@ -13,12 +17,89 @@ from starlette.websockets import WebSocketDisconnect
 
 from soliplex import util
 
+SSE_POLL_INTERVAL_SECS = 2.0
+SSE_KEEPALIVE_INTERVAL_SECS = 15.0
+SSE_KEEPALIVE_MESSAGE = ": keepalive\n\n"  # no field name, ergo a comment
+HEADERS_DO_NOT_BUFFER_SSE = {
+    "Cache-Control": "no-cache, no-store",
+    "X-Accel-Buffering": "no",
+}
+
 router = fastapi.APIRouter()
+
+
+async def stream_sse_with_keepalive(
+    sse_event_stream,
+    *,
+    request: fastapi.Request = None,
+    log_info: typing.Callable[str, ...] = None,
+    poll_interval_secs: float = SSE_POLL_INTERVAL_SECS,
+    keepalive_interval_secs: float = SSE_KEEPALIVE_INTERVAL_SECS,
+    keepalive_message: str = SSE_KEEPALIVE_MESSAGE,
+):
+    """Stream SSE events.
+
+    If an event has not occurred within the given interval, emit
+    an empty "keepalive" event
+    """
+    sse_iter = sse_event_stream.__aiter__()
+    pending: asyncio.Future = None
+    last_update: float = time.monotonic()
+
+    try:
+        #  Unroll the more idiomatic 'async for event in sse_event_stream:'
+        #  so that we can do keepalive checking at set intervals.
+        while True:
+            if request is not None:
+                if await request.is_disconnected():
+                    break
+
+            if pending is None:
+                pending = asyncio.ensure_future(sse_iter.__anext__())
+
+            done, _ = await asyncio.wait(
+                [pending],
+                timeout=poll_interval_secs,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if pending in done:
+                try:
+                    event = pending.result()
+                    yield event
+                    last_update = time.monotonic()
+                except StopAsyncIteration:
+                    break
+                finally:
+                    pending = None
+
+            else:
+                # Poll timed out — check for keepalive
+                now = time.monotonic()
+                if now - last_update >= keepalive_interval_secs:
+                    yield keepalive_message
+                    last_update = time.monotonic()
+
+    except asyncio.CancelledError:
+        if request is not None:
+            parms = request.path_params
+        else:
+            parms = {"thread_id": "<unknown>", "run_id": "<unknown>"}
+
+        log_info = log_info(
+            "SSE generator cancelled {thread_id}/{run_id}",
+            **parms,
+        )
+        raise
+
+    finally:  # pragma NO COVER
+        if pending and not pending.done():
+            pending.cancel()
 
 
 @util.logfire_span("GET /ssetest")
 @router.get("/ssetest", tags=["streaming"])
-async def sse_endpoint():  # pragma: no cover
+async def sse_endpoint():  # pragma: NO COVER
     """Server-Sent Events endpoint for real-time streaming.
 
     Returns a continuous stream of counter values every second.
@@ -36,7 +117,7 @@ async def sse_endpoint():  # pragma: no cover
 
 
 @router.websocket("/wstest")
-async def websocket_endpoint(ws: WebSocket):  # pragma: no cover
+async def websocket_endpoint(ws: WebSocket):  # pragma: NO COVER
     """WebSocket endpoint for bidirectional real-time communication.
 
     Accepts a WebSocket connection and sends counter values every second.

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -12,11 +12,11 @@ from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
-from soliplex import views
 from soliplex.agui import features as agui_features
 from soliplex.config import agui as config_agui
 from soliplex.config import rooms as config_rooms
 from soliplex.views import agui as agui_views
+from soliplex.views import streaming as streaming_views
 
 NOW = datetime.datetime.now(datetime.UTC)
 USER_NAME = "phreddy"
@@ -1049,17 +1049,21 @@ async def test_stream_llm_events(num_events):
 )
 @pytest.mark.parametrize("w_usage", [False, True])
 @mock.patch("fastapi.responses.StreamingResponse")
+@mock.patch("soliplex.views.streaming.stream_sse_with_keepalive")
 @mock.patch("soliplex.views.agui.stream_llm_events")
 @mock.patch("soliplex.views.agui.drive_llm_stream")
 @mock.patch("soliplex.agui.compact_event_stream")
 @mock.patch("pydantic_ai.ui.ag_ui.AGUIAdapter")
 @mock.patch("soliplex.views.agui._check_user_room_agent")
-async def test_post_room_agui_thread_id_run_id(
+@mock.patch("soliplex.views.agui.logfire")
+async def test_post_room_agui_thread_id_run_id_streaming(
+    logfire,
     cura,
     aga,
     ces,
     dls,
     sle,
+    sswk,
     frsr,
     the_threads,
     test_run,
@@ -1116,9 +1120,15 @@ async def test_post_room_agui_thread_id_run_id(
         assert found is frsr.return_value
 
         frsr.assert_called_once_with(
-            exp_sse_stream,
+            sswk.return_value,
             media_type=exp_adapter.accept,
-            headers=views.HEADERS_DO_NOT_BUFFER_SSE,
+            headers=streaming_views.HEADERS_DO_NOT_BUFFER_SSE,
+        )
+
+        sswk.assert_called_once_with(
+            exp_sse_stream,
+            request=request,
+            log_info=logfire.info,
         )
 
         exp_adapter.encode_stream.assert_called_once_with(sle.return_value)

--- a/tests/unit/views/test_completions_views.py
+++ b/tests/unit/views/test_completions_views.py
@@ -5,9 +5,9 @@ import pytest
 
 from soliplex import installation
 from soliplex import models
-from soliplex import views
 from soliplex.config import completions as config_completions
 from soliplex.views import completions as completions_views
+from soliplex.views import streaming as streaming_views
 
 COMPLETION_IDS = ["foo", "bar", "baz"]
 COMPLETION_ID = "qux"
@@ -121,9 +121,16 @@ async def test_get_chat_completion(fc, completion_configs):
 @pytest.mark.anyio
 @pytest.mark.parametrize("w_exception", [False, True])
 @pytest.mark.parametrize("w_history", [False, True])
+@mock.patch("soliplex.views.streaming.stream_sse_with_keepalive")
 @mock.patch("soliplex.completions.stream_chat_responses")
 @mock.patch("fastapi.responses.StreamingResponse")
-async def test_openai_chat_completion(sr_class, scp, w_history, w_exception):
+async def test_openai_chat_completion(
+    sr_class,
+    scp,
+    sswk,
+    w_history,
+    w_exception,
+):
     CR_MESSAGES = [
         {
             "role": "user",
@@ -132,6 +139,7 @@ async def test_openai_chat_completion(sr_class, scp, w_history, w_exception):
     ]
     agent = mock.Mock(spec_set=["model", "run_stream"])
     agent_deps = mock.Mock(spec_set=())
+    request = mock.create_autospec(fastapi.Request)
 
     if w_history:
         CR_MESSAGES.insert(
@@ -154,6 +162,7 @@ async def test_openai_chat_completion(sr_class, scp, w_history, w_exception):
     if w_exception:
         with pytest.raises(fastapi.HTTPException):
             await completions_views.openai_chat_completion(
+                request,
                 agent,
                 agent_deps,
                 chat_request,
@@ -161,6 +170,7 @@ async def test_openai_chat_completion(sr_class, scp, w_history, w_exception):
         return
     else:
         response = await completions_views.openai_chat_completion(
+            request,
             agent,
             agent_deps,
             chat_request,
@@ -169,9 +179,14 @@ async def test_openai_chat_completion(sr_class, scp, w_history, w_exception):
     assert response is sr_class.return_value
 
     sr_class.assert_called_once_with(
-        scp.return_value,
+        sswk.return_value,
         media_type="text/event-stream",
-        headers=views.HEADERS_DO_NOT_BUFFER_SSE,
+        headers=streaming_views.HEADERS_DO_NOT_BUFFER_SSE,
+    )
+
+    sswk.assert_called_once_with(
+        scp.return_value,
+        request=request,
     )
 
     # TODO not passing history
@@ -247,6 +262,7 @@ async def test_post_chat_completion_hit(
 
     exp_user_profile = models.UserProfile(**exp_user)
     occ.assert_awaited_once_with(
+        request,
         the_installation.get_agent_for_completion.return_value,
         the_installation.get_agent_deps_for_completion.return_value,
         chat_request,

--- a/tests/unit/views/test_streaming.py
+++ b/tests/unit/views/test_streaming.py
@@ -1,0 +1,127 @@
+import asyncio
+from unittest import mock
+
+import fastapi
+import pytest
+
+from soliplex.views import streaming as views_streaming
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("disconnect_after", [None, 0, 2, 1000])
+@pytest.mark.parametrize("w_request", [False, True])
+@pytest.mark.parametrize(
+    "events",
+    [
+        [],
+        ["data: only one\n\n"],
+        [f"data: {i_evt}\n\n" for i_evt in range(15)],
+    ],
+)
+async def test_stream_sse_with_keepalive_w_no_timeouts(
+    events,
+    w_request,
+    disconnect_after,
+):
+    async def event_stream():
+        for event in events:
+            yield event
+
+    request_kw = {}
+
+    expected = events[:]
+
+    if w_request:
+        request = mock.create_autospec(fastapi.Request)
+
+        if disconnect_after is not None:
+            flags = [False] * disconnect_after + [True] * 1000
+            request.is_disconnected.side_effect = flags
+            expected = expected[:disconnect_after]
+        else:
+            request.is_disconnected.return_value = False
+
+        request_kw = {"request": request}
+
+    found = [
+        event
+        async for event in views_streaming.stream_sse_with_keepalive(
+            event_stream(),
+            **request_kw,
+        )
+    ]
+
+    assert found == expected
+
+
+@pytest.mark.asyncio
+async def test_stream_sse_with_keepalive_w_timeout():
+    keepalive_interval = 0.25
+    poll_interval = 0.1
+    sleep_interval = 0.5
+    events = ["data: only one\n\n"]
+    expected = [": keepalive\n\n"] + events
+
+    async def event_stream():
+        for event in events:
+            await asyncio.sleep(sleep_interval)
+            yield event
+
+    found = [
+        event
+        async for event in views_streaming.stream_sse_with_keepalive(
+            event_stream(),
+            keepalive_interval_secs=keepalive_interval,
+            poll_interval_secs=poll_interval,
+        )
+    ]
+
+    assert found == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("w_request", [False, True])
+async def test_stream_sse_with_keepalive_w_cancellation(w_request):
+    THREAD_ID = "test-thread"
+    RUN_ID = "test-run"
+
+    keepalive_interval = 0.25
+    poll_interval = 0.1
+    sleep_interval = 0.5
+    events = ["data: only one\n\n"]
+    log_info = mock.Mock()
+
+    if w_request:
+        request = mock.create_autospec(fastapi.Request)
+        request.is_disconnected.return_value = False
+        request.path_params = {"thread_id": THREAD_ID, "run_id": RUN_ID}
+        exp_params = request.path_params
+        request_kw = {"request": request}
+    else:
+        request_kw = {}
+        exp_params = {"thread_id": "<unknown>", "run_id": "<unknown>"}
+
+    async def event_stream():
+        for _event in events:
+            await asyncio.sleep(sleep_interval)
+            raise asyncio.CancelledError("testing")
+            yield None
+        else:  # pragma NO COVER
+            pass
+
+    with pytest.raises(asyncio.CancelledError):
+        [
+            event
+            async for event in views_streaming.stream_sse_with_keepalive(
+                event_stream(),
+                log_info=log_info,
+                keepalive_interval_secs=keepalive_interval,
+                poll_interval_secs=poll_interval,
+                **request_kw,
+            )
+        ]
+
+    log_info.assert_called_once_with(
+        "SSE generator cancelled {thread_id}/{run_id}",
+        **exp_params,
+    )


### PR DESCRIPTION
- Send 'keepalive' events for slow LLM response
- Detect request cancellation.

Closes #683.

refactor: move 'HEADERS_DO_NOT_CACHE_SSE' to 'views.streaming'