### PR TITLE
Preserve entrypoint skill tools and instructions

### DIFF
--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -143,6 +143,7 @@ class _DiscoveredSkillConfigBase(
     kind: typing.ClassVar[hs_models.SkillSource]  # quasi- @abstractproperty
 
     _skill_metadata: hs_models.SkillMetadata
+    _skill: hs_models.Skill = None
     state_namespace: str | None = None
     state_type: SkillStateType = None
 
@@ -154,6 +155,7 @@ class _DiscoveredSkillConfigBase(
     def from_skill(cls, skill: hs_models.Skill):
         return cls(
             _skill_metadata=skill.metadata,
+            _skill=skill,
             state_type=skill.state_type,
             state_namespace=skill.state_namespace,
         )
@@ -167,6 +169,9 @@ class _DiscoveredSkillConfigBase(
 
     @property
     def skill(self) -> hs_models.Skill:
+        if self._skill is not None:
+            return self._skill
+
         return hs_models.Skill(
             source=self.kind,
             metadata=self._skill_metadata,
@@ -188,6 +193,7 @@ class FilesystemSkillConfig(_DiscoveredSkillConfigBase):
     def from_skill(cls, skill: hs_models.Skill):
         return cls(
             _skill_metadata=skill.metadata,
+            _skill=skill,
             _skill_path=skill.path,
             state_type=skill.state_type,
             state_namespace=skill.state_namespace,
@@ -231,6 +237,9 @@ class FilesystemSkillConfig(_DiscoveredSkillConfigBase):
 
     @property
     def skill(self) -> hs_models.Skill:
+        if self._skill is not None:
+            return self._skill
+
         return hs_models.Skill(
             source=self.kind,
             metadata=self._skill_metadata,
@@ -245,20 +254,6 @@ class EntrypointSkillConfig(_DiscoveredSkillConfigBase):
     """Configuration for an agent skill loaded from an entrypoint"""
 
     kind: typing.ClassVar[hs_models.SkillSource] = SkillKind.ENTRYPOINT
-
-    _skill: hs_models.Skill = None
-
-    @classmethod
-    def from_skill(cls, skill: hs_models.Skill):
-        result = super().from_skill(skill)
-        result._skill = skill
-        return result
-
-    @property
-    def skill(self) -> hs_models.Skill:
-        if self._skill is not None:
-            return self._skill
-        return super().skill
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -185,6 +185,30 @@ def test_filesystemskillconfig_ctor_w_errors(skill_path):
     assert skill_config.errors == [validation_error]
 
 
+def test_filesystemskillconfig_from_skill_preserves_original(skill_path):
+    """FilesystemSkillConfig.from_skill returns the original Skill object,
+    preserving tools, instructions, and other fields that would be lost
+    if the Skill were reconstructed from metadata alone."""
+
+    my_tool = mock.Mock()
+
+    original = hs_models.Skill(
+        metadata=hs_models.SkillMetadata(
+            name=SKILL_NAME,
+            description=SKILL_DESC,
+        ),
+        source=hs_models.SkillSource.FILESYSTEM,
+        path=skill_path,
+        instructions="Use the tool.",
+        tools=[my_tool],
+    )
+
+    skill_config = config_skills.FilesystemSkillConfig.from_skill(original)
+    found = skill_config.skill
+
+    assert found is original
+
+
 @pytest.mark.parametrize("w_errors", [[], [SKILL_VALIDATION_ERROR]])
 @mock.patch("haiku.skills.discovery.discover_from_paths")
 def test_filesystemskillconfig_from_path(
@@ -338,6 +362,29 @@ def test_entrypointskillconfig_ctor(w_metadata_kw, exp_allowed_tools):
     assert skill_config.metadata == w_metadata_kw.get("metadata", {})
 
 
+def test_entrypointskillconfig_from_skill_preserves_original():
+    """EntrypointSkillConfig.from_skill returns the original Skill object,
+    preserving tools, instructions, and other fields that would be lost
+    if the Skill were reconstructed from metadata alone."""
+
+    my_tool = mock.Mock()
+
+    original = hs_models.Skill(
+        metadata=hs_models.SkillMetadata(
+            name=SKILL_NAME,
+            description=SKILL_DESC,
+        ),
+        source=hs_models.SkillSource.ENTRYPOINT,
+        instructions="Use the tool.",
+        tools=[my_tool],
+    )
+
+    skill_config = config_skills.EntrypointSkillConfig.from_skill(original)
+    found = skill_config.skill
+
+    assert found is original
+
+
 @pytest.mark.parametrize(
     "w_kw",
     [
@@ -409,29 +456,6 @@ def test_entrypointskillconfig_skill(skill_path, w_metadata_kw, w_kw):
     assert found.metadata.metadata == skill_config.metadata
     assert found.state_type is w_kw.get("state_type")
     assert found.state_namespace is w_kw.get("state_namespace")
-
-
-def test_entrypointskillconfig_from_skill_preserves_original():
-    """EntrypointSkillConfig.from_skill returns the original Skill object,
-    preserving tools, instructions, and other fields that would be lost
-    if the Skill were reconstructed from metadata alone."""
-
-    my_tool = mock.Mock()
-
-    original = hs_models.Skill(
-        metadata=hs_models.SkillMetadata(
-            name=SKILL_NAME,
-            description=SKILL_DESC,
-        ),
-        source=hs_models.SkillSource.ENTRYPOINT,
-        instructions="Use the tool.",
-        tools=[my_tool],
-    )
-
-    skill_config = config_skills.EntrypointSkillConfig.from_skill(original)
-    found = skill_config.skill
-
-    assert found is original
 
 
 @pytest.fixture


### PR DESCRIPTION
`EntrypointSkillConfig.from_skill()` decomposed the Skill into metadata and state fields, then `.skill` reconstructed a bare Skill, dropping tools, instructions, path, and toolsets. 
This caused entrypoint skill sub-agents to run with no tools, silently hallucinating answers.
