### PR TITLE
fix: create separate session for 'capture_usage_after_stream'

### DIFF
--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 
 import fastapi
 import logfire
@@ -464,6 +465,82 @@ async def post_room_agui_thread_id_meta(
     return fastapi.Response(status_code=205)
 
 
+@util.logfire_span("DELETE /v1/rooms/{room_id}/agui/{thread_id}")
+@router.delete("/v1/rooms/{room_id}/agui/{thread_id}")
+async def delete_room_agui_thread_id(
+    request: fastapi.Request,
+    room_id: str,
+    thread_id: str,
+    the_installation: installation.Installation = depend_the_installation,
+    the_threads: agui_package.ThreadStorage = depend_the_threads,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
+    the_user_claims: authn.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> fastapi.Response:
+    """Delete an AGUI thread within the given room"""
+    the_logger.debug(loggers.AGUI_DELETE_ROOM_THREAD)
+
+    user_name = the_user_claims.get("preferred_username", "<unknown>")
+    _room_config = await _check_user_in_room(
+        room_id=room_id,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=the_user_claims,
+        the_logger=the_logger,
+    )
+    try:
+        await the_threads.delete_thread(
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+        )
+
+    except agui_package.AGUI_Exception as exc:
+        raise fastapi.HTTPException(
+            status_code=exc.status_code,
+            detail=exc.args,
+        ) from None
+
+    return fastapi.Response(
+        status_code=204,
+        content=f"Deleted thread: {thread_id}",
+    )
+
+
+async def capture_usage_after_stream(
+    result,
+    *,
+    sqla_engine,
+    user_name: str,
+    room_id: str,
+    thread_id: str,
+    run_id: str,
+):
+    """Save the run usage to the database.
+
+    This function needs to build its own session, because the one bound
+    to the request lifetime in the `the_threads` dependency might have
+    been closed (e.g., with an early connection reset).
+    """
+    usage = getattr(result, "usage", None)
+
+    if usage is not None:
+        async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
+            the_threads = agui_persistence.ThreadStorage(session)
+
+            usage = usage()
+            await the_threads.save_run_usage(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                requests=usage.requests,
+                tool_calls=usage.tool_calls,
+            )
+
+
 async def save_thread_run_events(
     sqla_engine,
     event_list,
@@ -618,25 +695,16 @@ async def post_room_agui_thread_id_run_id(
         the_logger=the_logger,
     )
 
-    async def capture_usage_after_stream(result):
-        usage = getattr(result, "usage", None)
-
-        if usage is not None:
-            usage = usage()
-            await the_threads.save_run_usage(
-                user_name=user_name,
-                room_id=room_id,
-                thread_id=thread_id,
-                run_id=run_id,
-                input_tokens=usage.input_tokens,
-                output_tokens=usage.output_tokens,
-                requests=usage.requests,
-                tool_calls=usage.tool_calls,
-            )
-
     agent_stream = agui_adapter.run_stream(
         deps=agent_deps,
-        on_complete=capture_usage_after_stream,
+        on_complete=functools.partial(
+            capture_usage_after_stream,
+            sqla_engine=request.state.threads_engine,
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+        ),
     )
 
     compacted_stream = agui_package.compact_event_stream(agent_stream)
@@ -783,45 +851,3 @@ async def post_room_agui_thread_id_run_id_feedback(
         ) from None
 
     return fastapi.Response(status_code=205)
-
-
-@util.logfire_span("DELETE /v1/rooms/{room_id}/agui/{thread_id}")
-@router.delete("/v1/rooms/{room_id}/agui/{thread_id}")
-async def delete_room_agui_thread_id(
-    request: fastapi.Request,
-    room_id: str,
-    thread_id: str,
-    the_installation: installation.Installation = depend_the_installation,
-    the_threads: agui_package.ThreadStorage = depend_the_threads,
-    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
-    the_user_claims: authn.UserClaims = depend_the_user_claims,
-    the_logger: loggers.LogWrapper = depend_the_logger,
-) -> fastapi.Response:
-    """Delete an AGUI thread within the given room"""
-    the_logger.debug(loggers.AGUI_DELETE_ROOM_THREAD)
-
-    user_name = the_user_claims.get("preferred_username", "<unknown>")
-    _room_config = await _check_user_in_room(
-        room_id=room_id,
-        the_installation=the_installation,
-        the_authz_policy=the_authz_policy,
-        the_user_claims=the_user_claims,
-        the_logger=the_logger,
-    )
-    try:
-        await the_threads.delete_thread(
-            user_name=user_name,
-            room_id=room_id,
-            thread_id=thread_id,
-        )
-
-    except agui_package.AGUI_Exception as exc:
-        raise fastapi.HTTPException(
-            status_code=exc.status_code,
-            detail=exc.args,
-        ) from None
-
-    return fastapi.Response(
-        status_code=204,
-        content=f"Deleted thread: {thread_id}",
-    )

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import datetime
+import functools
 from unittest import mock
 
 import fastapi
@@ -900,6 +901,114 @@ async def test_post_room_agui_thread_id_meta(
     )
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "tsdr_side_effect, expectation",
+    [
+        (None, no_error(204)),
+        (UNKNOWN_THREAD, raises_httpexc(code=404, match="Unknown thread")),
+        (THREAD_ROOM_MISMATCH, raises_httpexc(code=400, match="Thread room")),
+    ],
+)
+@mock.patch("soliplex.views.agui._check_user_in_room")
+async def test_delete_room_agui_thread_id(
+    cuir,
+    the_threads,
+    test_thread,
+    tsdr_side_effect,
+    expectation,
+):
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    cuir.return_value = room_config
+
+    request = fastapi.Request(scope={"type": "http"})
+    the_installation = mock.create_autospec(installation.Installation)
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    the_threads.delete_thread.side_effect = tsdr_side_effect
+
+    with expectation as expected:
+        found = await agui_views.delete_room_agui_thread_id(
+            request,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            the_installation=the_installation,
+            the_threads=the_threads,
+            the_authz_policy=the_authz_policy,
+            the_user_claims=THE_USER_CLAIMS,
+            the_logger=the_logger,
+        )
+
+    if isinstance(expected, int):
+        assert isinstance(found, fastapi.Response)
+        assert found.status_code == expected
+
+    the_threads.delete_thread.assert_called_once_with(
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID,
+    )
+    cuir.assert_called_once_with(
+        room_id=TEST_ROOM_ID,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+    the_logger.debug.assert_called_once_with(loggers.AGUI_DELETE_ROOM_THREAD)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("w_usage", [False, True])
+@mock.patch("soliplex.agui.persistence.ThreadStorage")
+@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
+async def test_capture_usage_after_stream(a_session, t_storage, w_usage):
+    w_session = a_session.return_value.__aenter__.return_value
+    the_threads = t_storage.return_value
+    the_threads.save_run_usage = mock.AsyncMock(spec_set=())
+    sqla_engine = object()
+    usage = mock.create_autospec(
+        agui_package.RunUsage,
+        input_tokens=1,
+        output_tokens=2,
+        requests=3,
+        tool_calls=4,
+    )
+    if w_usage:
+        result = mock.Mock(spec_set=["usage"])
+        result.usage.return_value = usage
+    else:
+        result = object()
+
+    await agui_views.capture_usage_after_stream(
+        result,
+        sqla_engine=sqla_engine,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID,
+        run_id=TEST_RUN_ID,
+    )
+
+    if w_usage:
+        the_threads.save_run_usage.assert_awaited_once_with(
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            run_id=TEST_RUN_ID,
+            input_tokens=1,
+            output_tokens=2,
+            requests=3,
+            tool_calls=4,
+        )
+        t_storage.assert_called_once_with(w_session)
+        a_session.assert_called_once_with(bind=sqla_engine)
+    else:
+        the_threads.save_run_usage.assert_not_awaited()
+        t_storage.assert_not_called()
+        a_session.assert_not_called()
+
+
 @pytest.mark.asyncio
 @mock.patch("soliplex.agui.persistence.ThreadStorage")
 @mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
@@ -1047,11 +1156,11 @@ async def test_stream_llm_events(num_events):
         (ALREADY_STARTED, raises_httpexc(code=400, match="already started")),
     ],
 )
-@pytest.mark.parametrize("w_usage", [False, True])
 @mock.patch("fastapi.responses.StreamingResponse")
 @mock.patch("soliplex.views.streaming.stream_sse_with_keepalive")
 @mock.patch("soliplex.views.agui.stream_llm_events")
 @mock.patch("soliplex.views.agui.drive_llm_stream")
+@mock.patch("soliplex.views.agui.capture_usage_after_stream")
 @mock.patch("soliplex.agui.compact_event_stream")
 @mock.patch("pydantic_ai.ui.ag_ui.AGUIAdapter")
 @mock.patch("soliplex.views.agui._check_user_room_agent")
@@ -1061,6 +1170,7 @@ async def test_post_room_agui_thread_id_run_id_streaming(
     cura,
     aga,
     ces,
+    cuas,
     dls,
     sle,
     sswk,
@@ -1068,7 +1178,6 @@ async def test_post_room_agui_thread_id_run_id_streaming(
     the_threads,
     test_run,
     run_input,
-    w_usage,
     ari_side_effect,
     expectation,
 ):
@@ -1154,38 +1263,22 @@ async def test_post_room_agui_thread_id_run_id_streaming(
         assert rs_call_0.args == ()
         assert rs_call_0.kwargs["deps"] is exp_deps
         capture = rs_call_0.kwargs["on_complete"]
-        assert capture.__name__ == "capture_usage_after_stream"
-
-        the_threads.save_run_usage.assert_not_awaited()
+        assert isinstance(capture, functools.partial)
+        assert capture.func is cuas
 
         rs_on_complete = rs_call_0.kwargs["on_complete"]
-
-        if w_usage:
-            faux_result = mock.Mock()
-            faux_result.usage.return_value = agui_package.RunUsageStats(
-                1,
-                2,
-                3,
-                4,
-            )
-        else:
-            faux_result = object()
+        faux_result = object()
 
         await rs_on_complete(faux_result)
 
-        if w_usage:
-            the_threads.save_run_usage.assert_awaited_once_with(
-                user_name=USER_NAME,
-                room_id=TEST_ROOM_ID,
-                thread_id=TEST_THREAD_ID,
-                run_id=TEST_RUN_ID,
-                input_tokens=1,
-                output_tokens=2,
-                requests=3,
-                tool_calls=4,
-            )
-        else:
-            the_threads.save_run_usage.assert_not_awaited()
+        cuas.assert_awaited_once_with(
+            faux_result,
+            sqla_engine=sqla_engine,
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            run_id=TEST_RUN_ID,
+        )
 
         the_installation.get_agent_deps_for_room.assert_called_once_with(
             room_id=TEST_ROOM_ID,
@@ -1367,61 +1460,3 @@ async def test_post_room_agui_thread_id_run_id_feedback(
     the_logger.debug.assert_called_once_with(
         loggers.AGUI_POST_ROOM_THREAD_RUN_FEEDBACK,
     )
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize(
-    "tsdr_side_effect, expectation",
-    [
-        (None, no_error(204)),
-        (UNKNOWN_THREAD, raises_httpexc(code=404, match="Unknown thread")),
-        (THREAD_ROOM_MISMATCH, raises_httpexc(code=400, match="Thread room")),
-    ],
-)
-@mock.patch("soliplex.views.agui._check_user_in_room")
-async def test_delete_room_agui_thread_id(
-    cuir,
-    the_threads,
-    test_thread,
-    tsdr_side_effect,
-    expectation,
-):
-    room_config = mock.create_autospec(config_rooms.RoomConfig)
-    cuir.return_value = room_config
-
-    request = fastapi.Request(scope={"type": "http"})
-    the_installation = mock.create_autospec(installation.Installation)
-    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
-    the_logger = mock.create_autospec(loggers.LogWrapper)
-
-    the_threads.delete_thread.side_effect = tsdr_side_effect
-
-    with expectation as expected:
-        found = await agui_views.delete_room_agui_thread_id(
-            request,
-            room_id=TEST_ROOM_ID,
-            thread_id=TEST_THREAD_ID,
-            the_installation=the_installation,
-            the_threads=the_threads,
-            the_authz_policy=the_authz_policy,
-            the_user_claims=THE_USER_CLAIMS,
-            the_logger=the_logger,
-        )
-
-    if isinstance(expected, int):
-        assert isinstance(found, fastapi.Response)
-        assert found.status_code == expected
-
-    the_threads.delete_thread.assert_called_once_with(
-        user_name=USER_NAME,
-        room_id=TEST_ROOM_ID,
-        thread_id=TEST_THREAD_ID,
-    )
-    cuir.assert_called_once_with(
-        room_id=TEST_ROOM_ID,
-        the_installation=the_installation,
-        the_authz_policy=the_authz_policy,
-        the_user_claims=THE_USER_CLAIMS,
-        the_logger=the_logger,
-    )
-    the_logger.debug.assert_called_once_with(loggers.AGUI_DELETE_ROOM_THREAD)


### PR DESCRIPTION
Hoist it to module level, and pass it the 'sqla_engine'.

refactor: reorder AGUI views for clarity

Closes #719.