### PR TITLE
fix: avoid losing 'drive_llm_task' to GC

### DIFF
--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -54,6 +54,7 @@ def curry_lifespan(
 def app_with_lifespan(curried_lifespan: typing.Callable) -> fastapi.FastAPI:
     acm_lifespan = contextlib.asynccontextmanager(curried_lifespan)
     app = fastapi.FastAPI(lifespan=acm_lifespan)
+    app.state.agui_background_tasks = set()
 
     return app
 

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -645,7 +645,8 @@ async def post_room_agui_thread_id_run_id(
 
     # Drive the LLM stream in a background task, in order to save
     # the thread persistence and usage at the end.
-    asyncio.create_task(
+    bg_tasks = request.app.state.agui_background_tasks
+    task = asyncio.create_task(
         # No 'await' here:  'create_task' *wants* a coroutine
         drive_llm_stream(
             llm_stream=compacted_stream,
@@ -657,6 +658,8 @@ async def post_room_agui_thread_id_run_id(
             run_id=run_id,
         )
     )
+    bg_tasks.add(task)
+    task.add_done_callback(bg_tasks.discard)
 
     # Stream events to the client from the queue, as pushed from
     # the driver.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -99,6 +99,7 @@ def test_app_with_lifespan(acm, fapi):
     found = main.app_with_lifespan(lifespan)
 
     assert found is fapi.return_value
+    assert found.state.agui_background_tasks == set()
 
     fapi.assert_called_once_with(lifespan=acm.return_value)
     acm.assert_called_once_with(lifespan)

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1076,7 +1076,10 @@ async def test_post_room_agui_thread_id_run_id_streaming(
     agent = object()
     cura.return_value = (USER_PROFILE, agent)
 
-    request = fastapi.Request(scope={"type": "http"})
+    state = mock.Mock()
+    global_agui_bg_tasks = state.agui_background_tasks = set()
+    app = mock.create_autospec(fastapi.FastAPI, state=state)
+    request = fastapi.Request(scope={"type": "http", "app": app})
     sqla_engine = request.state.threads_engine = object()
 
     the_installation = mock.create_autospec(installation.Installation)
@@ -1137,6 +1140,7 @@ async def test_post_room_agui_thread_id_run_id_streaming(
         assert sle.call_args_list[0].kwargs == {}
         (event_queue,) = sle.call_args_list[0].args
 
+        # asyncio.task starts 'drive_llm_stream' right away.
         dls.assert_called_once_with(
             llm_stream=ces.return_value,
             sqla_engine=sqla_engine,
@@ -1214,6 +1218,9 @@ async def test_post_room_agui_thread_id_run_id_streaming(
             the_user_claims=THE_USER_CLAIMS,
             the_logger=the_logger,
         )
+
+        assert state.agui_background_tasks is global_agui_bg_tasks
+        assert len(global_agui_bg_tasks) == 1
 
     the_logger.debug.assert_called_once_with(loggers.AGUI_POST_ROOM_THREAD_RUN)
 


### PR DESCRIPTION
Stash it in a quasi-global set on the FastAPI app object's 'state'.

Closes #720.