### PR TITLE
feat: 'agui.ThreadStorage.list_recent_run_feedback'

### DIFF
--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import collections.abc
 import datetime
+import enum
 import typing
 
 import fastapi
@@ -112,6 +113,24 @@ class RunUsage(abc.ABC):
         """Return values as a tuple."""
 
 
+class FeedbackReviewStatus(enum.StrEnum):
+    """Workflow state for feedback."""
+
+    REVIEWED = "reviewed"
+    RESOLVED = "resolved"
+
+
+class RunFeedbackReviewEntry(abc.ABC):
+    status: FeedbackReviewStatus
+    """Reviewer marked state"""
+
+    note: str | None = None
+    """Reviewer supplied"""
+
+    created: datetime.datetime
+    """Timestamp"""
+
+
 class RunFeedback(abc.ABC):
     """Feedback returned from a user for a run"""
 
@@ -120,6 +139,15 @@ class RunFeedback(abc.ABC):
 
     reason: str | None
     """Explanation"""
+
+    created: datetime.datetime
+    """Timestamp"""
+
+    updated: datetime.datetime
+    """Timestamp"""
+
+    review_history: list[RunFeedbackReviewEntry]
+    """Track review state over time"""
 
 
 class RunMetadata(abc.ABC):
@@ -387,6 +415,44 @@ class ThreadStorage(abc.ABC):
         Selected values are returned in most-recent first order,
         based on the run's timestamp.
         """
+
+    @typing.overload
+    async def review_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        run_feedback: RunFeedback,
+    ) -> RunFeedbackReviewEntry: ...
+
+    @typing.overload
+    async def review_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+    ) -> RunFeedbackReviewEntry: ...
+
+    @typing.overload
+    async def resolve_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        run_feedback: RunFeedback,
+    ) -> RunFeedbackReviewEntry: ...
+
+    @typing.overload
+    async def resolve_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+    ) -> RunFeedbackReviewEntry: ...
 
 
 async def compact_event_stream(stream: AGUI_EventStream):

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -9,11 +9,20 @@ from sqlalchemy import sql as sqla_sql
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agui as agui_package
+from soliplex.agui import persistence as agui_persistence
 from soliplex.agui import schema as agui_schema
 from soliplex.agui import util as agui_util
 
 # Temporary backward-compatibility:  to be removed in 'v0.45'
 from soliplex.agui.schema import *  # noqa F403
+
+FeedbackReviewStatus = agui_package.FeedbackReviewStatus
+
+
+class NoFeedbackFound(ValueError):
+    def __init__(self, run_id: str):
+        self.run_id = run_id
+        super().__init__(f"No feed back found for run: {run_id}")
 
 
 class ThreadStorage(agui_package.ThreadStorage):
@@ -438,8 +447,6 @@ class ThreadStorage(agui_package.ThreadStorage):
         """Get the run feedback"""
         await self._session.commit()
 
-        result = None
-
         async with self.session as session:
             run = await self._find_thread_run(
                 user_name=user_name,
@@ -449,12 +456,7 @@ class ThreadStorage(agui_package.ThreadStorage):
                 session=session,
             )
 
-            existing = await run.awaitable_attrs.run_feedback
-
-            if existing is not None:
-                result = existing
-
-        return result
+            return await run.awaitable_attrs.run_feedback
 
     async def list_recent_run_feedback(
         self,
@@ -464,7 +466,8 @@ class ThreadStorage(agui_package.ThreadStorage):
         thread_id: str | None = None,
         limit: int | None = None,
         since: datetime.datetime | None = None,
-    ) -> typing.Sequence[agui_schema.Run]:
+        status: FeedbackReviewStatus | None = None,
+    ) -> typing.Sequence[agui_schema.RunFeedback]:
         """Query run feedback matching given criteria
 
         Selected values are returned in most-recent first order,
@@ -489,6 +492,18 @@ class ThreadStorage(agui_package.ThreadStorage):
                 .order_by(agui_schema.RunFeedback.created.desc())
             )
 
+            if status is not None:
+                query = (
+                    query.join(agui_schema.RunFeedback.review_history)
+                    .where(
+                        agui_schema.RunFeedbackReviewEntry.status == status,
+                    )
+                    .order_by(
+                        agui_schema.RunFeedbackReviewEntry.created,
+                    )
+                    .distinct()
+                )
+
             if room_id is not None:
                 query = query.where(agui_schema.Thread.room_id == room_id)
 
@@ -505,3 +520,147 @@ class ThreadStorage(agui_package.ThreadStorage):
                 query = query.limit(limit)
 
             return (await session.scalars(query)).all()
+
+    async def _find_run_feedback(
+        self,
+        session,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+    ) -> agui_schema.RunFeedback:
+        run = await self._find_thread_run(
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+            session=session,
+        )
+        run_feedback = await run.awaitable_attrs.run_feedback
+
+        if run_feedback is None:
+            raise NoFeedbackFound(run.run_id)
+
+        return run_feedback
+
+    async def _record_run_feedback_history(
+        self,
+        session,
+        run_feedback: agui_persistence.RunFeedback,
+        status: FeedbackReviewStatus,
+        note: str | None,
+    ):
+        history_entry = agui_schema.RunFeedbackReviewEntry(
+            run_feedback=run_feedback,
+            status=status,
+            note=note,
+        )
+        session.add(history_entry)
+
+        return history_entry
+
+    @typing.overload
+    async def review_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        run_feedback: agui_persistence.RunFeedback,
+    ) -> agui_schema.RunFeedbackReviewEntry: ...
+
+    @typing.overload
+    async def review_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+    ) -> agui_schema.RunFeedbackReviewEntry: ...
+
+    async def review_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        run_feedback: agui_persistence.RunFeedback | None = None,
+        user_name: str | None = None,
+        room_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+    ) -> agui_schema.RunFeedbackReviewEntry:
+        """Note that a run's feedback has been reviewed.
+
+        Find the feedback from its run.
+        """
+
+        async with self.session as session:
+            if run_feedback is None:
+                run_feedback = await self._find_run_feedback(
+                    user_name=user_name,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    session=session,
+                )
+
+            history_entry = await self._record_run_feedback_history(
+                session,
+                run_feedback,
+                FeedbackReviewStatus.REVIEWED,
+                note,
+            )
+
+            return history_entry
+
+    @typing.overload
+    async def resolve_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        run_feedback: agui_persistence.RunFeedback,
+    ) -> agui_schema.RunFeedbackReviewEntry: ...
+
+    @typing.overload
+    async def resolve_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+    ) -> agui_schema.RunFeedbackReviewEntry: ...
+
+    async def resolve_run_feedback(
+        self,
+        note: str | None = None,
+        *,
+        run_feedback: agui_persistence.RunFeedback | None = None,
+        user_name: str | None = None,
+        room_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+    ) -> agui_schema.RunFeedbackReviewEntry:
+        """Note that a run's feedback has been resolveed.
+
+        Find the feedback from its run.
+        """
+
+        async with self.session as session:
+            if run_feedback is None:
+                run_feedback = await self._find_run_feedback(
+                    user_name=user_name,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    session=session,
+                )
+
+            history_entry = await self._record_run_feedback_history(
+                session,
+                run_feedback,
+                FeedbackReviewStatus.RESOLVED,
+                note,
+            )
+
+            return history_entry

--- a/src/soliplex/agui/schema.py
+++ b/src/soliplex/agui/schema.py
@@ -42,6 +42,8 @@ JSON_Mapped_From = dict[str, typing.Any]
 
 metadata = sqla_schema.MetaData(naming_convention=NAMING_CONVENTION)
 
+FeedbackReviewStatus = agui_package.FeedbackReviewStatus
+
 
 class Base(AsyncAttrs, DeclarativeBase):
     metadata = metadata
@@ -484,6 +486,10 @@ class RunFeedback(Base):
         sqla_sqltypes.TIMESTAMP(timezone=True),
         default=agui_util._timestamp,
     )
+    updated: Mapped[datetime.datetime | None] = mapped_column(
+        sqla_sqltypes.TIMESTAMP(timezone=True),
+        default=None,
+    )
 
     run_id_: Mapped[int] = mapped_column(
         ForeignKey("run.id_", ondelete="CASCADE"),
@@ -492,6 +498,43 @@ class RunFeedback(Base):
 
     feedback: Mapped[str] = mapped_column()
     reason: Mapped[str | None] = mapped_column(default=None)
+
+    review_history: Mapped[list[RunFeedbackReviewEntry]] = relationship(
+        back_populates="run_feedback",
+        cascade="all, delete",
+        passive_deletes=True,
+        order_by="desc(RunFeedbackReviewEntry.created)",
+    )
+
+
+class RunFeedbackReviewEntry(Base):
+    """Hold optional feedback info for an AG-UI run
+
+    'run' is a one-to-one relationship to 'Run' (but optional from
+          the run side).
+
+    'feedback', str, required
+    'reason', str, optional
+    """
+
+    __tablename__ = "review_history"
+
+    id_: Mapped[int] = mapped_column(primary_key=True)
+    created: Mapped[datetime.datetime] = mapped_column(
+        sqla_sqltypes.TIMESTAMP(timezone=True),
+        default=agui_util._timestamp,
+    )
+
+    run_feedback_id_: Mapped[int] = mapped_column(
+        ForeignKey("run_feedback.id_", ondelete="CASCADE"),
+    )
+    run_feedback: Mapped[RunFeedback] = relationship(
+        back_populates="review_history",
+    )
+
+    status: Mapped[FeedbackReviewStatus | None] = mapped_column()
+
+    note: Mapped[str | None] = mapped_column(default=None)
 
 
 def get_engine(

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -11,6 +11,8 @@ from soliplex.agui import schema as agui_schema
 from soliplex.config import installation as config_installation
 from tests.unit.agui import agui_constants
 
+FeedbackReviewStatus = agui_package.FeedbackReviewStatus
+
 NOW = datetime.datetime.now(datetime.UTC)
 
 ROOM_ID = "test-room"
@@ -704,6 +706,252 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     tid_earlier_fb = await tid_earlier.awaitable_attrs.run_feedback
     assert await tid_earlier_fb.awaitable_attrs.feedback == "thumbs_up"
     assert await tid_earlier_fb.awaitable_attrs.reason == "fresh"
+
+    # Feedback review workflow
+    tid_later_hist = await tid_later_fb.awaitable_attrs.review_history
+    assert tid_later_hist == []
+
+    await the_async_session.commit()
+
+    await ts.review_run_feedback(
+        note="reviewing feedback",
+        run_feedback=tid_later_fb,
+    )
+
+    await the_async_session.commit()
+
+    tid_later_hist = await tid_later_fb.awaitable_attrs.review_history
+    (tid_later_entry,) = tid_later_hist
+    assert await tid_later_entry.awaitable_attrs.run_feedback is tid_later_fb
+    assert await tid_later_entry.awaitable_attrs.status == (
+        FeedbackReviewStatus.REVIEWED
+    )
+    assert await tid_later_entry.awaitable_attrs.note == "reviewing feedback"
+
+    await the_async_session.commit()
+
+    await ts.resolve_run_feedback(
+        note="resolving feedback",
+        run_feedback=tid_later_fb,
+    )
+    tid_later_hist = await tid_later_fb.awaitable_attrs.review_history
+
+    # Check that review history is sorted in descending order
+    (
+        first_entry,
+        *_,
+    ) = tid_later_hist
+    assert await first_entry.awaitable_attrs.run_feedback is tid_later_fb
+    assert await first_entry.awaitable_attrs.status == (
+        FeedbackReviewStatus.RESOLVED
+    )
+    assert await first_entry.awaitable_attrs.note == ("resolving feedback")
+
+    (
+        *_,
+        last_entry,
+    ) = tid_later_hist
+    assert await last_entry.awaitable_attrs.run_feedback is tid_later_fb
+    assert await last_entry.awaitable_attrs.status == (
+        FeedbackReviewStatus.REVIEWED
+    )
+    assert await last_entry.awaitable_attrs.note == ("reviewing feedback")
+
+    await the_async_session.commit()
+
+    # Feedback review workflow using lookup
+    await ts.review_run_feedback(
+        note="reviewing feedback",
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=added_id,
+    )
+
+    await the_async_session.commit()
+
+    tid_earlier_hist = await tid_earlier_fb.awaitable_attrs.review_history
+    (tid_earlier_entry,) = tid_earlier_hist
+    assert (
+        await tid_earlier_entry.awaitable_attrs.run_feedback is tid_earlier_fb
+    )
+    assert await tid_earlier_entry.awaitable_attrs.status == (
+        FeedbackReviewStatus.REVIEWED
+    )
+    assert await tid_earlier_entry.awaitable_attrs.note == "reviewing feedback"
+
+    await the_async_session.commit()
+
+    await ts.resolve_run_feedback(
+        note="resolving feedback",
+        run_feedback=tid_later_fb,
+    )
+    tid_later_hist = await tid_later_fb.awaitable_attrs.review_history
+
+    (
+        first_entry,
+        *_,
+    ) = tid_later_hist
+    assert await first_entry.awaitable_attrs.run_feedback is tid_later_fb
+    assert await first_entry.awaitable_attrs.status == (
+        FeedbackReviewStatus.RESOLVED
+    )
+    assert await first_entry.awaitable_attrs.note == "resolving feedback"
+
+    (
+        *_,
+        last_entry,
+    ) = tid_later_hist
+    assert await last_entry.awaitable_attrs.run_feedback is tid_later_fb
+    assert await last_entry.awaitable_attrs.status == (
+        FeedbackReviewStatus.REVIEWED
+    )
+    assert await last_entry.awaitable_attrs.note == "reviewing feedback"
+
+    await the_async_session.commit()
+
+    await ts.resolve_run_feedback(
+        note="resolving feedback",
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=added_id,
+    )
+
+    await the_async_session.commit()
+
+    tid_earlier_hist = await tid_earlier_fb.awaitable_attrs.review_history
+
+    (
+        first_entry,
+        *_,
+    ) = tid_earlier_hist
+    assert await first_entry.awaitable_attrs.run_feedback is tid_earlier_fb
+    assert await first_entry.awaitable_attrs.status == (
+        FeedbackReviewStatus.RESOLVED
+    )
+
+    (
+        *_,
+        last_entry,
+    ) = tid_earlier_hist
+    assert await last_entry.awaitable_attrs.run_feedback is tid_earlier_fb
+    assert await last_entry.awaitable_attrs.status == (
+        FeedbackReviewStatus.REVIEWED
+    )
+    assert await last_entry.awaitable_attrs.note == "reviewing feedback"
+
+    await the_async_session.commit()
+
+    # Test lookup where no feedback found
+    no_feedback = await ts.new_run(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+    )
+    no_feedback_id = await no_feedback.awaitable_attrs.run_id
+
+    await the_async_session.commit()
+
+    with pytest.raises(agui_persistence.NoFeedbackFound):
+        await ts.review_run_feedback(
+            note="reviewing feedback",
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            run_id=no_feedback_id,
+        )
+
+    await the_async_session.commit()
+
+    with pytest.raises(agui_persistence.NoFeedbackFound):
+        await ts.resolve_run_feedback(
+            note="resolving feedback",
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            run_id=no_feedback_id,
+        )
+
+    await the_async_session.commit()
+
+    # Query for reviewed status
+    review_only = await ts.new_run(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+    )
+    review_only_id = await review_only.awaitable_attrs.run_id
+
+    await the_async_session.commit()
+
+    await ts.save_run_feedback(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=review_only_id,
+        feedback="thumbs_up",
+        reason="winning",
+    )
+
+    await the_async_session.commit()
+
+    review_only_fb = await review_only.awaitable_attrs.run_feedback
+
+    await the_async_session.commit()
+
+    await ts.review_run_feedback(
+        note="reviewing feedback; no resolve",
+        run_feedback=review_only_fb,
+    )
+
+    await the_async_session.commit()
+
+    resolve_only = await ts.new_run(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+    )
+    await the_async_session.commit()
+
+    resolve_only_id = await resolve_only.awaitable_attrs.run_id
+
+    await the_async_session.commit()
+
+    await ts.save_run_feedback(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=resolve_only_id,
+        feedback="thumbs_up",
+        reason="winning",
+    )
+
+    await the_async_session.commit()
+
+    resolve_only_fb = await resolve_only.awaitable_attrs.run_feedback
+
+    await the_async_session.commit()
+
+    await ts.resolve_run_feedback(
+        note="resolving feedback; no view",
+        run_feedback=resolve_only_fb,
+    )
+
+    await the_async_session.commit()
+
+    w_reviewed = await ts.list_recent_run_feedback(
+        status=agui_package.FeedbackReviewStatus.REVIEWED,
+    )
+    assert review_only in w_reviewed
+    assert resolve_only not in w_reviewed
+
+    # Query for resolved status
+    w_resolved = await ts.list_recent_run_feedback(
+        status=agui_package.FeedbackReviewStatus.RESOLVED,
+    )
+    assert review_only not in w_resolved
+    assert resolve_only in w_resolved
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
... add ability to query for runs whose review history contains entries in 'REVIEWED' or 'RESOLVED' status.

feat: 'agui.ThreadStorage.{review,resolve}_run_feedback'

feat: schema support for feedback review history

Closes #730.