### PR TITLE
fix: agui parser crashing with nested tool calls

### DIFF
--- a/src/soliplex/agui/parser.py
+++ b/src/soliplex/agui/parser.py
@@ -407,6 +407,9 @@ class EventStreamParser:
                         )
                         self._add_message(parent_message)
 
+                    elif parent_message.tool_calls is None:
+                        parent_message.tool_calls = []
+
                 else:
                     parent_message = None
 
@@ -444,6 +447,8 @@ class EventStreamParser:
                 self.completed_tool_calls.add(event.tool_call_id)
 
                 if parent is not None:
+                    if parent.tool_calls is None:
+                        parent.tool_calls = []
                     parent.tool_calls.append(tool_call)
 
             case agui_core.EventType.TOOL_CALL_RESULT:

--- a/tests/unit/agui/test_agui_parser.py
+++ b/tests/unit/agui/test_agui_parser.py
@@ -651,6 +651,19 @@ tool_call_nonesuch = pytest.raises(agui_parser.ToolCallDoesNotExist)
             W_PARENT_E_TOOL_CALL_START,
             no_error(None),
         ),
+        # Parent exists but tool_calls is None
+        (
+            RUNNING,
+            [
+                agui_core.AssistantMessage(
+                    id=TOOL_CALL_PARENT_MESSAGE_ID,
+                    content="",
+                )
+            ],
+            {},
+            W_PARENT_E_TOOL_CALL_START,
+            no_error(None),
+        ),
         (RUNNING, [], {}, W_PARENT_E_TOOL_CALL_START, no_error(None)),
         (FINISHED, [], {}, E_TOOL_CALL_START, not_running),
         (ERROR, [], {}, E_TOOL_CALL_START, not_running),
@@ -773,6 +786,21 @@ def test_esp_call_w_tool_call_args(
                 TOOL_CALL_ID: (
                     TOOL_CALL,
                     TOOL_CALL_PARENT_MESSAGE.model_copy(deep=True),
+                )
+            },
+            E_TOOL_CALL_END,
+            no_error(None),
+        ),
+        # Parent created by TEXT_MESSAGE_START has tool_calls=None
+        (
+            RUNNING,
+            {
+                TOOL_CALL_ID: (
+                    TOOL_CALL,
+                    agui_core.AssistantMessage(
+                        id=TOOL_CALL_PARENT_MESSAGE_ID,
+                        content="",
+                    ),
                 )
             },
             E_TOOL_CALL_END,


### PR DESCRIPTION
Closes #746.

Authored by @bd-mkt in PR #738.

Split from that PR to fix only the parser bug.