### PR TITLE
fix: avoid hard-wired use of '/' for path separators

### DIFF
--- a/src/soliplex/config/quizzes.py
+++ b/src/soliplex/config/quizzes.py
@@ -3,6 +3,7 @@ from __future__ import annotations  # forward refs in typing decls
 import dataclasses
 import enum
 import json
+import os
 import pathlib
 import random
 
@@ -126,7 +127,7 @@ class QuizConfig:
 
     def __post_init__(self, question_file):
         if question_file is not None:
-            if "/" in question_file:
+            if os.sep in question_file or "/" in question_file:
                 self._question_file_path_override = question_file
             else:
                 if question_file.endswith(".json"):

--- a/tests/unit/config/test_config__utils.py
+++ b/tests/unit/config/test_config__utils.py
@@ -1,4 +1,5 @@
 import contextlib
+import pathlib
 from unittest import mock
 
 import pytest
@@ -117,7 +118,9 @@ def test_resolve_file_prefix(temp_dir, config_value, expected):
     config_path = temp_dir / "config.yaml"
 
     if isinstance(expected, str):
-        expected = expected.format(temp_dir=temp_dir.resolve())
+        expected = str(
+            pathlib.Path(expected.format(temp_dir=temp_dir.resolve()))
+        )
 
     found = config_installation.resolve_file_prefix(config_value, config_path)
 

--- a/tests/unit/config/test_config_authsystem.py
+++ b/tests/unit/config/test_config_authsystem.py
@@ -165,7 +165,7 @@ def test_authsystem_from_yaml(
     if oidc_client_pem_path is not None:
         expected = dataclasses.replace(
             expected,
-            oidc_client_pem_path=pathlib.Path(oidc_client_pem_path),
+            oidc_client_pem_path=config_path.parent / oidc_client_pem_path,
         )
 
     expected._config_path = config_path

--- a/tests/unit/config/test_config_installation.py
+++ b/tests/unit/config/test_config_installation.py
@@ -853,7 +853,14 @@ environment: production
     else:
         exp_obu = "http://localhost:11434"
 
-    with mock.patch.dict("os.environ", clear=True):
+    import os
+
+    home_vars = {
+        k: v
+        for k, v in os.environ.items()
+        if k in ("HOME", "HOMEDRIVE", "HOMEPATH", "USERPROFILE")
+    }
+    with mock.patch.dict("os.environ", home_vars, clear=True):
         hr_config = i_config.haiku_rag_config
 
     assert isinstance(hr_config, hr_config_module.AppConfig)
@@ -1247,6 +1254,11 @@ def test_installationconfig_from_yaml(
             expected_kw["_haiku_rag_config_file"] = (
                 config_path.parent / "haiku.rag.yaml"
             )
+        else:
+            # Match from_yaml: config_path.parent / hr_config_file
+            expected_kw["_haiku_rag_config_file"] = (
+                config_path.parent / expected_kw["_haiku_rag_config_file"]
+            )
 
         lfssc = mock.Mock(spec_set=())
         fs_skill_config = mock.create_autospec(
@@ -1450,16 +1462,19 @@ def test_installationconfig_as_yaml(w_logfire_config):
         "environment": {
             "OLLAMA_BASE_URL": OLLAMA_BASE_URL,
         },
-        "haiku_rag_config_file": HAIKU_RAG_CONFIG_FILE,
+        "haiku_rag_config_file": str(pathlib.Path(HAIKU_RAG_CONFIG_FILE)),
         "agent_configs": [
             agent_config.as_yaml,
         ],
-        "logging_config_file": LOGGING_CONFIG_FILE,
-        "oidc_paths": ["oidc-test"],
-        "room_paths": ["/path/to/rooms", "other/rooms"],
-        "completion_paths": ["/path/to/completions"],
-        "quizzes_paths": ["other/quizzes"],
-        "filesystem_skills_paths": ["other/skills"],
+        "logging_config_file": str(pathlib.Path(LOGGING_CONFIG_FILE)),
+        "oidc_paths": [str(pathlib.Path("oidc-test"))],
+        "room_paths": [
+            str(pathlib.Path("/path/to/rooms")),
+            str(pathlib.Path("other/rooms")),
+        ],
+        "completion_paths": [str(pathlib.Path("/path/to/completions"))],
+        "quizzes_paths": [str(pathlib.Path("other/quizzes"))],
+        "filesystem_skills_paths": [str(pathlib.Path("other/skills"))],
     }
 
     if w_logfire_config:
@@ -1487,10 +1502,9 @@ def test_installationconfig_oidc_auth_system_configs_wo_existing(
     w_pem,
     w_pem_path,
 ):
-    if w_pem_path.startswith("."):
-        exp_oidc_client_pem_path = temp_dir / "oidc_bare" / w_pem_path
-    else:
-        exp_oidc_client_pem_path = pathlib.Path(w_pem_path)
+    oidc_bare_path = temp_dir / "oidc_bare"
+    # Match source: oidc_path / pem_path
+    exp_oidc_client_pem_path = oidc_bare_path / w_pem_path
 
     bare_config_yaml = {
         "auth_systems": [test_authsystem.BARE_AUTHSYSTEM_CONFIG_KW.copy()],

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -1,4 +1,5 @@
 import contextlib
+import pathlib
 from unittest import mock
 
 import pytest
@@ -194,7 +195,11 @@ def test_get_env_var_secret_w_installation_config(
 @pytest.mark.parametrize(
     "file_path, expectation, expected",
     [
-        ("/path/to/nowhere", FilePathNotFound, ERROR_MISS),
+        (
+            str(pathlib.Path("/path/to/nowhere").resolve()),
+            FilePathNotFound,
+            ERROR_MISS,
+        ),
         ("./nonesuch", FilePathNotFound, ERROR_MISS),
         ("./secret_file", NoRaise, SECRET_VALUE),
     ],


### PR DESCRIPTION
... for Windows compatibility.

Closes #747.

Authored by @bd-mkt in PR #738.

Split from that PR to fix only the Windows / pathsep issue.