### PR TITLE
fix: call 'config_routing.add_registered_routers'

### DIFF
--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -25,6 +25,7 @@ from soliplex.config import completions as config_completions
 from soliplex.config import installation as config_installation
 from soliplex.config import logfire as config_logfire
 from soliplex.config import rooms as config_rooms
+from soliplex.config import routing as config_routing
 
 ProviderURL = str | None
 ProviderModelNames = set[str]
@@ -444,6 +445,8 @@ async def lifespan(
     the_installation.resolve_secrets()
     the_installation.resolve_environment()
     the_installation.resolve_app_routers()
+
+    config_routing.add_registered_routers(app)
 
     if log_config_file is not None:
         log_config_file = pathlib.Path(log_config_file)

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -1301,11 +1301,13 @@ def mcp_apps():
 @mock.patch("soliplex.installation.apply_logfire_configuration")
 @mock.patch("soliplex.secrets.resolve_secrets")
 @mock.patch("soliplex.mcp_server.setup_mcp_for_rooms")
+@mock.patch("soliplex.config.routing.add_registered_routers")
 @mock.patch("soliplex.config.installation.load_installation")
 @mock.patch("logging.config.dictConfig")
 async def test_lifespan(
     lcdc,
     load_installation,
+    arr,
     smfr,
     srs,
     alc,
@@ -1375,6 +1377,8 @@ root:
     i_config.reload_configurations.assert_called_once_with()
     i_config.resolve_environment.assert_called_once_with()
     i_config.resolve_app_routers.assert_called_once_with()
+
+    arr.assert_called_once_with(app)
 
     load_installation.assert_called_once_with(INSTALLATION_PATH)
 


### PR DESCRIPTION
... after populating the registry from the configuration.

Closes #752.

I will make a new release from the `v0.50.x` branch with this fix shortly.