### PR TITLE
WIP: 'skills.agui_run_feedback' skill

### DIFF
--- a/example/minimal-openai.yaml
+++ b/example/minimal-openai.yaml
@@ -329,6 +329,7 @@ room_paths:
   - "./rooms/skillstest"
   - "./rooms/multi_arg"
   - "./rooms/title_only"
+  - "./rooms/feedback"
 
 #==========================================================================
 # Completions configuration

--- a/example/minimal.yaml
+++ b/example/minimal.yaml
@@ -291,6 +291,9 @@ skill_configs:
   - skill_name: "bare-bones"
     kind: "filesystem"
 
+  - skill_name: "agui-run-feedback"
+    kind: "entrypoint"
+
 # Requires installing 'haiku-skills-image-generation'
 # - skill_name: "image-generation"
 #   kind: "entrypoint"
@@ -313,6 +316,7 @@ room_paths:
   - "./rooms/skillstest"
   - "./rooms/multi_arg"
   - "./rooms/title_only"
+  - "./rooms/feedback"
 
 #==========================================================================
 # Completions configuration

--- a/example/rooms/feedback/room_config.yaml
+++ b/example/rooms/feedback/room_config.yaml
@@ -1,0 +1,17 @@
+id: "feedback"
+name: "AGUI Run Feedback"
+description: "Test feedback skill."
+suggestions:
+- "List ten most recent AGUI feedback runs"
+
+
+agent:
+  template_id: "default_chat"
+  system_prompt: |
+    You are a friendly agent.  Use the supplied skills as needed when
+    replying to the user's prompts.
+
+skills:
+  installation_skill_names:
+    - "agui-run-feedback"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ soliplex-cli = "soliplex.cli:the_cli"
 soliplex-tui = "soliplex.tui.cli:the_cli"
 soliplex-tui-serve = "soliplex.tui.serve:main"
 
+[project.entry-points."haiku.skills"]
+agui-run-feedback = "soliplex.skills.agui_run_feedback:create_skill"
+
 [dependency-groups]
 dev = [
     "anyio",

--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -42,6 +42,7 @@ class AgentDependencies:
     """
 
     the_installation: typing.Any  # installation.Installation
+    the_threads: typing.Any  # agui.ThreadStorage
     user: models.UserProfile = None  # TBD make required
     tool_configs: ToolConfigMap = None
     thread_id: str | None = None

--- a/src/soliplex/skills/agui_run_feedback/__init__.py
+++ b/src/soliplex/skills/agui_run_feedback/__init__.py
@@ -1,0 +1,202 @@
+"""AI skill for AGUI run feedback
+
+- Allow users to query recent AGUI run feedback
+- Allow privileged users to mark feedback a as "reviewd", "resolved".
+"""
+
+import datetime
+import pathlib
+
+import pydantic
+import pydantic_ai
+from haiku.skills import models as hs_models
+from haiku.skills import parser as hs_parser
+from haiku.skills import state as hs_state
+
+from soliplex import agui as agui_package
+
+STATE_NAMESPACE = "soliplex-agui-run-feedback"
+
+
+class NoThreadsStorage(ValueError):
+    def __init__(self, ctx: pydantic_ai.RunContext):
+        self.ctx = ctx
+        msg = f"No 'the_threads' in context [{','.join(dir(ctx))}]"
+        super().__init__(msg)
+
+
+class StateTypeMismatch(ValueError):
+    def __init__(self, state):
+        self.state = state
+        super().__init__(
+            f"Skill state mismatch:  expected 'RecentRunFeedback', "
+            f"got '{type(state).__name__}'."
+        )
+
+
+class RunFeedbackEntry(pydantic.BaseModel):
+    """State of the feedback for a give AGUI run
+
+    Args:
+
+      'user_name' (string):  email-address of reporting user
+
+      'room_id' (string): ID of the room in which the AGUI run originated.
+
+      'thread_id' (string): UUID of the AGUI thread which spawned the run.
+
+      'run_id' (string): UUID of the run against which the feedback was made.
+
+      'created' (datetime.datetime): timestamp of the feedback.
+
+      'feedback': (one of "thumbs_up", "thumbs_down") user-supplied feedback.
+
+      'reason' (string or None): user-supplied reason for the feedback.
+
+      'status' (one of None, "reviewed", or "resolved"):  State of the
+        feedback in its review / resolution cycle.
+
+      'note': (str, optional): reviewer-supplied description for update
+        to the feedback status.
+    """
+
+    user_name: str
+    room_id: str
+    thread_id: str
+    run_id: str
+    created: datetime.datetime
+    feedback: str
+    reason: str | None
+    status: agui_package.FeedbackReviewStatus | None
+    note: str | None
+
+
+class RecentRunFeedbackQuery(pydantic.BaseModel):
+    """Define a query for recent AGUI run feedback
+
+    Args:
+
+      'user_name' (string, default None):  email-address of reporting user
+        If passed, include feedback only from the user whose username
+        matches this value.
+
+      'room_id' (string, default None): ID of the room in which the
+        AGUI run originated.  If passed, include feedback only for runs
+        in this rooom.
+
+      'limit' (integer, default None): the maximun number of feedback
+        entries to return.  If neither 'limit' nor 'since' are passed,
+        apply a system-defined limit.
+
+      'since' (datetime, default None): if passed, only include feedback
+        reported later than this value.
+    """
+
+    user_name: str | None = None
+    room_id: str | None = None
+    limit: int | None = None
+    since: datetime.datetime | None = None
+
+
+class RecentRunFeedbackEntries(pydantic.BaseModel):
+    """Recent feedback, divided into three buckets:
+
+    - 'opened' entries have not yet been reviewed or resolved.
+
+    - 'reviewed' entries have been reviewed, but not yet resolved.
+
+    - 'resolved' entries have been resolved.
+    """
+
+    opened: list[RunFeedbackEntry] = []
+    reviewed: list[RunFeedbackEntry] = []
+    resolved: list[RunFeedbackEntry] = []
+
+
+class RecentRunFeedback(pydantic.BaseModel):
+    query: RecentRunFeedbackQuery | None = None
+    entries: RecentRunFeedbackEntries | None = None
+
+
+async def _do_query(
+    ctx: pydantic_ai.RunContext[hs_state.SkillRunDeps],
+    query: RecentRunFeedbackQuery,
+) -> RecentRunFeedback:
+    deps = getattr(ctx, "deps", None)
+    the_threads = getattr(deps, "the_threads", None)
+
+    if the_threads is None:
+        raise NoThreadsStorage(ctx)
+
+    recent = await the_threads.list_recent_run_feedback(
+        user_name=query.user_name,
+        room_id=query.room_id,
+        limit=query.limit,
+        since=query.since,
+    )
+
+    entries = RecentRunFeedbackEntries()
+
+    for run_feedback in recent:
+        run = await run_feedback.awaitable_attrs.run
+        review_history = await run_feedback.awaitable_attrs.review_history
+        last = review_history[0]
+        entry = RunFeedbackEntry(
+            user_name=await run.awaitable_attrs.user_name,
+            room_id=await run.awaitable_attrs.room_id,
+            thread_id=await run.awaitable_attrs.thread_id,
+            run_id=await run.awaitable_attrs.run_id,
+            feedback=await run_feedback.awaitable_attrs.feedback,
+            reason=await run_feedback.awaitable_attrs.reason,
+            created=await run_feedback.awaitable_attrs.created,
+            status=await last.awaitable_attrs.status,
+            note=await last.awaitable_attrs.note,
+        )
+
+        if entry.status == "resolved":
+            entries.resolved.insert(0, entry)
+
+        elif entry.status == "reviewed":
+            entries.reviewed.insert(0, entry)
+
+        else:
+            entries.opened.insert(0, entry)
+
+    return entries
+
+
+async def query_recent_feedback(
+    ctx: pydantic_ai.RunContext[hs_state.SkillRunDeps],
+    query: RecentRunFeedbackQuery,
+) -> RecentRunFeedback:
+    """Query recent feedback for AGUI runs
+
+    Store the query and retrieved entries in the AGUI state for this skill.
+    """
+    deps = getattr(ctx, "deps", None)
+    state = getattr(deps, "state", None)
+    if state is not None and isinstance(state, RecentRunFeedback):
+        if query != state.query:
+            entries = await _do_query(ctx, query)
+            ctx.state = RecentRunFeedback(
+                query=query,
+                entries=entries,
+            )
+    return ctx.state.entries
+
+
+def create_skill() -> hs_models.Skill:
+    skill_dir = pathlib.Path(__file__).parent / "agui-run-feedback"
+    metadata, instructions = hs_parser.parse_skill_md(skill_dir / "SKILL.md")
+
+    return hs_models.Skill(
+        metadata=metadata,
+        source=hs_models.SkillSource.ENTRYPOINT,
+        path=skill_dir,
+        instructions=instructions,
+        tools=[
+            query_recent_feedback,
+        ],
+        state_type=RecentRunFeedback,
+        state_namespace=STATE_NAMESPACE,
+    )

--- a/src/soliplex/skills/agui_run_feedback/agui-run-feedback/SKILL.md
+++ b/src/soliplex/skills/agui_run_feedback/agui-run-feedback/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: agui-run-feedback
+description: query and update recent AGUI run feedback
+---
+
+# AGUI Run Feedback
+
+Use the `agui-run-feedback` tool to review and resolve AGUI run feedback.
+
+- Query recent AGUI run feedback based on user prompts.
+- Return feedback instances as Markdown fragments for user review.
+- Update the status of feedback instances based on user prompts.
+

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -701,6 +701,7 @@ async def post_room_agui_thread_id_run_id(
         run_agent_input=agui_adapter.run_input,
         the_logger=the_logger,
     )
+    agent_deps.the_threads = the_threads
 
     agent_stream = agui_adapter.run_stream(
         deps=agent_deps,

--- a/tests/unit/skills/test_agui_run_feedback.py
+++ b/tests/unit/skills/test_agui_run_feedback.py
@@ -1,0 +1,25 @@
+from unittest import mock
+
+import pytest
+
+from soliplex.skills import agui_run_feedback
+
+
+@pytest.fixture
+def rf_query() -> agui_run_feedback.RecentRunFeedbackQuery:
+    pass
+
+
+@pytest.mark.anyio
+async def test__do_query():
+    pass
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.skills.agui_run_feedback._do_query")
+async def test_query_recent_feedback(do_query, rf_query):
+    pass
+
+
+def test_create_skill():
+    pass


### PR DESCRIPTION
- Wire it up as and entrypoint skill (installation level)

- Make it available to the agent in the new 'feedback' room.

- Flail at getting access to the 'the_threads' facade object, needed to query and update AGUI run feedback.