### PR TITLE
chore: resurrect 'search_documents' tool

### DIFF
--- a/example/rooms/search/prompt.txt
+++ b/example/rooms/search/prompt.txt
@@ -1,0 +1,35 @@
+You are an English speaking knowledgeable assistant that helps users find information from a document knowledge base.
+
+IMPORTANT: You MUST use the `search_documents` tool for every question. Do not answer any question without first searching the knowledge base.
+
+Your process:
+1. IMMEDIATELY call the `search_documents` tool with relevant keywords from the user's question
+2. Review the search results and their relevance scores
+3. If you need additional context, perform follow-up searches with different ke
+words
+4. Provide a short and to the point comprehensive answer based only on the retrieved documents
+5. Always include citations for the sources used in your answer
+
+Guidelines:
+- Base your answers strictly on the provided document content
+- If multiple documents contain relevant information, synthesize them coherently
+- Indicate when information is incomplete or when you need to search for additional context
+- If the retrieved documents don't contain sufficient information, clearly state: "I cannot find enough information in the knowledge base to answer this question."
+- For complex questions, consider breaking them down and performing multiple searches
+- Stick to the answer, do not elaborate or provide context unless explicitly asked for it.
+- ALWAYS include citations at the end of your response using the format below
+
+Citation Format:
+After your answer, include a "Citations:" section that lists:
+- The document URI from each search result used
+- A brief excerpt (first 50-100 characters) of the content that supported your answer
+- Format: "Citations:\n- [document_uri]: [content_excerpt]..."
+
+Example response format:
+[Your answer here]
+
+Citations:
+- /path/to/document1.pdf: "This document explains that RTFM stands for Read the Fine Manual..."
+- /path/to/document2.pdf: "The manual provides guidance on business procedures and..."
+
+Be concise, and always maintain accuracy over completeness. Prefer short, direct answers that are well-supported by the documents.

--- a/example/rooms/search/room_config.yaml
+++ b/example/rooms/search/room_config.yaml
@@ -8,15 +8,13 @@ suggestions:
 
 agent:
   template_id: "default_chat"
-  system_prompt: |
-    You are a knowledgeable assistant that answers questions using a document knowledge base.
-    Use search to find relevant information, then synthesize a comprehensive answer.
+  system_prompt: "./prompt.txt"
 
-skills:
-  skill_configs:
-    - kind: "haiku.rag.skills.rag"
-      rag_lancedb_stem: "rag"
-      tool_names:
-        - "search"
+tools:
+  - tool_name: "soliplex.tools.rag.search_documents"
+    rag_lancedb_stem: "rag"
+    search_documents_limit: 7
+    # Apply HR config overrides local to this room
+    #haiku_rag_config: "./haiku.rag.yaml"
 
 allow_mcp: false

--- a/src/soliplex/cli.py
+++ b/src/soliplex/cli.py
@@ -452,9 +452,11 @@ def check_config(
                         the_console.print("  OK")
                     the_console.line()
 
-        for tool_config in room_config.tool_configs:
+        for tool_config in room_config.tool_configs.values():
             if isinstance(tool_config, config_rag._RAGConfigBase):
-                the_console.print("- Checking tool RAG DB: {tool_config.id}")
+                the_console.print(
+                    f"- Checking tool RAG DB: {tool_config.tool_name}"
+                )
                 try:
                     tool_config.rag_lancedb_path  # noqa B018
                 except Exception as exc:

--- a/src/soliplex/config/tools.py
+++ b/src/soliplex/config/tools.py
@@ -13,6 +13,7 @@ from pydantic_ai import tools as ai_tools
 
 from . import _utils
 from . import exceptions as config_exc
+from . import rag as config_rag
 
 # ============================================================================
 #   Tool configuration types
@@ -293,7 +294,55 @@ class ToolConfig:
         return {}
 
 
-TOOL_CONFIG_CLASSES_BY_TOOL_NAME = {}
+SDTC_TOOL_NAME = "soliplex.tools.rag.search_documents"
+_, SDTC_TOOL_KIND = SDTC_TOOL_NAME.rsplit(".", 1)
+
+
+@dataclasses.dataclass(kw_only=True)
+class SearchDocumentsToolConfig(ToolConfig, config_rag._RAGConfigBase):
+    kind: str = SDTC_TOOL_KIND
+    tool_name: str = SDTC_TOOL_NAME
+
+    search_documents_limit: int = 5
+
+    @classmethod
+    def from_yaml(
+        cls,
+        installation_config: InstallationConfig,  # noqa F821 cycle
+        config_path: pathlib.Path,
+        config_dict: dict[str, typing.Any],
+    ):
+        try:
+            config_dict["_installation_config"] = installation_config
+            config_dict["_config_path"] = config_path
+
+            instance = cls(**config_dict)
+        except Exception as exc:
+            raise config_exc.FromYamlException(
+                config_path,
+                "sdtc",
+                config_dict,
+            ) from exc
+
+        return instance
+
+    def get_extra_parameters(self) -> dict:
+        local = {
+            "search_documents_limit": self.search_documents_limit,
+        }
+        return (
+            super().get_extra_parameters()
+            | config_rag._RAGConfigBase.get_extra_parameters(self)
+            | local
+        )
+
+
+TOOL_CONFIG_CLASSES_BY_TOOL_NAME = {
+    klass.tool_name: klass
+    for klass in [
+        SearchDocumentsToolConfig,
+    ]
+}
 
 
 ToolConfigMap = dict[str, ToolConfig]

--- a/src/soliplex/tools/rag.py
+++ b/src/soliplex/tools/rag.py
@@ -1,0 +1,41 @@
+"""Tools based on 'haiku.rag'"""
+
+import pydantic_ai
+from haiku.rag import client as hr_client
+from haiku.rag.store.models import chunk as rag_store_models_chunk
+
+from soliplex import agents
+from soliplex.config import tools as config_tools
+
+
+async def search_documents(
+    ctx: pydantic_ai.RunContext[agents.AgentDependencies],
+    query: str,
+) -> list[rag_store_models_chunk.SearchResult]:
+    """
+    Search the document knowledge base for relevant information based on the user's query.
+
+    Args:
+        query (str): The search query derived from the user's question.
+
+    Returns:
+        list[rag_store_models_chunk.SearchResult]:
+            A list of search results with content, scores, and citations.
+    """  # noqa: E501  The first line is important to the LLM.
+    tool_config = ctx.deps.tool_configs[config_tools.SDTC_TOOL_KIND]
+
+    hr_config = tool_config.haiku_rag_config
+
+    async with hr_client.HaikuRAG(
+        db_path=tool_config.rag_lancedb_path,
+        config=hr_config,
+    ) as rag:
+        results = await rag.search(
+            query,
+            limit=tool_config.search_documents_limit,
+        )
+
+        if hr_config.search.context_radius > 0:
+            results = await rag.expand_context(results)
+
+        return results

--- a/tests/unit/config/test_config_tools.py
+++ b/tests/unit/config/test_config_tools.py
@@ -141,6 +141,32 @@ W_AI_TOOL_PARAMS_TOOL_CONFIG_PARAMS_YAML = f"""
         takes_ctx: true
 """
 
+
+# This one raises
+BOGUS_SDTC_CONFIG_YAML = """
+    #rag_lancedb_stem: "rag"
+    #rag_lancedb_override_path: "/path/to/rag.lancedb"
+"""
+
+W_STEM_SDTC_CONFIG_KW = {
+    "rag_lancedb_stem": "rag",
+    "search_documents_limit": 7,
+    "allow_mcp": True,
+}
+W_STEM_SDTC_CONFIG_YAML = """
+    rag_lancedb_stem: "rag"
+    search_documents_limit: 7
+    allow_mcp: true
+"""
+
+
+W_OVERRIDE_SDTC_CONFIG_KW = {
+    "rag_lancedb_override_path": "/path/to/rag.lancedb",
+}
+W_OVERRIDE_SDTC_CONFIG_YAML = """
+    rag_lancedb_override_path: "/path/to/rag.lancedb"
+"""
+
 # This one raises
 BOGUS_STDIO_MCTC_CONFIG_YAML = ""
 
@@ -618,6 +644,134 @@ def test_toolconfig_get_extra_parameters():
     )
 
     assert tool_config.get_extra_parameters() == {}
+
+
+def test_sdtc_ctor(installation_config, temp_dir):
+    db_rag_path = temp_dir / "db" / "rag"
+    db_rag_path.mkdir(parents=True)
+
+    from_stem = db_rag_path / "stem.lancedb"
+    from_stem.mkdir()
+
+    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
+    installation_config.get_environment = ic_environ.get
+
+    config_path = temp_dir / "rooms" / "test" / "room_config.yaml"
+
+    sdt_config = config_tools.SearchDocumentsToolConfig(
+        _installation_config=installation_config,
+        _config_path=config_path,
+        rag_lancedb_stem="stem",
+    )
+
+    assert sdt_config._installation_config is installation_config
+    assert sdt_config._config_path == config_path
+
+    found = sdt_config.rag_lancedb_path
+    assert found.resolve() == from_stem.resolve()
+
+    expected_ep = {
+        "rag_lancedb_path": from_stem.resolve(),
+        "search_documents_limit": 5,
+    }
+
+    assert sdt_config.get_extra_parameters() == expected_ep
+
+
+@pytest.mark.parametrize(
+    "config_yaml, exp_config",
+    [
+        (BOGUS_SDTC_CONFIG_YAML, None),
+        (W_STEM_SDTC_CONFIG_YAML, W_STEM_SDTC_CONFIG_KW),
+        (W_OVERRIDE_SDTC_CONFIG_YAML, W_OVERRIDE_SDTC_CONFIG_KW),
+    ],
+)
+def test_sdtc_from_yaml(
+    installation_config,
+    temp_dir,
+    config_yaml,
+    exp_config,
+):
+    db_rag_dir = temp_dir / "db" / "rag"
+    db_rag_dir.mkdir(parents=True)
+
+    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_dir)}
+    installation_config.get_environment = ic_environ.get
+
+    config_dir = temp_dir / "rooms" / "test_room"
+    config_dir.mkdir(parents=True)
+
+    config_path = config_dir / "room_config.yaml"
+    config_path.write_text(config_yaml)
+
+    with config_path.open() as stream:
+        config_dict = yaml.safe_load(stream)
+
+    if exp_config is None:
+        with pytest.raises(config_exc.FromYamlException) as exc:
+            config_tools.SearchDocumentsToolConfig.from_yaml(
+                installation_config=installation_config,
+                config_path=config_path,
+                config_dict=config_dict,
+            )
+
+        assert exc.value._config_path == config_path
+
+    else:
+        sdt_config = config_tools.SearchDocumentsToolConfig.from_yaml(
+            installation_config=installation_config,
+            config_path=config_path,
+            config_dict=config_dict,
+        )
+        expected = config_tools.SearchDocumentsToolConfig(
+            _installation_config=installation_config,
+            _config_path=config_path,
+            **exp_config,
+        )
+        assert sdt_config == expected
+
+
+@pytest.mark.parametrize(
+    "stem, override, which",
+    [
+        ("testing", None, "stem"),
+        (None, "./override", "override"),
+    ],
+)
+def test_sdtc_get_extra_parameters_w_missing_file(
+    installation_config,
+    temp_dir,
+    stem,
+    override,
+    which,
+):
+    db_rag_path = temp_dir / "db" / "rag"
+    db_rag_path.mkdir(parents=True)
+
+    if which == "stem":
+        exp_filename = db_rag_path / f"{stem}.lancedb"
+    else:
+        exp_filename = temp_dir / override
+
+    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
+    installation_config.get_environment = ic_environ.get
+
+    kw = {
+        "_installation_config": installation_config,
+        "_config_path": temp_dir / "room_config.yaml",
+    }
+
+    if stem is not None:
+        kw["rag_lancedb_stem"] = stem
+
+    if override is not None:
+        kw["rag_lancedb_override_path"] = override
+
+    sdt_config = config_tools.SearchDocumentsToolConfig(**kw)
+
+    ep = sdt_config.get_extra_parameters()
+
+    assert ep["rag_lancedb_path"] == f"MISSING: {exp_filename.resolve()}"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/tools/test_rag_tools.py
+++ b/tests/unit/tools/test_rag_tools.py
@@ -1,0 +1,82 @@
+from unittest import mock
+
+import pydantic_ai
+import pytest
+
+from soliplex import agents
+from soliplex.config import tools as config_tools
+from soliplex.tools import rag as rag_tools
+
+QUESTION = "What are postal regulations regarding lithium batteries?"
+
+
+@pytest.fixture
+def sd_tool_config():
+    return mock.create_autospec(config_tools.SearchDocumentsToolConfig)
+
+
+@pytest.fixture
+def ctx_w_deps(sd_tool_config):
+    ctx = mock.create_autospec(pydantic_ai.RunContext)
+    ctx.deps = mock.create_autospec(agents.AgentDependencies)
+    ctx.deps.tool_configs = {
+        config_tools.SDTC_TOOL_KIND: sd_tool_config,
+    }
+    return ctx
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("w_limit", [None, 2])
+@pytest.mark.parametrize("w_radius", [0, 2])
+@pytest.mark.parametrize("n_docs", [0, 1, 10])
+@mock.patch("soliplex.tools.rag.hr_client")
+async def test_search_documents(
+    hr_client, ctx_w_deps, sd_tool_config, n_docs, w_radius, w_limit
+):
+    hr_class = hr_client.HaikuRAG = mock.MagicMock()
+    hr = hr_class.return_value
+    client = hr.__aenter__.return_value
+    search = client.search
+    expand_context = client.expand_context
+
+    search_results = [
+        mock.Mock(
+            spec=["content", "document_uri", "score"],
+            content=f"Doc #{i_doc}",
+            document_uri=f"https://example.com/docs/doc_{i_doc}.pdf",
+            score=i_doc,
+        )
+        for i_doc in range(n_docs)
+    ]
+
+    search.return_value = expand_context.return_value = search_results
+
+    sd_tool_config.haiku_rag_config.search.context_radius = w_radius
+
+    if w_limit is None:
+        sd_tool_config.search_documents_limit = exp_limit = 5
+    else:
+        sd_tool_config.search_documents_limit = w_limit
+        exp_limit = w_limit
+
+    found = await rag_tools.search_documents(
+        ctx_w_deps,
+        query=QUESTION,
+    )
+
+    if w_radius > 0:
+        assert found is expand_context.return_value
+    else:
+        assert found is search_results
+
+    search.assert_awaited_once_with(QUESTION, limit=exp_limit)
+
+    if w_radius > 0:
+        expand_context.assert_called_once_with(search_results)
+    else:
+        expand_context.assert_not_called()
+
+    hr_class.assert_called_once_with(
+        db_path=sd_tool_config.rag_lancedb_path,
+        config=sd_tool_config.haiku_rag_config,
+    )


### PR DESCRIPTION
  Now located as 'soliplex.tools.rag.search_documents'.

chore: resurrect 'SearchDocumentsToolConfig' class

  Excised in soliplex 'v0.38'.

  Expose 'SDTC_TOOL_NAME' and 'SDTC_TOOL_KIND' constants.

chore: update the 'search' room to use the 'search_documents' tool

  Prompt and config reloaded from the 'haiku' room in soliplex 'v0.37.2'.

fix: CLI tool RAG checking in 'check-config' command

Closes #763.