### PR TITLE
chore: pin development dependencies to conservative ranges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version matching your devenv setup
-    rev: v0.14.6
+    rev: v0.15.7
     hooks:
       - id: ruff-format
         types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,14 @@ soliplex-tui-serve = "soliplex.tui.serve:main"
 
 [dependency-groups]
 dev = [
-    "anyio",
-    "coverage",
-    "pytest",
-    "pytest-cov",
-    "pytest-asyncio",
-    "ruff",
+    "anyio >= 4.12.1, < 4.13",
+    "coverage >= 7.13.5, < 7.14",
+    "pytest >= 9.0.2, < 9.1",
+    "pytest-cov >= 7.0.0, < 7.1",
+    "pytest-asyncio >= 1.3.0, < 1.4",
+    "ruff >= 0.15.6, < 0.16",
     "skills-ref",
-    "trio",
+    "trio >= 0.33.0, < 0.34",
 ]
 docs = [
     "mkdocs>=1.6.1",


### PR DESCRIPTION
Use the same version for 'ruff' in 'pre-commit' as we install.