### PR TITLE
feat: record 'email' claim of user creating a thread

### DIFF
--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -211,6 +211,15 @@ class Thread(abc.ABC):
     room_id: str
     """ID for room in which the thread was created"""
 
+    user_name: str
+    """'preferred_username' claim for user who created the thread"""
+
+    email: str | None
+    """'email' claim for user who created the thread
+
+    Optional only for forward-compatibility of existing data.
+    """
+
     thread_metadata: ThreadMetadata | None
     """Optional thread metadata"""
 
@@ -254,6 +263,7 @@ class ThreadStorage(abc.ABC):
         self,
         *,
         user_name: str,
+        email: str,
         room_id: str,
         thread_metadata: ThreadMetadata | dict = None,
         initial_run: bool = True,
@@ -405,6 +415,7 @@ class ThreadStorage(abc.ABC):
         self,
         *,
         user_name: str | None = None,
+        email: str | None = None,
         room_id: str | None = None,
         thread_id: str | None = None,
         limit: int | None = None,

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -118,6 +118,7 @@ class ThreadStorage(agui_package.ThreadStorage):
         self,
         *,
         user_name: str,
+        email: str,
         room_id: str,
         thread_metadata: agui_schema.ThreadMetadata | dict = None,
         initial_run: bool = True,
@@ -125,7 +126,9 @@ class ThreadStorage(agui_package.ThreadStorage):
         async with self.session as session:
             async with session.begin_nested():
                 thread = agui_schema.Thread(
-                    user_name=user_name, room_id=room_id
+                    user_name=user_name,
+                    email=email,
+                    room_id=room_id,
                 )
                 session.add(thread)
 
@@ -462,6 +465,7 @@ class ThreadStorage(agui_package.ThreadStorage):
         self,
         *,
         user_name: str | None = None,
+        email: str | None = None,
         room_id: str | None = None,
         thread_id: str | None = None,
         limit: int | None = None,
@@ -509,6 +513,9 @@ class ThreadStorage(agui_package.ThreadStorage):
 
             if user_name is not None:
                 query = query.where(agui_schema.Thread.user_name == user_name)
+
+            if email is not None:
+                query = query.where(agui_schema.Thread.email == email)
 
             if thread_id is not None:
                 query = query.where(agui_schema.Thread.thread_id == thread_id)

--- a/src/soliplex/agui/schema.py
+++ b/src/soliplex/agui/schema.py
@@ -93,6 +93,7 @@ class Thread(Base):
     #   Not part of the generic 'soliplex.agui.Thread' contract
     #
     user_name: Mapped[str] = mapped_column(index=True)
+    email: Mapped[str | None] = mapped_column(index=True)
     runs: Mapped[list[Run]] = relationship(
         back_populates="thread",
         order_by="Run.created",

--- a/src/soliplex/tools/agui_run_feedback.py
+++ b/src/soliplex/tools/agui_run_feedback.py
@@ -32,7 +32,9 @@ class RunFeedbackEntry(pydantic.BaseModel):
 
     Args:
 
-      'user_name' (string):  email-address of reporting user
+      'user_name' (string):  preferred username of reporting user
+
+      'email' (string):  email-address of reporting user
 
       'room_id' (string): ID of the room in which the AGUI run originated.
 
@@ -54,6 +56,7 @@ class RunFeedbackEntry(pydantic.BaseModel):
     """
 
     user_name: str
+    email: str
     room_id: str
     thread_id: str
     run_id: str
@@ -68,6 +71,7 @@ class RunFeedbackInfo(pydantic.BaseModel):
     """Information about the run which was the target of feedback"""
 
     user_name: str
+    email: str
     room_id: str
     thread_id: str
     run_id: str
@@ -80,8 +84,12 @@ class RecentRunFeedbackQuery(pydantic.BaseModel):
 
     Args:
 
-      'user_name' (string, default None):  email-address of reporting user
+      'user_name' (string, default None):  user name of reporting user
         If passed, include feedback only from the user whose username
+        matches this value.
+
+      'email' (string, default None):  email of reporting user
+        If passed, include feedback only from the user whose email
         matches this value.
 
       'room_id' (string, default None): ID of the room in which the
@@ -97,9 +105,25 @@ class RecentRunFeedbackQuery(pydantic.BaseModel):
     """
 
     user_name: str | None = None
+    email: str | None = None
     room_id: str | None = None
     limit: int | None = None
     since: datetime.datetime | None = None
+
+    @property
+    def as_kwargs(self) -> dict[str, typing.Any]:
+        candidates = {
+            "user_name": self.user_name,
+            "email": self.email,
+            "room_id": self.room_id,
+            "limit": self.limit,
+            "since": self.since,
+        }
+        return {
+            key: value
+            for key, value in candidates.items()
+            if value is not None
+        }
 
 
 class RecentRunFeedbackEntries(pydantic.BaseModel):
@@ -156,10 +180,7 @@ async def _do_query(
 ) -> RecentRunFeedback:
     the_threads = ctx.deps.the_threads
     runs_w_recent_fb = await the_threads.list_recent_run_feedback(
-        user_name=query.user_name,
-        room_id=query.room_id,
-        limit=query.limit,
-        since=query.since,
+        **query.as_kwargs,
     )
 
     entries = RecentRunFeedbackEntries()
@@ -183,6 +204,7 @@ async def _do_query(
 
         entry = RunFeedbackEntry(
             user_name=await thread.awaitable_attrs.user_name,
+            email=await thread.awaitable_attrs.email,
             room_id=await thread.awaitable_attrs.room_id,
             thread_id=await thread.awaitable_attrs.thread_id,
             run_id=await run.awaitable_attrs.run_id,
@@ -307,6 +329,8 @@ async def get_feedback_run_info(
         run_id=to_query.run_id,
     )
 
+    thread = await run.awaitable_attrs.thread
+    email = await thread.awaitable_attrs.email
     run_input = await run.awaitable_attrs.run_agent_input
     events = await run.awaitable_attrs.events
 
@@ -332,6 +356,7 @@ async def get_feedback_run_info(
 
     return RunFeedbackInfo(
         user_name=to_query.user_name,
+        email=email,
         room_id=to_query.room_id,
         thread_id=to_query.thread_id,
         run_id=run_id,

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -275,6 +275,7 @@ async def post_room_agui(
     the_logger.debug(loggers.AGUI_POST_ROOM)
 
     user_name = the_user_claims.get("preferred_username", "<unknown>")
+    email = the_user_claims.get("email", "<unknown>")
     room_config = await _check_user_in_room(
         room_id=room_id,
         the_installation=the_installation,
@@ -291,6 +292,7 @@ async def post_room_agui(
     thread = await the_threads.new_thread(
         room_id=room_id,
         user_name=user_name,
+        email=email,
         thread_metadata=t_metadata,
         initial_run=True,
     )

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -17,6 +17,7 @@ NOW = datetime.datetime.now(datetime.UTC)
 
 ROOM_ID = "test-room"
 USER_NAME = "phreddy"
+EMAIL = "phreddy@example.com"
 
 
 @pytest.fixture
@@ -80,7 +81,11 @@ async def test_threadstorage_thread_crud(the_async_session):
             thread_id="NONESUCH",
         )
 
-    thread = await ts.new_thread(user_name=USER_NAME, room_id=ROOM_ID)
+    thread = await ts.new_thread(
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+    )
 
     thread_id = await thread.awaitable_attrs.thread_id
 
@@ -232,6 +237,7 @@ async def test_threadstorage_thread_crud(the_async_session):
 
     w_md_dict = await ts.new_thread(
         user_name=USER_NAME,
+        email=EMAIL,
         room_id=ROOM_ID,
         thread_metadata={
             "name": "w_md_dict",
@@ -251,6 +257,7 @@ async def test_threadstorage_thread_crud(the_async_session):
 
     w_md_obj = await ts.new_thread(
         user_name=USER_NAME,
+        email=EMAIL,
         room_id=ROOM_ID,
         thread_metadata=agui_schema.ThreadMetadata(
             name="w_md_obj",
@@ -273,7 +280,11 @@ async def test_threadstorage_thread_crud(the_async_session):
 async def test_threadstorage_thread_run_cru(the_async_session):
     ts = agui_persistence.ThreadStorage(the_async_session)
 
-    thread = await ts.new_thread(user_name=USER_NAME, room_id=ROOM_ID)
+    thread = await ts.new_thread(
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+    )
 
     thread_id = await thread.awaitable_attrs.thread_id
 
@@ -509,7 +520,11 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 async def test_threadstorage_thread_run_feedback(the_async_session):
     ts = agui_persistence.ThreadStorage(the_async_session)
 
-    thread = await ts.new_thread(user_name=USER_NAME, room_id=ROOM_ID)
+    thread = await ts.new_thread(
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+    )
     thread_id = await thread.awaitable_attrs.thread_id
 
     runs = await thread.list_runs()
@@ -652,6 +667,24 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     uname_earlier_fb = await uname_earlier.awaitable_attrs.run_feedback
     assert await uname_earlier_fb.awaitable_attrs.feedback == "thumbs_down"
     assert await uname_earlier_fb.awaitable_attrs.reason == "dithering"
+
+    # Query with email
+    email_miss = await ts.list_recent_run_feedback(
+        email="BOGUS",
+    )
+    assert email_miss == []
+
+    email_later, email_earlier = await ts.list_recent_run_feedback(
+        email=EMAIL,
+    )
+
+    email_later_fb = await email_later.awaitable_attrs.run_feedback
+    assert await email_later_fb.awaitable_attrs.feedback == "thumbs_up"
+    assert await email_later_fb.awaitable_attrs.reason == "fresh"
+
+    email_earlier_fb = await email_earlier.awaitable_attrs.run_feedback
+    assert await email_earlier_fb.awaitable_attrs.feedback == "thumbs_down"
+    assert await email_earlier_fb.awaitable_attrs.reason == "dithering"
 
     # Query with thread_id
     tid_miss = await ts.list_recent_run_feedback(
@@ -976,7 +1009,11 @@ async def test_threadstorage_save_run_events(
 
     ts = agui_persistence.ThreadStorage(the_async_session)
 
-    thread = await ts.new_thread(user_name=USER_NAME, room_id=ROOM_ID)
+    thread = await ts.new_thread(
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+    )
 
     thread_id = await thread.awaitable_attrs.thread_id
 

--- a/tests/unit/agui/test_agui_schema.py
+++ b/tests/unit/agui/test_agui_schema.py
@@ -11,6 +11,7 @@ from tests.unit.agui import agui_constants
 
 ROOM_ID = "test-room"
 USER_NAME = "phreddy"
+EMAIL = "phreddy@example.com"
 
 
 def _mock_run(run_id, thread):
@@ -189,13 +190,27 @@ def test_runevent_from_agui_event(agui_event):
     assert found.type == agui_event.type
 
 
-def test_thread_ctor(the_session):
+@pytest.mark.parametrize(
+    "email_kwargs, exp_email",
+    [
+        ({}, None),
+        ({"email": EMAIL}, EMAIL),
+    ],
+)
+def test_thread_ctor(the_session, email_kwargs, exp_email):
     thread = agui_schema.Thread(
         room_id=ROOM_ID,
         user_name=USER_NAME,
+        **email_kwargs,
     )
     the_session.add(thread)
     the_session.commit()
+
+    after = the_session.query(agui_schema.Thread).first()
+
+    assert after.room_id == ROOM_ID
+    assert after.user_name == USER_NAME
+    assert after.email == exp_email
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/tools/test_agui_run_feedback.py
+++ b/tests/unit/tools/test_agui_run_feedback.py
@@ -15,7 +15,10 @@ from tests.unit.agui import agui_constants
 FRS = agui_package.FeedbackReviewStatus
 
 NOW = datetime.datetime.now(datetime.UTC)
-USER_NAME = "phreddy@example.com"
+SINCE = NOW - datetime.timedelta(days=1)
+LIMIT = 7
+USER_NAME = "phreddy"
+EMAIL = "phreddy@example.com"
 OTHER_USER_NAME = "bharney@example.com"
 ROOM_ID = "test-room-id"
 THREAD_ID = "test-thread-id"
@@ -113,6 +116,7 @@ def the_thread():
         awaitable_attrs=mock.AsyncMock(),
     )
     thread.awaitable_attrs.user_name = _awaitable("user_name", USER_NAME)
+    thread.awaitable_attrs.email = _awaitable("email", EMAIL)
     thread.awaitable_attrs.room_id = _awaitable("room_id", ROOM_ID)
     thread.awaitable_attrs.thread_id = _awaitable("thread_id", THREAD_ID)
 
@@ -137,6 +141,20 @@ def the_run(request, the_thread, the_run_feedback):
         return None
 
 
+@pytest.fixture(
+    params=[
+        {},
+        {"user_name": USER_NAME},
+        {"email": EMAIL},
+        {"room_id": ROOM_ID},
+        {"limit": LIMIT},
+        {"since": SINCE},
+    ],
+)
+def rf_query(request) -> arf_tools.RecentRunFeedbackQuery:
+    return arf_tools.RecentRunFeedbackQuery(**request.param)
+
+
 @pytest.mark.anyio
 async def test__do_query(
     the_run,
@@ -144,15 +162,14 @@ async def test__do_query(
     the_run_feedback,
     the_review_entries,
     ctx_w_deps,
+    rf_query,
 ):
     lrrf = ctx_w_deps.deps.the_threads.list_recent_run_feedback
     lrrf.return_value = [the_run] if the_run else []
 
     review_entries, exp_status = the_review_entries
 
-    query = arf_tools.RecentRunFeedbackQuery()
-
-    found = await arf_tools._do_query(ctx_w_deps, query)
+    found = await arf_tools._do_query(ctx_w_deps, rf_query)
 
     if exp_status == FRS.RESOLVED:
         if the_run:
@@ -184,8 +201,11 @@ async def test__do_query(
         assert len(found.resolved) == 0
         assert len(found.reviewed) == 0
 
+    lrrf.assert_called_once_with(**rf_query.as_kwargs)
+
     if not the_run:  # silence resource warnings for unused fixtures
         await the_thread.awaitable_attrs.user_name
+        await the_thread.awaitable_attrs.email
         await the_thread.awaitable_attrs.room_id
         await the_thread.awaitable_attrs.thread_id
 
@@ -197,11 +217,6 @@ async def test__do_query(
         for review_entry in review_entries:
             await review_entry.awaitable_attrs.status
             await review_entry.awaitable_attrs.note
-
-
-@pytest.fixture
-def rf_query() -> arf_tools.RecentRunFeedbackQuery:
-    return arf_tools.RecentRunFeedbackQuery(user_name=USER_NAME)
 
 
 @pytest.mark.anyio
@@ -220,6 +235,7 @@ async def test_query_recent_feedback(do_query, ctx_w_deps, rf_query, w_state):
         opened=[
             arf_tools.RunFeedbackEntry(
                 user_name=USER_NAME,
+                email=EMAIL,
                 room_id=ROOM_ID,
                 thread_id=THREAD_ID,
                 run_id=RUN_ID,
@@ -274,6 +290,7 @@ async def test_query_recent_feedback(do_query, ctx_w_deps, rf_query, w_state):
 def run_feedback_entry():
     return arf_tools.RunFeedbackEntry(
         user_name=USER_NAME,
+        email=EMAIL,
         room_id=ROOM_ID,
         thread_id=THREAD_ID,
         run_id=RUN_ID,
@@ -338,6 +355,7 @@ async def test_get_feedback_run_info(
     esp,
     run_feedback_entry,
     ctx_w_deps,
+    the_thread,
 ):
     get_run = ctx_w_deps.deps.the_threads.get_run
 
@@ -397,6 +415,7 @@ async def test_get_feedback_run_info(
         agui_package.Run,
         awaitable_attrs=mock.AsyncMock(),
     )
+    run.awaitable_attrs.thread = _awaitable("thread", the_thread)
     run.awaitable_attrs.run_agent_input = _awaitable("run_agent_input", rai)
     run.awaitable_attrs.events = _awaitable("events", db_events)
     get_run.return_value = run
@@ -426,6 +445,11 @@ async def test_get_feedback_run_info(
         strict=True,
     ):
         assert esp_call == mock.call(agui_event)
+
+    # silence resource warnings for unused fixtures
+    await the_thread.awaitable_attrs.user_name
+    await the_thread.awaitable_attrs.room_id
+    await the_thread.awaitable_attrs.thread_id
 
 
 @pytest.mark.anyio

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -28,7 +28,7 @@ GIVEN_NAME = "Phred"
 FAMILY_NAME = "Phlyntstone"
 EMAIL = "phreddy@example.com"
 
-THE_USER_CLAIMS = {"preferred_username": USER_NAME}
+THE_USER_CLAIMS = {"preferred_username": USER_NAME, "email": EMAIL}
 
 AUTH_USER = {
     "preferred_username": USER_NAME,
@@ -704,6 +704,7 @@ async def test_post_room_agui_only(
     the_threads.new_thread.assert_called_once_with(
         room_id=TEST_ROOM_ID,
         user_name=USER_NAME,
+        email=EMAIL,
         thread_metadata=exp_meta,
         initial_run=True,
     )


### PR DESCRIPTION
Allow querying recent feedback entries using 'email'.

Return 'email' for feedback entries / run info queried from AGUI feedback tools.

Closes #777.