### PR TITLE
chore: deprecate 'config.skills.HR_{RAG,RLM}_SkillConfig'

### DIFF
--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -314,6 +314,18 @@ class _HR_SkillConfigBase(
         )
 
 
+HR_RAG_SKILLCONFIG_DEPRECATION = """\
+The 'haiku.rag.skills.rag' skill is deprecated, and will be removed after
+'soliplex v0.58'.
+
+Replace instances with a skill generated using 'haiku-rag create-skill'.
+
+See: https://ggozad.github.io/haiku.rag/skills/#generating-custom-skills
+
+Configured in: {config_path}
+"""
+
+
 @dataclasses.dataclass(kw_only=True)
 class HR_RAG_SkillConfig(_HR_SkillConfigBase):
     """Configuration for an agent skill from 'haiku.rag.skills.rag"""
@@ -332,6 +344,13 @@ class HR_RAG_SkillConfig(_HR_SkillConfigBase):
         config_path: pathlib.Path,
         config_dict: dict,
     ):
+        warnings.warn(
+            HR_RAG_SKILLCONFIG_DEPRECATION.format(
+                config_path=config_path,
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         tool_names = config_dict.pop("tool_names", None)
         rag_features = config_dict.pop("rag_features", None)
 
@@ -356,12 +375,44 @@ class HR_RAG_SkillConfig(_HR_SkillConfigBase):
         )
 
 
+HR_RLM_SKILLCONFIG_DEPRECATION = """\
+The 'haiku.rag.skills.rlm' skill is deprecated, and will be removed after
+'soliplex v0.58'.
+
+Replace instances with a skill generated using 'haiku-rag create-skill'.
+
+See: https://ggozad.github.io/haiku.rag/skills/#generating-custom-skills
+
+Configured in: {config_path}
+"""
+
+
 @dataclasses.dataclass(kw_only=True)
 class HR_RLM_SkillConfig(_HR_SkillConfigBase):
     """Configuration for an agent skill from 'haiku.rag.skills.rlm"""
 
     kind: typing.ClassVar[hs_models.SkillSource] = "haiku.rag.skills.rlm"
     _hr_skill_module = hr_skills_rlm
+
+    @classmethod
+    def from_yaml(
+        cls,
+        installation_config: InstallationConfig,  # noqa F821 cycles
+        config_path: pathlib.Path,
+        config_dict: dict,
+    ):
+        warnings.warn(
+            HR_RLM_SKILLCONFIG_DEPRECATION.format(
+                config_path=config_path,
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return super().from_yaml(
+            installation_config,
+            config_path,
+            config_dict,
+        )
 
 
 SKILL_CONFIG_CLASSES_BY_KIND = {

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -1,5 +1,6 @@
 import contextlib
 import dataclasses
+import warnings
 from unittest import mock
 
 import pytest
@@ -223,23 +224,38 @@ allow_mcp: true
 
 
 @pytest.mark.parametrize(
-    "config_yaml, expectation",
+    "config_yaml, expectation, w_depr",
     [
-        (BOGUS_ROOM_CONFIG_YAML, pytest.raises(config_exc.FromYamlException)),
-        (BARE_ROOM_CONFIG_YAML, contextlib.nullcontext(BARE_ROOM_CONFIG_KW)),
+        (
+            BOGUS_ROOM_CONFIG_YAML,
+            pytest.raises(config_exc.FromYamlException),
+            None,
+        ),
+        (
+            BARE_ROOM_CONFIG_YAML,
+            contextlib.nullcontext(BARE_ROOM_CONFIG_KW),
+            False,
+        ),
         (
             W_NON_HR_SKILLS_ROOM_CONFIG_YAML,
             contextlib.nullcontext(W_NON_HR_SKILLS_ROOM_CONFIG_KW),
+            False,
         ),
         (
             W_HR_SKILLS_ROOM_CONFIG_YAML,
             contextlib.nullcontext(W_HR_SKILLS_ROOM_CONFIG_KW),
+            True,
         ),
         (
             W_NON_HR_TOOLS_ROOM_CONFIG_YAML,
             contextlib.nullcontext(W_NON_HR_TOOLS_ROOM_CONFIG_KW),
+            False,
         ),
-        (FULL_ROOM_CONFIG_YAML, contextlib.nullcontext(FULL_ROOM_CONFIG_KW)),
+        (
+            FULL_ROOM_CONFIG_YAML,
+            contextlib.nullcontext(FULL_ROOM_CONFIG_KW),
+            False,
+        ),
     ],
 )
 def test_roomconfig_from_yaml(
@@ -247,6 +263,7 @@ def test_roomconfig_from_yaml(
     temp_dir,
     config_yaml,
     expectation,
+    w_depr,
 ):
     skill = mock.create_autospec(hs_models.Skill)
     skill_config = mock.create_autospec(
@@ -265,7 +282,10 @@ def test_roomconfig_from_yaml(
     with yaml_file.open() as stream:
         config_dict = yaml.safe_load(stream)
 
-    with expectation as expected:
+    with (
+        warnings.catch_warnings(record=True) as warned,
+        expectation as expected,
+    ):
         found = config_rooms.RoomConfig.from_yaml(
             installation_config,
             yaml_file,
@@ -330,6 +350,12 @@ def test_roomconfig_from_yaml(
             ]
 
         assert found == expected
+
+        if w_depr:
+            (depr,) = warned
+            assert depr.category is DeprecationWarning
+        else:
+            assert len(warned) == 0
 
 
 @pytest.mark.parametrize("w_order", [False, True])

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -708,17 +708,17 @@ def test_hr_rag_skillconfig_metadata(
             {"not_a_valid_key": "FAIL"},
             pytest.raises(config_exc.FromYamlException),
         ),
-        ({}, contextlib.nullcontext(0)),
+        ({}, contextlib.nullcontext(1)),
         (
             {"tool_names": ["get_document", "list_documents"]},
-            contextlib.nullcontext(1),
+            contextlib.nullcontext(2),
         ),
-        ({"rag_features": ["search"]}, contextlib.nullcontext(1)),
-        ({"rag_features": ["bogus"]}, contextlib.nullcontext(1)),
-        ({"rag_features": ["analysis"]}, contextlib.nullcontext(1)),
+        ({"rag_features": ["search"]}, contextlib.nullcontext(2)),
+        ({"rag_features": ["bogus"]}, contextlib.nullcontext(2)),
+        ({"rag_features": ["analysis"]}, contextlib.nullcontext(2)),
         (
             {"tool_names": ["ask"], "rag_features": ["search"]},
-            contextlib.nullcontext(2),
+            contextlib.nullcontext(3),
         ),
     ],
 )
@@ -799,9 +799,53 @@ def test_hr_rlm_skillconfig_skill(temp_dir, installation_config):
 
 
 @pytest.mark.parametrize(
+    "w_config, expectation",
+    [
+        # kwargs, expected_warning_count or exception type
+        (
+            {"not_a_valid_key": "FAIL"},
+            pytest.raises(config_exc.FromYamlException),
+        ),
+        ({}, contextlib.nullcontext(1)),
+    ],
+)
+def test_hr_rlg_skillconfig_from_yaml(
+    temp_dir,
+    installation_config,
+    w_config,
+    expectation,
+):
+    config_path = temp_dir / "config_file.yaml"
+    lancedb = temp_dir / "rag.lancedb"
+    lancedb.mkdir()
+
+    config_dict = {
+        "rag_lancedb_override_path": lancedb,
+    } | w_config
+
+    with (
+        warnings.catch_warnings(record=True) as warned,
+        expectation as expected,
+    ):
+        inst = config_skills.HR_RLM_SkillConfig.from_yaml(
+            installation_config=installation_config,
+            config_path=config_path,
+            config_dict=config_dict,
+        )
+
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert len(warned) == expected
+        for warning in warned:
+            assert warning.category is DeprecationWarning
+
+        assert inst.rag_lancedb_path == lancedb
+        assert inst.haiku_rag_config is installation_config.haiku_rag_config
+
+
+@pytest.mark.parametrize(
     "w_error, expectation",
     [
-        (False, contextlib.nullcontext()),
+        (False, contextlib.nullcontext(1)),
         (True, pytest.raises(config_exc.FromYamlException)),
     ],
 )
@@ -821,14 +865,20 @@ def test_hr_rlm_skillconfig_from_yaml(
     if w_error:
         config_dict["not_a_valid_key"] = "FAIL"
 
-    with expectation as expected:
+    with (
+        warnings.catch_warnings(record=True) as warned,
+        expectation as expected,
+    ):
         inst = config_skills.HR_RLM_SkillConfig.from_yaml(
             installation_config=installation_config,
             config_path=config_path,
             config_dict=config_dict,
         )
 
-    if expected is None:
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert len(warned) == expected
+        for warning in warned:
+            assert warning.category is DeprecationWarning
         assert inst.rag_lancedb_path == lancedb
         assert inst.haiku_rag_config is installation_config.haiku_rag_config
 
@@ -836,7 +886,7 @@ def test_hr_rlm_skillconfig_from_yaml(
 @pytest.mark.parametrize(
     "w_invalid_kind, expectation",
     [
-        (False, contextlib.nullcontext()),
+        (False, contextlib.nullcontext(2)),
         (True, pytest.raises(config_skills.InvalidSkillKind)),
     ],
 )
@@ -867,14 +917,21 @@ def test_extractskillconfigs(
             }
         )
 
-    with expectation as expected:
+    with (
+        warnings.catch_warnings(record=True) as warned,
+        expectation as expected,
+    ):
         found = config_skills.extract_skill_configs(
             installation_config=installation_config,
             config_path=config_path,
             config_dict=config_dict,
         )
 
-    if expected is None:
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert len(warned) == expected
+        for warning in warned:
+            assert warning.category is DeprecationWarning
+
         assert isinstance(found["rag"], config_skills.HR_RAG_SkillConfig)
         assert found["rag"].rag_lancedb_stem == "test-foo"
 


### PR DESCRIPTION
Note their removal after 'v0.58'.

Toward #787.