### PR TITLE
feat: meta-config agent capabilty types

### DIFF
--- a/src/soliplex/config/agents.py
+++ b/src/soliplex/config/agents.py
@@ -20,6 +20,13 @@ _no_repr_no_compare_none = _utils._no_repr_no_compare_none
 _default_dict_field = _utils._default_dict_field
 _default_list_field = _utils._default_list_field
 
+
+#
+#   Copy the pydantic_ai capability registry as defaults, so that we
+#   can extend via meta-config.
+#
+AGENT_CAPABILITY_CLASSES_BY_NAME = ai_capabilities.CAPABILITY_TYPES.copy()
+
 # ============================================================================
 #   Agent-related configuration types
 # ============================================================================
@@ -93,7 +100,7 @@ class AgentCapabilityConfig:
     @property
     def as_capability(self) -> ai_capabilities.AbstractCapability:
         try:
-            cap_klass = ai_capabilities.CAPABILITY_TYPES[self.name]
+            cap_klass = AGENT_CAPABILITY_CLASSES_BY_NAME[self.name]
         except KeyError:
             raise UnknownCapability(self.name) from None
 
@@ -110,7 +117,7 @@ def extract_capability_config(
     else:
         ((name, kwargs),) = cap_config.items()
 
-    if name not in ai_capabilities.CAPABILITY_TYPES:
+    if name not in AGENT_CAPABILITY_CLASSES_BY_NAME:
         raise UnknownCapability(name, _config_path)
 
     return AgentCapabilityConfig(

--- a/src/soliplex/config/meta.py
+++ b/src/soliplex/config/meta.py
@@ -123,6 +123,11 @@ class InstallationConfigMeta:
         config classes) or `ConfigMeta' mappings, defining the types
         of skills which can be configured.
 
+    'agent_capability_types'
+        a list consisting of strings (importable dotted names of agent
+        capability classes) or `ConfigMeta' mappings, defining additional
+        capability types with which agents can be configured.
+
     'agent_configs'
         a list consisting of strings (importable dotted names of agent
         config classes) or `ConfigMeta' mappings, defining the
@@ -143,6 +148,7 @@ class InstallationConfigMeta:
     mcp_toolset_configs: list[str | ConfigMeta] = ()
     mcp_server_tool_wrappers: list[ConfigMeta] = ()
     skill_configs: list[str | ConfigMeta] = ()
+    agent_capability_types: list[str | ConfigMeta] = ()
     agent_configs: list[str | ConfigMeta] = ()
     secret_sources: list[str | ConfigMeta] = ()
 
@@ -183,6 +189,11 @@ class InstallationConfigMeta:
             config_dict["skill_configs"] = [
                 ConfigMeta.from_yaml(sc_yaml)
                 for sc_yaml in config_dict.get("skill_configs", ())
+            ]
+
+            config_dict["agent_capability_types"] = [
+                ConfigMeta.from_yaml(ac_yaml)
+                for ac_yaml in config_dict.get("agent_capability_types", ())
             ]
 
             config_dict["agent_configs"] = [
@@ -243,6 +254,12 @@ class InstallationConfigMeta:
             klass = sc_meta.config_klass
             config_skills.SKILL_CONFIG_CLASSES_BY_KIND[klass.kind] = klass
 
+        self.agent_capability_types = list(self.agent_capability_types)
+        act_registry = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME
+        for act_meta in self.agent_capability_types:
+            klass = act_meta.config_klass
+            act_registry[klass.__name__] = klass
+
         self.agent_configs = list(self.agent_configs)
         for ac_meta in self.agent_configs:
             klass = ac_meta.config_klass
@@ -300,6 +317,11 @@ class InstallationConfigMeta:
             for klass in skill_config_registry.values()
         ]
 
+        cap_types = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME.values()
+        capability_type_entries = [
+            _utils._dotted_name(klass) for klass in cap_types
+        ]
+
         agent_config_registry = config_agents.AGENT_CONFIG_CLASSES_BY_KIND
         agent_config_entries = [
             _utils._dotted_name(klass)
@@ -324,6 +346,7 @@ class InstallationConfigMeta:
             "mcp_toolset_configs": mcp_toolset_config_entries,
             "mcp_server_tool_wrappers": mcp_server_tool_wrapper_entries,
             "skill_configs": skill_config_entries,
+            "agent_capability_types": capability_type_entries,
             "agent_configs": agent_config_entries,
             "secret_sources": secret_source_entries,
         }

--- a/tests/unit/config/test_config_agents.py
+++ b/tests/unit/config/test_config_agents.py
@@ -266,6 +266,18 @@ extra_config:
 """
 
 
+@pytest.fixture
+def extra_agent_capability(patched_agent_capabilities):
+    @dataclasses.dataclass(kw_only=True)
+    class TestCapability:
+        dotted_name: str | None = None
+
+    # Register our extension capability
+    patched_agent_capabilities["testing"] = TestCapability
+
+    return TestCapability
+
+
 @pytest.mark.parametrize(
     "config_dict, expected",
     [
@@ -328,16 +340,13 @@ def test__apply_agent_config_template(temp_dir, config_dict, expected):
     "name, kwargs, expectation",
     [
         ("bogus", {}, pytest.raises(config_agents.UnknownCapability)),
-        ("WebSearch", {}, contextlib.nullcontext(ai_capabilities.WebSearch())),
-        (
-            "Thinking",
-            {"effort": "high"},
-            contextlib.nullcontext(ai_capabilities.Thinking(effort="high")),
-        ),
+        ("testing", {}, contextlib.nullcontext()),
+        ("testing", {"dotted_name": "foo.bar"}, contextlib.nullcontext()),
     ],
 )
 def test_agentcapabilityconfig_as_capability(
     temp_dir,
+    extra_agent_capability,
     name,
     kwargs,
     expectation,
@@ -352,29 +361,34 @@ def test_agentcapabilityconfig_as_capability(
     with expectation as expected:
         found = acc.as_capability
 
-    if not isinstance(expected, pytest.ExceptionInfo):
-        assert found == expected
+    if expected is None:
+        assert isinstance(found, extra_agent_capability)
+        for key, value in kwargs.items():
+            assert getattr(found, key) == value
 
 
 @pytest.mark.parametrize(
     "cap_config, expectation",
     [
         (
-            {"name": "bogus"},
+            "bogus",
             pytest.raises(config_agents.UnknownCapability),
         ),
         (
-            "WebSearch",
+            "testing",
             contextlib.nullcontext(
-                config_agents.AgentCapabilityConfig(name="WebSearch"),
+                config_agents.AgentCapabilityConfig(
+                    name="testing",
+                    kwargs={},
+                ),
             ),
         ),
         (
-            {"Thinking": {"effort": "high"}},
+            {"testing": {"dotted_name": "foo.bar"}},
             contextlib.nullcontext(
                 config_agents.AgentCapabilityConfig(
-                    name="Thinking",
-                    kwargs={"effort": "high"},
+                    name="testing",
+                    kwargs={"dotted_name": "foo.bar"},
                 ),
             ),
         ),
@@ -382,9 +396,11 @@ def test_agentcapabilityconfig_as_capability(
 )
 def test_extract_agent_capability(
     temp_dir,
+    extra_agent_capability,
     cap_config,
     expectation,
 ):
+
     config_path = temp_dir / "config.yaml"
 
     with expectation as expected:

--- a/tests/unit/config/test_config_meta.py
+++ b/tests/unit/config/test_config_meta.py
@@ -23,6 +23,10 @@ class FauxToolConfig:
     tool_name = "faux"
 
 
+class FauxCapability:
+    dotted_name = "foo.bar"
+
+
 BOGUS_ICMETA_YAML = """\
 meta:
     tool_configs:
@@ -33,6 +37,7 @@ BARE_ICMETA_KW = {
     "mcp_toolset_configs": [],
     "skill_configs": [],
     "mcp_server_tool_wrappers": [],
+    "agent_capability_types": [],
     "agent_configs": [],
     "secret_sources": [],
 }
@@ -103,6 +108,18 @@ W_SKILL_CONFIGS_ICMETA_YAML = """\
 meta:
   skill_configs:
     - "soliplex.config.skills.HR_RAG_SkillConfig"
+"""
+
+
+W_AGENT_CAPABILITY_ICMETA_KW = BARE_ICMETA_KW | {
+    "agent_capability_types": [
+        config_meta.ConfigMeta(config_klass=FauxCapability),
+    ],
+}
+W_AGENT_CAPABILITY_ICMETA_YAML = """\
+meta:
+  agent_capability_types:
+      - "test_config_meta.FauxCapability"
 """
 
 
@@ -264,6 +281,7 @@ def test_configmeta_from_yaml_w_dict_w_names(w_wrapper):
         (W_TOOL_CONFIGS_ICMETA_YAML, W_TOOL_CONFIGS_ICMETA_KW),
         (W_MCP_TOOLSET_CONFIGS_ICMETA_YAML, W_MCP_TOOLSET_CONFIGS_ICMETA_KW),
         (W_SKILL_CONFIGS_ICMETA_YAML, W_SKILL_CONFIGS_ICMETA_KW),
+        (W_AGENT_CAPABILITY_ICMETA_YAML, W_AGENT_CAPABILITY_ICMETA_KW),
         (W_AGENT_CONFIGS_ICMETA_YAML, W_AGENT_CONFIGS_ICMETA_KW),
         (
             W_SECRET_SOURCE_ICMETA_YAML,
@@ -276,6 +294,7 @@ def test_installationconfigmeta_from_yaml(
     temp_dir,
     patched_soliplex_config,
     patched_skill_configs,
+    patched_agent_capabilities,
     patched_agent_configs,
     patched_secret_getters,
     patched_agui_features,
@@ -366,6 +385,15 @@ def test_installationconfigmeta_from_yaml(
                     == mcptcp_by_class_name[wrapper_klass_name]
                 )
 
+        if config_dict_meta and "agent_capability_types" in config_dict_meta:
+            acts_by_class_name = {
+                f"{klass.__module__}.{klass.__name__}": klass.__name__
+                for klass in patched_agent_capabilities.values()
+            }
+            for klass_name in config_dict_meta["agent_capability_types"]:
+                short_name = acts_by_class_name[klass_name]
+                assert short_name in patched_agent_capabilities
+
         if config_dict_meta and "agent_configs" in config_dict_meta:
             acs_by_class_name = {
                 f"{klass.__module__}.{klass.__name__}": klass
@@ -383,12 +411,14 @@ def test_installationconfigmeta_from_yaml(
 
 @pytest.mark.parametrize("w_secret_reg", [False, True])
 @pytest.mark.parametrize("w_agent", [False, True])
+@pytest.mark.parametrize("w_capability", [False, True])
 @pytest.mark.parametrize("w_skills", [False, True])
 @pytest.mark.parametrize("w_mcp_toolsets", [False, True])
 @pytest.mark.parametrize("w_tools", [False, True])
 def test_installationconfigmeta_as_yaml(
     patched_soliplex_config,
     patched_agent_configs,
+    patched_agent_capabilities,
     patched_skill_configs,
     patched_secret_getters,
     patched_agui_features,
@@ -399,6 +429,7 @@ def test_installationconfigmeta_as_yaml(
     w_tools,
     w_mcp_toolsets,
     w_skills,
+    w_capability,
     w_agent,
     w_secret_reg,
 ):
@@ -433,6 +464,13 @@ def test_installationconfigmeta_as_yaml(
         patched_skill_configs[klass.kind] = klass
         expected["skill_configs"].append(
             "soliplex.config.skills.HR_RAG_SkillConfig",
+        )
+
+    if w_capability:
+        klass = FauxCapability
+        patched_agent_capabilities[klass.__name__] = klass
+        expected["agent_capability_types"].append(
+            "test_config_meta.FauxCapability",
         )
 
     if w_agent:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -106,6 +106,14 @@ def patched_skill_configs():
 
 
 @pytest.fixture
+def patched_agent_capabilities():
+    with mock.patch.dict(config_agents.__dict__) as patched:
+        registry = patched["AGENT_CAPABILITY_CLASSES_BY_NAME"] = {}
+
+        yield registry
+
+
+@pytest.fixture
 def patched_agent_configs():
     with mock.patch.dict(config_agents.__dict__) as patched:
         result = patched["AGENT_CONFIG_CLASSES_BY_KIND"] = {}


### PR DESCRIPTION
refactor: copy 'pydantic_ai.capabilities. capabilty type registry

... locally to enable registering new capability types via meta-config.

Follow-on to #809.