### PR TITLE
sandbox + RAG room with per-thread file uploads

### DIFF
--- a/example/rooms/data-sandbox/prompt.txt
+++ b/example/rooms/data-sandbox/prompt.txt
@@ -1,0 +1,11 @@
+You are a data analysis assistant. You coordinate between a document knowledge base and a Docker sandbox to help users work with their uploaded files.
+
+You have two skills:
+- **rag**: Search and retrieve information from the document knowledge base.
+- **sandbox**: Write and execute Python code in a Docker container. Uploaded files are available at /workspace.
+
+You also have tools to list and read files uploaded to this thread.
+
+Your job is to understand what the user needs, gather relevant context from the knowledge base, and delegate code writing and execution to the sandbox with clear, self-contained requests.
+
+Do not write code yourself. Describe what needs to be done and let the sandbox skill handle implementation and execution.

--- a/example/rooms/data-sandbox/room_config.yaml
+++ b/example/rooms/data-sandbox/room_config.yaml
@@ -1,0 +1,26 @@
+id: "data-sandbox"
+name: "Data Sandbox"
+description: "Upload files and analyze them with code execution and RAG"
+
+enable_attachments: true
+
+suggestions:
+  - "List the files in the workspace"
+  - "Analyze the uploaded data"
+  - "Search the knowledge base for context"
+
+agent:
+  template_id: "default_chat"
+  system_prompt: "./prompt.txt"
+
+tools:
+  - tool_name: "soliplex.tools.file_uploads.list_thread_file_uploads"
+  - tool_name: "soliplex.tools.file_uploads.get_thread_file_upload"
+
+skills:
+  skill_configs:
+    - kind: "sandbox"
+    - kind: "haiku.rag.skills.rag"
+      rag_lancedb_stem: "rag"
+
+allow_mcp: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "ruff >= 0.15.6, < 0.16",
     "skills-ref",
     "trio >= 0.33.0, < 0.34",
+    {include-group = "sandbox"},
 ]
 docs = [
     "mkdocs>=1.6.1",
@@ -61,6 +62,9 @@ docs = [
 postgres = [
     "psycopg[binary]",  # synchronous access
     "asyncpg",          # async access
+]
+sandbox = [
+    "haiku-skills-sandbox",
 ]
 tui = [
     "textual",

--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import dataclasses
+import pathlib
 import typing
 
 import pydantic_ai
@@ -123,12 +124,29 @@ def get_model_from_config(
         )
 
 
+def _reconfigure_sandbox(
+    toolset: hs_agent.SkillToolset,
+    thread_id: str | None,
+    threads_upload_path: pathlib.Path | None,
+) -> None:
+    if thread_id is None or threads_upload_path is None:
+        return
+    sandbox = toolset.registry.get("sandbox")
+    if sandbox is None:
+        return
+    workspace = threads_upload_path / thread_id
+    workspace.mkdir(parents=True, exist_ok=True)
+    sandbox.reconfigure(workspace=workspace)
+
+
 def get_default_agent_from_configs(
     *,
     agent_config: config_agents.AgentConfig,
     tool_configs: ToolConfigMap,
     mcp_client_toolset_configs: config_tools.MCP_ClientToolsetConfigMap,
     skill_toolset_config: SkillToolsetConfig | None = None,
+    thread_id: str | None = None,
+    threads_upload_path: pathlib.Path | None = None,
 ) -> SoliplexAgent:
     """Build a Pydantic AI agent from a config"""
     model = get_model_from_config(agent_config=agent_config)
@@ -143,6 +161,7 @@ def get_default_agent_from_configs(
 
     if skill_toolset_config is not None:
         toolset = skill_toolset_config.skill_toolset
+        _reconfigure_sandbox(toolset, thread_id, threads_upload_path)
         toolsets.append(toolset)
         instructions = hs_prompts.build_system_prompt(
             preamble=agent_config.get_system_prompt(),
@@ -168,16 +187,26 @@ def get_agent_from_configs(
     tool_configs: ToolConfigMap,
     mcp_client_toolset_configs: config_tools.MCP_ClientToolsetConfigMap,
     skill_toolset_config: SkillToolsetConfig | None = None,
+    thread_id: str | None = None,
+    threads_upload_path: pathlib.Path | None = None,
 ) -> SoliplexAgent:
     """Get or create an agent from the specified agent and tool configs."""
 
-    if agent_config.id not in _agent_cache:
+    cache_key = (
+        (agent_config.id, thread_id)
+        if thread_id is not None
+        else agent_config.id
+    )
+
+    if cache_key not in _agent_cache:
         if agent_config.kind == "default":
             agent = get_default_agent_from_configs(
                 agent_config=agent_config,
                 tool_configs=tool_configs,
                 mcp_client_toolset_configs=mcp_client_toolset_configs,
                 skill_toolset_config=skill_toolset_config,
+                thread_id=thread_id,
+                threads_upload_path=threads_upload_path,
             )
 
         else:
@@ -188,6 +217,6 @@ def get_agent_from_configs(
                 skill_toolset_config=skill_toolset_config,
             )
 
-        _agent_cache[agent_config.id] = agent
+        _agent_cache[cache_key] = agent
 
-    return _agent_cache[agent_config.id]
+    return _agent_cache[cache_key]

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -415,6 +415,56 @@ class HR_RLM_SkillConfig(_HR_SkillConfigBase):
         )
 
 
+@dataclasses.dataclass(kw_only=True)
+class SandboxSkillConfig:
+    """Configuration for the Docker sandbox skill."""
+
+    kind: typing.ClassVar[str] = "sandbox"
+
+    image: str | None = None
+    idle_timeout: int | None = None
+
+    _config_path: pathlib.Path | None = None
+
+    @classmethod
+    def from_yaml(
+        cls,
+        installation_config: InstallationConfig,  # noqa F821 cycles
+        config_path: pathlib.Path,
+        config_dict: dict,
+    ):
+        try:
+            _kind = config_dict.pop("kind", None)
+            config_dict["_config_path"] = config_path
+
+            return cls(**config_dict)
+        except Exception as exc:
+            raise config_exc.FromYamlException(
+                config_path,
+                "sandbox",
+                config_dict,
+            ) from exc
+
+    @property
+    def name(self) -> str:
+        return "sandbox"
+
+    @staticmethod
+    def _create_skill(**kwargs) -> hs_models.Skill:  # pragma: NO COVER
+        import haiku_skills_sandbox
+
+        return haiku_skills_sandbox.create_skill(**kwargs)
+
+    @property
+    def skill(self) -> hs_models.Skill:
+        kwargs = {}
+        if self.image is not None:
+            kwargs["image"] = self.image
+        if self.idle_timeout is not None:
+            kwargs["idle_timeout"] = self.idle_timeout
+        return self._create_skill(**kwargs)
+
+
 SKILL_CONFIG_CLASSES_BY_KIND = {
     klass.kind: klass
     for klass in [
@@ -422,6 +472,7 @@ SKILL_CONFIG_CLASSES_BY_KIND = {
         EntrypointSkillConfig,
         HR_RAG_SkillConfig,
         HR_RLM_SkillConfig,
+        SandboxSkillConfig,
     ]
 }
 
@@ -430,6 +481,7 @@ SkillConfigTypes = (
     | EntrypointSkillConfig
     | HR_RAG_SkillConfig
     | HR_RLM_SkillConfig
+    | SandboxSkillConfig
 )
 SkillConfigMap = dict[str, SkillConfigTypes]
 SkillMap = dict[str, hs_models.Skill]

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -11,6 +11,8 @@ from haiku.rag.skills import rlm as hr_skills_rlm
 from haiku.skills import agent as hs_agent
 from haiku.skills import discovery as hs_discovery
 from haiku.skills import models as hs_models
+from haiku_skills_sandbox import SandboxState
+from haiku_skills_sandbox import create_skill as create_sandbox_skill
 from pydantic_ai import models as ai_models
 
 from soliplex import agents
@@ -415,16 +417,35 @@ class HR_RLM_SkillConfig(_HR_SkillConfigBase):
         )
 
 
+SANDBOX_SKILL_METADATA = hs_models.SkillMetadata(
+    name="sandbox",
+    description=(
+        "Writes and executes Python code in a Docker sandbox"
+        " with filesystem access and pre-installed data"
+        " science packages."
+    ),
+)
+
+
 @dataclasses.dataclass(kw_only=True)
-class SandboxSkillConfig:
+class SandboxSkillConfig(_SkillPropertiesFromMetadata):
     """Configuration for the Docker sandbox skill."""
 
     kind: typing.ClassVar[str] = "sandbox"
+    source: typing.ClassVar[str] = SkillKind.ENTRYPOINT
 
     image: str | None = None
     idle_timeout: int | None = None
 
+    _skill_metadata: hs_models.SkillMetadata = dataclasses.field(
+        default_factory=lambda: SANDBOX_SKILL_METADATA,
+        repr=False,
+        compare=False,
+    )
     _config_path: pathlib.Path | None = None
+
+    state_type: SkillStateType = SandboxState
+    state_namespace: str | None = "sandbox"
 
     @classmethod
     def from_yaml(
@@ -446,14 +467,8 @@ class SandboxSkillConfig:
             ) from exc
 
     @property
-    def name(self) -> str:
-        return "sandbox"
-
-    @staticmethod
-    def _create_skill(**kwargs) -> hs_models.Skill:  # pragma: NO COVER
-        import haiku_skills_sandbox
-
-        return haiku_skills_sandbox.create_skill(**kwargs)
+    def agui_feature_names(self) -> tuple[str]:
+        return ("sandbox",)
 
     @property
     def skill(self) -> hs_models.Skill:
@@ -462,7 +477,9 @@ class SandboxSkillConfig:
             kwargs["image"] = self.image
         if self.idle_timeout is not None:
             kwargs["idle_timeout"] = self.idle_timeout
-        return self._create_skill(**kwargs)
+        skill = create_sandbox_skill(**kwargs)
+        skill._factory = create_sandbox_skill
+        return skill
 
 
 SKILL_CONFIG_CLASSES_BY_KIND = {

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -283,6 +283,7 @@ class Installation:
         *,
         room_id: str,
         user: dict,
+        thread_id: str | None = None,
         the_authz_policy: authz_package.AuthorizationPolicy = None,
         the_logger: loggers.LogWrapper = None,
     ) -> pydantic_ai.Agent:
@@ -294,11 +295,17 @@ class Installation:
         )
         mcpcts_configs = room_config.mcp_client_toolset_configs
 
+        kwargs = {}
+        if thread_id is not None:
+            kwargs["thread_id"] = thread_id
+            kwargs["threads_upload_path"] = self._config.threads_upload_path
+
         return agents.get_agent_from_configs(
             agent_config=room_config.agent_config,
             tool_configs=room_config.tool_configs,
             mcp_client_toolset_configs=mcpcts_configs,
             skill_toolset_config=room_config.skills,
+            **kwargs,
         )
 
     async def get_agent_for_completion(

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -75,6 +75,7 @@ async def _check_user_room_agent(
     the_authz_policy: authz_package.AuthorizationPolicy,
     the_user_claims: authn.UserClaims,
     the_logger: loggers.LogWrapper,
+    thread_id: str | None = None,
 ) -> tuple[models.UserProfile, pydantic_ai.Agent]:
     """Check that the user has access to the given room.
 
@@ -86,6 +87,7 @@ async def _check_user_room_agent(
         agent = await the_installation.get_agent_for_room(
             room_id=room_id,
             user=the_user_claims,
+            thread_id=thread_id,
             the_authz_policy=the_authz_policy,
             the_logger=the_logger,
         )
@@ -700,6 +702,7 @@ async def post_room_agui_thread_id_run_id(
         the_authz_policy=the_authz_policy,
         the_user_claims=the_user_claims,
         the_logger=the_logger,
+        thread_id=thread_id,
     )
 
     agui_adapter = await ai_ag_ui.AGUIAdapter.from_request(

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -1140,3 +1140,82 @@ def test_roomskillsconfig_skill_toolset(
         gmfc.assert_called_once_with(agent_config=model_agent_config)
     else:
         gmfc.assert_not_called()
+
+
+# ====================================================================
+# SandboxSkillConfig
+# ====================================================================
+
+
+@pytest.mark.parametrize(
+    "w_kw, exp_create_kw",
+    [
+        ({}, {}),
+        (
+            {"image": "my-image:v1", "idle_timeout": 1800},
+            {"image": "my-image:v1", "idle_timeout": 1800},
+        ),
+    ],
+)
+@mock.patch.object(config_skills.SandboxSkillConfig, "_create_skill")
+def test_sandboxskillconfig_skill(
+    mock_create_skill, w_kw, exp_create_kw
+):
+    fake_skill = mock.create_autospec(hs_models.Skill)
+    mock_create_skill.return_value = fake_skill
+
+    inst = config_skills.SandboxSkillConfig(**w_kw)
+
+    found = inst.skill
+
+    assert found is fake_skill
+    mock_create_skill.assert_called_once_with(**exp_create_kw)
+
+
+@pytest.mark.parametrize(
+    "w_config, expectation",
+    [
+        (
+            {"not_a_valid_key": "FAIL"},
+            pytest.raises(config_exc.FromYamlException),
+        ),
+        (
+            {"image": "custom:latest", "idle_timeout": 600},
+            contextlib.nullcontext(
+                {"image": "custom:latest", "idle_timeout": 600}
+            ),
+        ),
+        ({}, contextlib.nullcontext({})),
+    ],
+)
+def test_sandboxskillconfig_from_yaml(
+    installation_config,
+    temp_dir,
+    w_config,
+    expectation,
+):
+    config_path = temp_dir / "config_file.yaml"
+    config_dict = {"kind": "sandbox"} | w_config
+
+    with expectation as expected:
+        inst = config_skills.SandboxSkillConfig.from_yaml(
+            installation_config=installation_config,
+            config_path=config_path,
+            config_dict=config_dict,
+        )
+
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert isinstance(inst, config_skills.SandboxSkillConfig)
+        assert inst.image == expected.get("image")
+        assert inst.idle_timeout == expected.get("idle_timeout")
+
+
+def test_sandboxskillconfig_registered():
+    assert "sandbox" in config_skills.SKILL_CONFIG_CLASSES_BY_KIND
+    assert (
+        config_skills.SKILL_CONFIG_CLASSES_BY_KIND["sandbox"]
+        is config_skills.SandboxSkillConfig
+    )
+
+    inst = config_skills.SandboxSkillConfig()
+    assert inst.name == "sandbox"

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -1157,10 +1157,8 @@ def test_roomskillsconfig_skill_toolset(
         ),
     ],
 )
-@mock.patch.object(config_skills.SandboxSkillConfig, "_create_skill")
-def test_sandboxskillconfig_skill(
-    mock_create_skill, w_kw, exp_create_kw
-):
+@mock.patch("soliplex.config.skills.create_sandbox_skill")
+def test_sandboxskillconfig_skill(mock_create_skill, w_kw, exp_create_kw):
     fake_skill = mock.create_autospec(hs_models.Skill)
     mock_create_skill.return_value = fake_skill
 
@@ -1217,5 +1215,16 @@ def test_sandboxskillconfig_registered():
         is config_skills.SandboxSkillConfig
     )
 
+    from haiku_skills_sandbox import SandboxState
+
     inst = config_skills.SandboxSkillConfig()
     assert inst.name == "sandbox"
+    assert inst.description is not None
+    assert inst.source == hs_models.SkillSource.ENTRYPOINT
+    assert inst.state_type is SandboxState
+    assert inst.state_namespace == "sandbox"
+    assert inst.agui_feature_names == ("sandbox",)
+    assert inst.license is None
+    assert inst.compatibility is None
+    assert inst.allowed_tools == []
+    assert inst.metadata == {}

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1,7 +1,11 @@
 import dataclasses
+import pathlib
 from unittest import mock
 
 import pytest
+from haiku.skills import agent as hs_agent
+from haiku.skills import models as hs_models
+from haiku.skills import registry as hs_registry
 from pydantic_ai import capabilities as ai_capabilities
 from pydantic_ai import tools as ai_tools
 
@@ -365,6 +369,8 @@ def test_get_agent_from_configs_wo_hit_w_default_kind(
         agent_config=agent_config,
         tool_configs=tool_configs,
         mcp_client_toolset_configs=mcp_tc_configs,
+        thread_id=None,
+        threads_upload_path=None,
         **kwargs,
     )
 
@@ -425,3 +431,115 @@ def test_get_agent_from_configs_w_hit():
         )
 
     assert found is expected
+
+
+THREAD_ID = "thread-abc-123"
+
+
+def test_get_agent_from_configs_w_thread_id_cache_key():
+    """When thread_id is provided, the cache key includes it."""
+    a_config = mock.create_autospec(config_agents.AgentConfig)
+    a_config.id = ROOM_ID
+    a_config.kind = "default"
+
+    with (
+        mock.patch(
+            "soliplex.agents.get_default_agent_from_configs"
+        ) as gdafc,
+        mock.patch.dict(
+            "soliplex.agents._agent_cache", clear=True
+        ) as cache,
+    ):
+        found = agents.get_agent_from_configs(
+            agent_config=a_config,
+            tool_configs={},
+            mcp_client_toolset_configs={},
+            thread_id=THREAD_ID,
+        )
+
+        assert (ROOM_ID, THREAD_ID) in cache
+        assert cache[(ROOM_ID, THREAD_ID)] is found
+
+
+def test_get_agent_from_configs_w_thread_id_cache_hit():
+    """Cache hit by (room_id, thread_id) key."""
+    expected = object()
+    a_config = mock.create_autospec(config_agents.AgentConfig)
+    a_config.id = ROOM_ID
+
+    with mock.patch.dict(
+        "soliplex.agents._agent_cache", clear=True
+    ) as ac:
+        ac[(ROOM_ID, THREAD_ID)] = expected
+
+        found = agents.get_agent_from_configs(
+            agent_config=a_config,
+            tool_configs={},
+            mcp_client_toolset_configs={},
+            thread_id=THREAD_ID,
+        )
+
+    assert found is expected
+
+
+@mock.patch("soliplex.agents.get_default_agent_from_configs")
+def test_get_agent_from_configs_passes_thread_id(gdafc):
+    """thread_id and threads_upload_path are forwarded."""
+    a_config = mock.create_autospec(config_agents.AgentConfig)
+    a_config.id = ROOM_ID
+    a_config.kind = "default"
+    threads_path = pathlib.Path("/uploads/threads")
+
+    with mock.patch.dict(
+        "soliplex.agents._agent_cache", clear=True
+    ):
+        agents.get_agent_from_configs(
+            agent_config=a_config,
+            tool_configs={},
+            mcp_client_toolset_configs={},
+            thread_id=THREAD_ID,
+            threads_upload_path=threads_path,
+        )
+
+    gdafc.assert_called_once()
+    call_kw = gdafc.call_args.kwargs
+    assert call_kw["thread_id"] == THREAD_ID
+    assert call_kw["threads_upload_path"] is threads_path
+
+
+@pytest.mark.parametrize(
+    "thread_id, w_upload_path, has_sandbox",
+    [
+        (None, False, True),
+        (THREAD_ID, False, True),
+        (THREAD_ID, True, False),
+        (THREAD_ID, True, True),
+    ],
+)
+def test_reconfigure_sandbox(
+    temp_dir, thread_id, w_upload_path, has_sandbox
+):
+    toolset = mock.create_autospec(hs_agent.SkillToolset)
+    registry = hs_registry.SkillRegistry()
+    toolset.registry = registry
+
+    sandbox_skill = None
+    if has_sandbox:
+        sandbox_skill = mock.create_autospec(hs_models.Skill)
+        sandbox_skill.metadata = hs_models.SkillMetadata(
+            name="sandbox", description="test"
+        )
+        registry.register(sandbox_skill)
+
+    upload_path = temp_dir / "uploads" / "threads" if w_upload_path else None
+
+    agents._reconfigure_sandbox(toolset, thread_id, upload_path)
+
+    if thread_id and upload_path and has_sandbox:
+        expected_workspace = upload_path / thread_id
+        sandbox_skill.reconfigure.assert_called_once_with(
+            workspace=expected_workspace,
+        )
+        assert expected_workspace.exists()
+    elif has_sandbox:
+        sandbox_skill.reconfigure.assert_not_called()

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -443,12 +443,8 @@ def test_get_agent_from_configs_w_thread_id_cache_key():
     a_config.kind = "default"
 
     with (
-        mock.patch(
-            "soliplex.agents.get_default_agent_from_configs"
-        ) as gdafc,
-        mock.patch.dict(
-            "soliplex.agents._agent_cache", clear=True
-        ) as cache,
+        mock.patch("soliplex.agents.get_default_agent_from_configs"),
+        mock.patch.dict("soliplex.agents._agent_cache", clear=True) as cache,
     ):
         found = agents.get_agent_from_configs(
             agent_config=a_config,
@@ -467,9 +463,7 @@ def test_get_agent_from_configs_w_thread_id_cache_hit():
     a_config = mock.create_autospec(config_agents.AgentConfig)
     a_config.id = ROOM_ID
 
-    with mock.patch.dict(
-        "soliplex.agents._agent_cache", clear=True
-    ) as ac:
+    with mock.patch.dict("soliplex.agents._agent_cache", clear=True) as ac:
         ac[(ROOM_ID, THREAD_ID)] = expected
 
         found = agents.get_agent_from_configs(
@@ -490,9 +484,7 @@ def test_get_agent_from_configs_passes_thread_id(gdafc):
     a_config.kind = "default"
     threads_path = pathlib.Path("/uploads/threads")
 
-    with mock.patch.dict(
-        "soliplex.agents._agent_cache", clear=True
-    ):
+    with mock.patch.dict("soliplex.agents._agent_cache", clear=True):
         agents.get_agent_from_configs(
             agent_config=a_config,
             tool_configs={},
@@ -516,9 +508,7 @@ def test_get_agent_from_configs_passes_thread_id(gdafc):
         (THREAD_ID, True, True),
     ],
 )
-def test_reconfigure_sandbox(
-    temp_dir, thread_id, w_upload_path, has_sandbox
-):
+def test_reconfigure_sandbox(temp_dir, thread_id, w_upload_path, has_sandbox):
     toolset = mock.create_autospec(hs_agent.SkillToolset)
     registry = hs_registry.SkillRegistry()
     toolset.registry = registry

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -1,5 +1,6 @@
 import contextlib
 import dataclasses
+import pathlib
 from unittest import mock
 
 import fastapi
@@ -973,6 +974,46 @@ async def test_installation_get_agent_for_room(
             the_installation=the_installation,
             user=test_user,
         )
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.agents.get_agent_from_configs")
+@mock.patch("soliplex.loggers.LogWrapper")
+async def test_installation_get_agent_for_room_w_thread_id(
+    lw_klass,
+    gafc,
+    test_user,
+):
+    a_config = mock.create_autospec(config_agents.AgentConfig)
+    r_config = mock.create_autospec(config_rooms.RoomConfig)
+    r_config.agent_config = a_config
+    r_config.skills = None
+    t_configs = r_config.tool_configs = {}
+    mcp_configs = r_config.mcp_client_toolset_configs = {}
+
+    threads_path = pathlib.Path("/uploads/threads")
+
+    i_config = mock.create_autospec(config_installation.InstallationConfig)
+    i_config.room_configs = {"room_id": r_config}
+    i_config.threads_upload_path = threads_path
+
+    the_installation = installation.Installation(i_config)
+
+    found = await the_installation.get_agent_for_room(
+        room_id="room_id",
+        user=test_user,
+        thread_id="thread-123",
+    )
+
+    assert found is gafc.return_value
+    gafc.assert_called_once_with(
+        agent_config=a_config,
+        tool_configs=t_configs,
+        mcp_client_toolset_configs=mcp_configs,
+        skill_toolset_config=None,
+        thread_id="thread-123",
+        threads_upload_path=threads_path,
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -270,6 +270,7 @@ async def test__check_user_room_agent(w_miss, expectation):
     the_installation.get_agent_for_room.assert_awaited_once_with(
         room_id=TEST_ROOM_ID,
         user=THE_USER_CLAIMS,
+        thread_id=None,
         the_authz_policy=the_authz_policy,
         the_logger=the_logger,
     )
@@ -1388,6 +1389,7 @@ async def test_post_room_agui_thread_id_run_id_streaming(
             the_authz_policy=the_authz_policy,
             the_user_claims=THE_USER_CLAIMS,
             the_logger=the_logger,
+            thread_id=TEST_THREAD_ID_STR,
         )
 
         assert state.agui_background_tasks is global_agui_bg_tasks

--- a/uv.lock
+++ b/uv.lock
@@ -294,6 +294,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -366,6 +375,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "7.4.0.post2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4b/1fe1ade6b4d33abff0224b45a8310775b04308668ad1bdef725af8e3fcaa/chardet-7.4.0.post2.tar.gz", hash = "sha256:21a6b5ca695252c03385dcfcc8b55c27907f1fe80838aa171b1ff4e356a1bb67", size = 767694, upload-time = "2026-03-29T18:07:23.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/24/b012c1fd362e1a25425afd9f746166976b8ba3b2d78140a39df23bba2886/chardet-7.4.0.post2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7aced16fe8098019c7c513dd92e9ee3ad29fffac757fa7de13ff8f3a8607a344", size = 854615, upload-time = "2026-03-29T18:06:52.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/778bcb1e162000c5b8295a25191935b0b2eaf0000096bd3fcbf782b5c8c0/chardet-7.4.0.post2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dc6829803ba71cb427dffac03a948ae828c617710bbd5f97ae3b34ab18558414", size = 838434, upload-time = "2026-03-29T18:06:54.332Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6a/827065f0390160d1c74e4cbe8f68815d56daf392c1eb5027fb16d0700d75/chardet-7.4.0.post2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46659d38ba18e7c740f10a4c2edd0ef112e0322606ab2570cb8fd387954e0de9", size = 860089, upload-time = "2026-03-29T18:06:56.233Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/32/3abb90c7057e2cbdd711b59d99dc4dfc1a28b7da5a41971ec918f0928682/chardet-7.4.0.post2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5933289313b8cbfb0d07cf44583a2a6c7e31bffe5dcb7ebb6592825aa197d5b0", size = 869310, upload-time = "2026-03-29T18:06:57.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/e2/c0f2a96cbda065765ad33b3a8f466b279983a72a6e3035e0f5cfa54b831f/chardet-7.4.0.post2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b99b417fac30641429829666ee7331366e797863504260aa1b18bfc2020e4e3", size = 863047, upload-time = "2026-03-29T18:06:59.427Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/0b6039f2d254698a525d9a1b00334b3262a6521adede50885f05ba714fad/chardet-7.4.0.post2-cp312-cp312-win_amd64.whl", hash = "sha256:a07dc1257fef2685dfc5182229abccd3f9b1299006a5b4d43ac7bd252faa1118", size = 924680, upload-time = "2026-03-29T18:07:00.772Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6f/40998484582edf32ebcbe30a51c0b33fb476aa4d22b172d4aabc3f47c5ed/chardet-7.4.0.post2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9bdb9387e692dd53c837aa922f676e5ab51209895cd99b15d30c6004418e0d27", size = 854448, upload-time = "2026-03-29T18:07:02.432Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ed/0fc7f4be6d346049bafec134cb4d122317e8e803b42e520f8214f02d9d13/chardet-7.4.0.post2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:422ac637f5a2a8b13151245591cb0fabdf9ec1427725f0560628cb5ad4fb1462", size = 838289, upload-time = "2026-03-29T18:07:04.026Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/f22cf8861c18126b6775b4d4a95fa4141ecc4a24d87c5a225d1d5df472c1/chardet-7.4.0.post2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d52b3f15249ba877030045900d179d44552c3c37dda487462be473ec67bed2f", size = 859345, upload-time = "2026-03-29T18:07:05.563Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ff/0f582b7a9369bba8abb47d72c3d1d1122c351b8fb04dcac2637683072bcb/chardet-7.4.0.post2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccdfb13b4a727d3d944157c7f350c6d64630511a0ce39e37ffa5114e90f7d3a7", size = 868537, upload-time = "2026-03-29T18:07:07.093Z" },
+    { url = "https://files.pythonhosted.org/packages/51/7b/226d88c86a5351dcb03cf7702f6916ab304d6ce5146a96d1636c9b4287a2/chardet-7.4.0.post2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daae5b0579e7e33adacb4722a62b540e6bec49944e081a859cb9a6a010713817", size = 862733, upload-time = "2026-03-29T18:07:08.948Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ef/b34d768e047796f69866b88dd81f10993bb5d7421a6196799512e478dd6a/chardet-7.4.0.post2-cp313-cp313-win_amd64.whl", hash = "sha256:6c448fe2d77e329cec421b95f844b75f8c9cb744e808ecc9124b6063ca6acb5e", size = 924887, upload-time = "2026-03-29T18:07:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1e/8b5d54ecc873e828e9b91cddfce6bf5a058d7bb3d64007cfbbbc872b0bda/chardet-7.4.0.post2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5862b17677f7e8fcee4e37fe641f01d30762e4b075ac37ce9584e4407896e2d9", size = 853887, upload-time = "2026-03-29T18:07:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/26/17/8c2cf762c876b04036e561d2a27df8a6305435db1cb584f71c356e319c40/chardet-7.4.0.post2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:22d05c4b7e721d5330d99ef4a6f6233a9de58ae6f2275c21a098bedd778a6cb7", size = 838555, upload-time = "2026-03-29T18:07:13.689Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/21/51fb8cfbcf2f1acc7c03776f4452f64ff2b9051505b38bc9e2a3941af330/chardet-7.4.0.post2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a035d407f762c21eb77069982425eb403e518dd758617aa43bf11d0d2203a1b6", size = 861305, upload-time = "2026-03-29T18:07:15.194Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/b6/13cc503f45beeb1117fc9c83f294df16ebce5d75eac9f0cefb8cce4357a1/chardet-7.4.0.post2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2adfa7390e69cb5ed499b54978d31f6d476788d07d83da3426811181b7ca7682", size = 868868, upload-time = "2026-03-29T18:07:16.781Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ca/f1ab73f8d431c5257ad536956992513a5c135c53cf2a3dc94b8a45f83082/chardet-7.4.0.post2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2345f20ea67cdadddb778b2bc31e2defc2a85ae027931f9ad6ab84fd5d345320", size = 863417, upload-time = "2026-03-29T18:07:18.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/cc/d2918dc6d110cf585a30ee11dbdcfa56a2b2fbf16e2b4117fe8bf800f320/chardet-7.4.0.post2-cp314-cp314-win_amd64.whl", hash = "sha256:52602972d4815047cee262551bc383ab394aa145f5ca9ee10d0a53d27965882e", size = 919100, upload-time = "2026-03-29T18:07:20.312Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d2/22ac0b5b832bb9d2f29311dcded6c09ad0c32c23e3e53a8033aad5eb8652/chardet-7.4.0.post2-py3-none-any.whl", hash = "sha256:e0c9c6b5c296c0e5197bc8876fcc04d58a6ddfba18399e598ba353aba28b038e", size = 625322, upload-time = "2026-03-29T18:07:21.81Z" },
 ]
 
 [[package]]
@@ -677,6 +713,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -1084,6 +1134,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/61/5c1a8e7978b1eab1a17fb65026f8f837f48f34830f43ac944feb473c71b7/haiku_skills-0.13.0.tar.gz", hash = "sha256:02bca51247254d685c26a142d6f5321279ef10c4aed5aee90e8e4db996e82c26", size = 249960, upload-time = "2026-03-27T15:51:00.074Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/85/740e9a778bede480aa5540c7f520803a0226636f425f2b0320bada13a02c/haiku_skills-0.13.0-py3-none-any.whl", hash = "sha256:6f18c84e31de3b67c9476f7a19b1719877314dcaceb7a0b94963ca9d43ccac2f", size = 31451, upload-time = "2026-03-27T15:50:59.072Z" },
+]
+
+[[package]]
+name = "haiku-skills-sandbox"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "haiku-skills" },
+    { name = "pydantic-ai-backend", extra = ["console", "docker"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/3c/63c1aeb60e6443adbe1dcb3d8f21b66d690bdb17728481e33da1c75b5a27/haiku_skills_sandbox-0.13.0.tar.gz", hash = "sha256:d935998d6a1bc81dbd7176503e9997d4bad6870439269c0a2a433110a6ccf247", size = 3831, upload-time = "2026-03-27T15:54:45.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/46/cabbaccac6dd4da62df454c2f9bc4f25e26cb6a40d38720fc71c0ef3e7e4/haiku_skills_sandbox-0.13.0-py3-none-any.whl", hash = "sha256:359da82e12cff59cefe4892436b99a3f17d420fb7c07b2c4837c8a8ccec2de3f", size = 4962, upload-time = "2026-03-27T15:54:43.193Z" },
 ]
 
 [[package]]
@@ -2635,6 +2698,29 @@ email = [
 ]
 
 [[package]]
+name = "pydantic-ai-backend"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/7d/67038690af9bdc882ea771dea9492369a8dc8131b8b5b1977b19e59d6862/pydantic_ai_backend-0.2.2.tar.gz", hash = "sha256:c07e9590066bb4b6fa0fad3350b4b0da685dbfde4ccea55c3994e9aa067093ea", size = 13770673, upload-time = "2026-03-31T15:05:16.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/66/020ca3caedc570c2b393a81c20a9961c8ad53005dd80ae96130f7481a759/pydantic_ai_backend-0.2.2-py3-none-any.whl", hash = "sha256:7025c8517392190ad6ad9381f4d954d44a25d1643f06f055d3853fb486d5a203", size = 57558, upload-time = "2026-03-31T15:05:14.887Z" },
+]
+
+[package.optional-dependencies]
+console = [
+    { name = "pydantic-ai-slim" },
+]
+docker = [
+    { name = "chardet" },
+    { name = "docker" },
+    { name = "pypdf" },
+]
+
+[[package]]
 name = "pydantic-ai-slim"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2876,6 +2962,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/83/691bdb309306232362503083cb15777491045dd54f45393a317dc7d8082f/pypdf-6.9.2.tar.gz", hash = "sha256:7f850faf2b0d4ab936582c05da32c52214c2b089d61a316627b5bfb5b0dab46c", size = 5311837, upload-time = "2026-03-23T14:53:27.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/7e/c85f41243086a8fe5d1baeba527cb26a1918158a565932b41e0f7c0b32e9/pypdf-6.9.2-py3-none-any.whl", hash = "sha256:662cf29bcb419a36a1365232449624ab40b7c2d0cfc28e54f42eeecd1fd7e844", size = 333744, upload-time = "2026-03-23T14:53:26.573Z" },
 ]
 
 [[package]]
@@ -3423,6 +3518,7 @@ dependencies = [
 dev = [
     { name = "anyio" },
     { name = "coverage" },
+    { name = "haiku-skills-sandbox" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -3438,6 +3534,9 @@ docs = [
 postgres = [
     { name = "asyncpg" },
     { name = "psycopg", extra = ["binary"] },
+]
+sandbox = [
+    { name = "haiku-skills-sandbox" },
 ]
 tui = [
     { name = "textual" },
@@ -3474,6 +3573,7 @@ requires-dist = [
 dev = [
     { name = "anyio", specifier = ">=4.12.1,<4.13" },
     { name = "coverage", specifier = ">=7.13.5,<7.14" },
+    { name = "haiku-skills-sandbox" },
     { name = "pytest", specifier = ">=9.0.2,<9.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<1.4" },
     { name = "pytest-cov", specifier = ">=7.0.0,<7.1" },
@@ -3490,6 +3590,7 @@ postgres = [
     { name = "asyncpg" },
     { name = "psycopg", extras = ["binary"] },
 ]
+sandbox = [{ name = "haiku-skills-sandbox" }]
 tui = [
     { name = "textual" },
     { name = "textual-fspicker" },
@@ -3962,6 +4063,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Added support for a Docker sandbox room with per-thread file uploads.

New skill config kind `"sandbox"` (`config/skills.py`)  creates a fresh `haiku-skills-sandbox` `Skill` on each access, avoiding shared-state races between concurrent threads. Inherits `_SkillPropertiesFromMetadata` for the full config interface and sets `_factory` on created skills to enable `reconfigure()`.

Per-thread agent caching and sandbox workspace mounting: when `thread_id` is provided, agents are cached per `(room_id, thread_id)` instead of just `room_id`. A new `_reconfigure_sandbox()` helper finds the sandbox skill in the `SkillToolset` registry and calls `reconfigure(workspace=threads_upload_path/thread_id)`, mounting the thread's upload directory at `/workspace` in the Docker container. The `thread_id` is threaded from the AGUI view endpoint through `get_agent_for_room` to agent creation.

Design decisions

- Per-thread uploads: users upload to their thread; each thread gets its own sandbox container with its own workspace mount.
- Fresh `Skill` per request: unlike `EntrypointSkillConfig` which returns a shared instance, `SandboxSkillConfig.skill` creates a new `Skill` each call, making concurrent `reconfigure()` safe.
- Container persistence: the sandbox container lives across runs within a thread via `SandboxState.session_id` in AG-UI state. The mount is set once on first container creation and reused.

Example room: `example/rooms/data-sandbox/` with a room config combining sandbox and RAG skills, file upload tools, and a system prompt for orchestrating between them.
