### PR TITLE
fix: implement server-side OIDC state storage

### DIFF
--- a/src/soliplex/authz/__init__.py
+++ b/src/soliplex/authz/__init__.py
@@ -78,6 +78,23 @@ class AuthorizationPolicy(abc.ABC):
     ) -> None:
         """Delete the authorization policy for the room"""
 
+    @abc.abstractmethod
+    async def create_oidc_state(
+        self,
+        state: str,
+        nonce: str,
+        system: str,
+    ) -> None:
+        """Store an OIDC state/nonce pair for a system."""
+
+    @abc.abstractmethod
+    async def consume_oidc_state(
+        self,
+        state: str,
+        system: str,
+    ) -> str | None:
+        """Return and delete the nonce for an OIDC state/system pair."""
+
 
 async def get_the_authz_policy(
     request: fastapi.Request,

--- a/src/soliplex/authz/__init__.py
+++ b/src/soliplex/authz/__init__.py
@@ -83,17 +83,21 @@ class AuthorizationPolicy(abc.ABC):
         self,
         state: str,
         nonce: str,
+        redirect_uri: str,
         system: str,
     ) -> None:
-        """Store an OIDC state/nonce pair for a system."""
+        """Store an OIDC state/nonce/redirect_uri for a system."""
 
     @abc.abstractmethod
     async def consume_oidc_state(
         self,
         state: str,
         system: str,
-    ) -> str | None:
-        """Return and delete the nonce for an OIDC state/system pair."""
+    ) -> dict | None:
+        """Return and delete the OIDC state data for a state/system pair.
+
+        Returns a dict with 'nonce' and 'redirect_uri', or None.
+        """
 
 
 async def get_the_authz_policy(

--- a/src/soliplex/authz/persistence.py
+++ b/src/soliplex/authz/persistence.py
@@ -219,3 +219,29 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
             if policy is not None:
                 async with session.begin_nested():
                     await session.delete(policy)
+
+    async def create_oidc_state(self, state: str, nonce: str, system: str):
+        """Store an OIDC state/nonce pair for a system."""
+        async with self.session as session:
+            oidc_state = authz_schema.OIDCState(
+                state=state,
+                nonce=nonce,
+                system=system,
+            )
+            session.add(oidc_state)
+
+    async def consume_oidc_state(self, state: str, system: str) -> str | None:
+        """Return and delete the nonce for an OIDC state/system pair."""
+        async with self.session as session:
+            query = sqla_sql.select(authz_schema.OIDCState).where(
+                authz_schema.OIDCState.state == state,
+                authz_schema.OIDCState.system == system,
+            )
+            oidc_state = (await session.scalars(query)).first()
+
+            if oidc_state is not None:
+                nonce = oidc_state.nonce
+                await session.delete(oidc_state)
+                return nonce
+
+        return None

--- a/src/soliplex/authz/persistence.py
+++ b/src/soliplex/authz/persistence.py
@@ -220,18 +220,21 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
                 async with session.begin_nested():
                     await session.delete(policy)
 
-    async def create_oidc_state(self, state: str, nonce: str, system: str):
-        """Store an OIDC state/nonce pair for a system."""
+    async def create_oidc_state(
+        self, state: str, nonce: str, redirect_uri: str, system: str
+    ):
+        """Store an OIDC state/nonce/redirect_uri for a system."""
         async with self.session as session:
             oidc_state = authz_schema.OIDCState(
                 state=state,
                 nonce=nonce,
+                redirect_uri=redirect_uri,
                 system=system,
             )
             session.add(oidc_state)
 
-    async def consume_oidc_state(self, state: str, system: str) -> str | None:
-        """Return and delete the nonce for an OIDC state/system pair."""
+    async def consume_oidc_state(self, state: str, system: str) -> dict | None:
+        """Return and delete the OIDC state data for a state/system pair."""
         async with self.session as session:
             query = sqla_sql.select(authz_schema.OIDCState).where(
                 authz_schema.OIDCState.state == state,
@@ -240,8 +243,11 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
             oidc_state = (await session.scalars(query)).first()
 
             if oidc_state is not None:
-                nonce = oidc_state.nonce
+                data = {
+                    "nonce": oidc_state.nonce,
+                    "redirect_uri": oidc_state.redirect_uri,
+                }
                 await session.delete(oidc_state)
-                return nonce
+                return data
 
         return None

--- a/src/soliplex/authz/schema.py
+++ b/src/soliplex/authz/schema.py
@@ -67,6 +67,27 @@ class AdminUser(Base):
     )
 
 
+class OIDCState(Base):
+    """Store OAuth state and nonce for cross-site redirect robustness.
+
+    'state': random string sent to OIDC provider
+    'nonce': random string used for ID token validation
+    'system': the name of the OIDC system (e.g. 'josce')
+    'timestamp': when the state was generated (for cleanup)
+    """
+
+    __tablename__ = "oidc_states"
+
+    state: Mapped[str] = mapped_column(primary_key=True)
+    nonce: Mapped[str] = mapped_column()
+    system: Mapped[str] = mapped_column()
+
+    created: Mapped[datetime.datetime] = mapped_column(
+        sqla_sqltypes.TIMESTAMP(timezone=True),
+        default=_timestamp,
+    )
+
+
 class RoomPolicy(Base):
     """Describe authorization policy for a room
 

--- a/src/soliplex/authz/schema.py
+++ b/src/soliplex/authz/schema.py
@@ -72,14 +72,16 @@ class OIDCState(Base):
 
     'state': random string sent to OIDC provider
     'nonce': random string used for ID token validation
+    'redirect_uri': the callback URI for the token exchange
     'system': the name of the OIDC system (e.g. 'josce')
-    'timestamp': when the state was generated (for cleanup)
+    'created': when the state was generated (for cleanup)
     """
 
     __tablename__ = "oidc_states"
 
     state: Mapped[str] = mapped_column(primary_key=True)
     nonce: Mapped[str] = mapped_column()
+    redirect_uri: Mapped[str] = mapped_column()
     system: Mapped[str] = mapped_column()
 
     created: Mapped[datetime.datetime] = mapped_column(

--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -57,9 +57,14 @@ def app_with_cors(app: fastapi.FastAPI) -> fastapi.FastAPI:
 
 
 def app_with_session(app: fastapi.FastAPI, token: str) -> fastapi.FastAPI:
+    # We now store OIDC state/nonce in the database, so the session cookie
+    # SameSite policy is no longer critical for the login flow. We keep it
+    # as 'lax' for a secure default.
     app.add_middleware(
         starlette_mw_sessions.SessionMiddleware,
         secret_key=token.encode("ascii"),
+        same_site="lax",
+        https_only=True,
     )
     return app
 

--- a/src/soliplex/views/authn.py
+++ b/src/soliplex/views/authn.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import secrets
+import time
 from urllib import parse as urlparse
 
 import fastapi
@@ -82,6 +83,7 @@ async def get_login_system(
     await the_authz_policy.create_oidc_state(
         state=state,
         nonce=nonce,
+        redirect_uri=str(redirect_uri),
         system=system,
     )
 
@@ -126,24 +128,32 @@ async def get_auth_system(
     oauth = authn.get_oauth(the_installation)
     oauth_app = oauth.create_client(system)
 
-    # Retrieve state from URL and look up corresponding nonce from DB
+    # Retrieve state from URL and look up corresponding data from DB
     state = request.query_params.get("state")
-    nonce = await the_authz_policy.consume_oidc_state(
+    state_data = await the_authz_policy.consume_oidc_state(
         state=state,
         system=system,
     )
 
-    if nonce is None:
+    if state_data is None:
         bound_logger.error("OIDC state not found in database: %s", state)
         raise fastapi.HTTPException(
             status_code=401,
             detail="Invalid OIDC state",
         )
 
-    # Mock the session so authlib finds the expected state/nonce
+    # Populate the session with the format authlib expects:
+    # key: _state_{system}_{state_value}
+    # value: {"data": {nonce, redirect_uri, ...}, "exp": timestamp}
+    # See: authlib/integrations/starlette_client/integration.py
     request.scope["session"] = {
-        f"_{system}_state_": state,
-        f"_{system}_nonce_": nonce,
+        f"_state_{system}_{state}": {
+            "data": {
+                "nonce": state_data["nonce"],
+                "redirect_uri": state_data["redirect_uri"],
+            },
+            "exp": time.time() + 3600,
+        }
     }
 
     try:

--- a/src/soliplex/views/authn.py
+++ b/src/soliplex/views/authn.py
@@ -158,14 +158,11 @@ async def get_auth_system(
 
     try:
         tokendict = await oauth_app.authorize_access_token(request)
-    except starlette_client.OAuthError as exc:
-        # Diagnostic logging for session issues (though we now use DB)
-        bound_logger.error(
-            "OAuth error: %s, session keys: %s",
-            str(exc),
+    except starlette_client.OAuthError:
+        bound_logger.exception(
+            "OAuth error, session keys: %s",
             list(request.session.keys()),
         )
-        bound_logger.exception(loggers.AUTHN_JWT_INVALID)
         raise fastapi.HTTPException(
             status_code=401,
             detail=loggers.AUTHN_JWT_INVALID,

--- a/src/soliplex/views/authn.py
+++ b/src/soliplex/views/authn.py
@@ -1,6 +1,7 @@
 """Soliplex authentication views"""
 
 import dataclasses
+import secrets
 from urllib import parse as urlparse
 
 import fastapi
@@ -8,6 +9,7 @@ from authlib.integrations import starlette_client
 from fastapi import responses
 
 from soliplex import authn
+from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
@@ -17,6 +19,7 @@ from soliplex import views
 router = fastapi.APIRouter(tags=["authentication"])
 
 depend_the_installation = installation.depend_the_installation
+depend_the_authz = authz_package.depend_the_authz_policy
 depend_the_user_claims = views.depend_the_user_claims
 depend_the_unauth_logger = views.depend_the_unauth_logger
 depend_the_logger = views.depend_the_logger
@@ -50,6 +53,7 @@ async def get_login_system(
     request: fastapi.Request,
     system: str,
     the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
     the_unauth_logger: loggers.LogWrapper = depend_the_unauth_logger,
 ):
     """Initiate token auth flow with the specified OIDC auth provider"""
@@ -70,7 +74,26 @@ async def get_login_system(
     oauth = authn.get_oauth(the_installation)
     oauth_app = oauth.create_client(system)
 
-    found = await oauth_app.authorize_redirect(request, redirect_uri)
+    # Generate state and nonce and store them in the database instead of
+    # the session cookie. This avoids SameSite cookie issues during
+    # cross-site redirects (e.g. ADFS).
+    state = secrets.token_urlsafe(32)
+    nonce = secrets.token_urlsafe(32)
+    await the_authz_policy.create_oidc_state(
+        state=state,
+        nonce=nonce,
+        system=system,
+    )
+
+    # We must mock the session for authlib's authorize_redirect to see it,
+    # even though we don't intend to use the cookie it might try to set.
+    request.scope.setdefault("session", {})
+    found = await oauth_app.authorize_redirect(
+        request,
+        redirect_uri,
+        state=state,
+        nonce=nonce,
+    )
     bound_logger.debug(loggers.AUTHN_GET_LOGIN_SYSTEM)
     return found
 
@@ -84,6 +107,7 @@ async def get_auth_system(
     request: fastapi.Request,
     system: str,
     the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
     the_unauth_logger: loggers.LogWrapper = depend_the_unauth_logger,
 ):
     """Complete the OIDC token auth flow with the specified provider
@@ -102,9 +126,35 @@ async def get_auth_system(
     oauth = authn.get_oauth(the_installation)
     oauth_app = oauth.create_client(system)
 
+    # Retrieve state from URL and look up corresponding nonce from DB
+    state = request.query_params.get("state")
+    nonce = await the_authz_policy.consume_oidc_state(
+        state=state,
+        system=system,
+    )
+
+    if nonce is None:
+        bound_logger.error("OIDC state not found in database: %s", state)
+        raise fastapi.HTTPException(
+            status_code=401,
+            detail="Invalid OIDC state",
+        )
+
+    # Mock the session so authlib finds the expected state/nonce
+    request.scope["session"] = {
+        f"_{system}_state_": state,
+        f"_{system}_nonce_": nonce,
+    }
+
     try:
         tokendict = await oauth_app.authorize_access_token(request)
-    except starlette_client.OAuthError:
+    except starlette_client.OAuthError as exc:
+        # Diagnostic logging for session issues (though we now use DB)
+        bound_logger.error(
+            "OAuth error: %s, session keys: %s",
+            str(exc),
+            list(request.session.keys()),
+        )
         bound_logger.exception(loggers.AUTHN_JWT_INVALID)
         raise fastapi.HTTPException(
             status_code=401,
@@ -126,12 +176,12 @@ async def get_auth_system(
     refresh_expires_in = tokendict["refresh_expires_in"]
 
     # Handle hash-based routing (e.g., /#/auth/callback)
-    # Query params must be placed before the hash fragment for Flutter to see
-    # them
+    # Tokens should be passed via the URL fragment (#) instead of query
+    # params (?) to avoid exposure in server logs and browser history.
     return_to = request.query_params.get("return_to", "/")
 
     components = urlparse.urlparse(return_to)
-    qs = urlparse.urlencode(
+    token_fragment = urlparse.urlencode(
         dict(
             token=access_token,
             refresh_token=refresh_token,
@@ -139,14 +189,23 @@ async def get_auth_system(
             refresh_expires_in=refresh_expires_in,
         )
     )
+
+    if components.fragment:
+        if "?" in components.fragment:
+            new_fragment = f"{components.fragment}&{token_fragment}"
+        else:
+            new_fragment = f"{components.fragment}?{token_fragment}"
+    else:
+        new_fragment = token_fragment
+
     return_to = urlparse.urlunparse(
         (
             components.scheme,
             components.netloc,
             components.path,
             components.params,
-            qs,
-            components.fragment,
+            "",  # query params cleared
+            new_fragment,
         )
     )
 

--- a/tests/unit/authz/test_authz_persistence.py
+++ b/tests/unit/authz/test_authz_persistence.py
@@ -228,3 +228,44 @@ async def test_authorizationpolicy_room_policy_crud(the_async_session):
 
     await ap.delete_room_policy(ROOM_ID, USER_TOKEN)
     await the_async_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_authorizationpolicy_oidc_state_roundtrip(
+    the_async_session,
+):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    await ap.create_oidc_state(
+        state="abc123",
+        nonce="nonce456",
+        redirect_uri="https://example.com/callback",
+        system="test-oidc",
+    )
+    await the_async_session.commit()
+
+    result = await ap.consume_oidc_state("abc123", "test-oidc")
+    await the_async_session.commit()
+
+    assert result == {
+        "nonce": "nonce456",
+        "redirect_uri": "https://example.com/callback",
+    }
+
+    # Second consume returns None (state was deleted)
+    result = await ap.consume_oidc_state("abc123", "test-oidc")
+    await the_async_session.commit()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_authorizationpolicy_consume_oidc_state_not_found(
+    the_async_session,
+):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    result = await ap.consume_oidc_state("nonexistent", "test-oidc")
+    await the_async_session.commit()
+
+    assert result is None

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -124,6 +124,8 @@ def test_app_with_session():
     app.add_middleware.assert_called_once_with(
         starlette_mw_sessions.SessionMiddleware,
         secret_key=TOKEN.encode("ascii"),
+        same_site="lax",
+        https_only=True,
     )
 
 

--- a/tests/unit/views/test_authn_views.py
+++ b/tests/unit/views/test_authn_views.py
@@ -5,6 +5,7 @@ import pytest
 from authlib.integrations import starlette_client
 from fastapi import responses
 
+from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
@@ -56,6 +57,8 @@ async def test_get_login_system(get_oauth, w_return_to, w_auth_disabled):
     system = "test_oauth_appname"
     the_installation = mock.create_autospec(installation.Installation)
     the_installation.auth_disabled = w_auth_disabled
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_authz_policy.create_oidc_state = mock.AsyncMock()
     the_unauth_logger = mock.create_autospec(loggers.LogWrapper)
     bound_logger = the_unauth_logger.bind.return_value
 
@@ -85,6 +88,7 @@ async def test_get_login_system(get_oauth, w_return_to, w_auth_disabled):
                 request=request,
                 system=system,
                 the_installation=the_installation,
+                the_authz_policy=the_authz_policy,
                 the_unauth_logger=the_unauth_logger,
             )
 
@@ -103,12 +107,28 @@ async def test_get_login_system(get_oauth, w_return_to, w_auth_disabled):
             request=request,
             system=system,
             the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
             the_unauth_logger=the_unauth_logger,
         )
 
         assert found is oidc.authorize_redirect.return_value
 
-        ar.assert_awaited_once_with(request, rqp.return_value)
+        # authorize_redirect is called with state and nonce kwargs
+        ar.assert_awaited_once()
+        call_args = ar.call_args
+        assert call_args[0][0] is request
+        assert call_args[0][1] == rqp.return_value
+        assert "state" in call_args[1]
+        assert "nonce" in call_args[1]
+
+        # State was persisted to DB
+        the_authz_policy.create_oidc_state.assert_awaited_once()
+        create_call = the_authz_policy.create_oidc_state.call_args[1]
+        assert create_call["state"] == call_args[1]["state"]
+        assert create_call["nonce"] == call_args[1]["nonce"]
+        assert create_call["system"] == system
+        assert "redirect_uri" in create_call
+
         rqp.assert_called_once_with(return_to=exp_path)
         ruf.assert_called_once_with("get_auth_system", system=system)
         cc.assert_called_once_with(system)
@@ -136,8 +156,15 @@ async def test_get_auth_system(
     w_auth_disabled,
 ):
     system = "test_oauth_appname"
+    state = "test_state_value"
+    nonce = "test_nonce_value"
+    redirect_uri = "https://example.com/api/auth/test_oauth_appname"
     the_installation = mock.create_autospec(installation.Installation)
     the_installation.auth_disabled = w_auth_disabled
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_authz_policy.consume_oidc_state = mock.AsyncMock(
+        return_value={"nonce": nonce, "redirect_uri": redirect_uri},
+    )
     the_unauth_logger = mock.create_autospec(loggers.LogWrapper)
     bound_logger = the_unauth_logger.bind.return_value
 
@@ -163,40 +190,25 @@ async def test_get_auth_system(
             "email": "phreddy@example.com",
         }
 
-    session = {}
+    token_params = (
+        "token=TOKEN&refresh_token=RTOKEN"
+        "&expires_in=EXPIRES_IN&refresh_expires_in=REFRESH_EXPIRES_IN"
+    )
 
     if w_return_to:
-        exp_path = (
-            "/another/path?token=TOKEN&refresh_token=RTOKEN"
-            "&expires_in=EXPIRES_IN&refresh_expires_in=REFRESH_EXPIRES_IN"
-        )
-        qs = "return_to=/another/path"
+        exp_path = f"/another/path#{token_params}"
+        qs = f"return_to=/another/path&state={state}"
     else:
-        exp_path = (
-            "/?token=TOKEN&refresh_token=RTOKEN"
-            "&expires_in=EXPIRES_IN&refresh_expires_in=REFRESH_EXPIRES_IN"
-        )
-        qs = ""
+        exp_path = f"/#{token_params}"
+        qs = f"state={state}"
 
     request = fastapi.Request(
         scope={
             "type": "http",
             "query_string": qs,
-            "session": session,
+            "session": {},
         }
     )
-
-    aat = oidc.authorize_access_token = mock.AsyncMock()
-
-    if w_error == "aat":
-        aat.side_effect = starlette_client.OAuthError("testing")
-    else:
-        aat.return_value = {
-            "access_token": "TOKEN",
-            "refresh_token": "RTOKEN",
-            "expires_in": "EXPIRES_IN",
-            "refresh_expires_in": "REFRESH_EXPIRES_IN",
-        }
 
     if w_auth_disabled:
         with pytest.raises(fastapi.HTTPException) as exc:
@@ -204,6 +216,7 @@ async def test_get_auth_system(
                 request=request,
                 system=system,
                 the_installation=the_installation,
+                the_authz_policy=the_authz_policy,
                 the_unauth_logger=the_unauth_logger,
             )
         bound_logger.error.assert_called_once_with(
@@ -224,6 +237,7 @@ async def test_get_auth_system(
                     request=request,
                     system=system,
                     the_installation=the_installation,
+                    the_authz_policy=the_authz_policy,
                     the_unauth_logger=the_unauth_logger,
                 )
 
@@ -237,6 +251,7 @@ async def test_get_auth_system(
                 request=request,
                 system=system,
                 the_installation=the_installation,
+                the_authz_policy=the_authz_policy,
                 the_unauth_logger=the_unauth_logger,
             )
 
@@ -247,6 +262,12 @@ async def test_get_auth_system(
             bound_logger.debug.assert_called_once_with(
                 loggers.AUTHN_JWT_VALID,
             )
+
+        # State was consumed from DB
+        the_authz_policy.consume_oidc_state.assert_awaited_once_with(
+            state=state,
+            system=system,
+        )
 
         aat.assert_awaited_once_with(request)
 
@@ -264,23 +285,29 @@ async def test_get_auth_system(
 
 @pytest.mark.anyio
 async def test_get_auth_system_with_hash_routing():
-    """Test that authn callback handles hash-based routing correctly."""
+    """Test that authn callback handles hash-based routing correctly.
+
+    Tokens are placed in the URL fragment to avoid exposure in server logs.
+    """
+    state = "test_state"
+    nonce = "test_nonce"
+    redirect_uri = "http://test/authn/system"
 
     # Mock request with hash-based return_to URL
     request = mock.Mock()
-    request.query_params = {"return_to": "/#/authn/callback"}
-    request.url_for = mock.Mock(
-        return_value=mock.Mock(
-            replace_query_params=mock.Mock(
-                return_value="http://test/authn/system"
-            )
-        )
-    )
+    request.query_params = {
+        "return_to": "/#/authn/callback",
+        "state": state,
+    }
+    request.scope = {"session": {}}
 
-    # Mock installation with empty oidc_auth_system_configs
     the_installation = mock.create_autospec(installation.Installation)
     the_installation.auth_disabled = False
     the_installation.oidc_auth_system_configs = []
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_authz_policy.consume_oidc_state = mock.AsyncMock(
+        return_value={"nonce": nonce, "redirect_uri": redirect_uri},
+    )
     the_unauth_logger = mock.create_autospec(loggers.LogWrapper)
 
     # Mock OAuth components
@@ -301,54 +328,50 @@ async def test_get_auth_system_with_hash_routing():
         mock.patch("soliplex.authn.get_oauth", return_value=oauth),
         mock.patch("soliplex.authn.authenticate"),
     ):
-        # Call the function
         result = await authn_views.get_auth_system(
             request=request,
             system="pydio",
             the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
             the_unauth_logger=the_unauth_logger,
         )
 
-    # Check that the redirect URL has query params before the hash
     assert isinstance(result, responses.RedirectResponse)
     redirect_url = result.headers.get("location")
 
-    # Should be /?token=xxx&refresh_token=xxx#/authn/callback
-    # Not /#/authn/callback?token=xxx
-    assert redirect_url.startswith("/")
-    assert "?token=test_access_token" in redirect_url
-    assert "&refresh_token=test_refresh_token" in redirect_url
-    assert redirect_url.endswith("#/authn/callback")
-
-    # Verify the correct structure
+    # Tokens should be in the fragment, after the hash route
+    # e.g. /#/authn/callback?token=xxx&refresh_token=xxx
     parts = redirect_url.split("#")
     assert len(parts) == 2
-    assert "?token=" in parts[0]  # Query params before hash
-    assert parts[1] == "/authn/callback"  # Hash fragment preserved
+    assert parts[0] == "/"  # No query params in the path
+    assert "/authn/callback?" in parts[1]
+    assert "token=test_access_token" in parts[1]
+    assert "refresh_token=test_refresh_token" in parts[1]
 
 
 @pytest.mark.anyio
 async def test_get_authn_system_without_hash():
-    """Test that authn callback still works without hash routing."""
+    """Test that authn callback works without hash routing.
 
-    # Mock request without hash in return_to
+    Tokens are placed in the fragment even when there's no hash route.
+    """
+    state = "test_state"
+    nonce = "test_nonce"
+    redirect_uri = "http://test/authn/system"
+
     request = mock.Mock()
-    request.query_params = {"return_to": "/dashboard"}
-    request.url_for = mock.Mock(
-        return_value=mock.Mock(
-            replace_query_params=mock.Mock(
-                return_value="http://test/authn/system"
-            )
-        )
-    )
+    request.query_params = {"return_to": "/dashboard", "state": state}
+    request.scope = {"session": {}}
 
-    # Mock installation with empty oidc_auth_system_configs
     the_installation = mock.create_autospec(installation.Installation)
     the_installation.auth_disabled = False
     the_installation.oidc_auth_system_configs = []
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_authz_policy.consume_oidc_state = mock.AsyncMock(
+        return_value={"nonce": nonce, "redirect_uri": redirect_uri},
+    )
     the_unauth_logger = mock.create_autospec(loggers.LogWrapper)
 
-    # Mock OAuth components
     oauth = mock.Mock()
     oauth_app = mock.Mock()
     tokendict = {
@@ -361,28 +384,25 @@ async def test_get_authn_system_without_hash():
     oauth_app.authorize_access_token = mock.AsyncMock(return_value=tokendict)
     oauth.create_client = mock.Mock(return_value=oauth_app)
 
-    # Patch auth functions
     with (
         mock.patch("soliplex.authn.get_oauth", return_value=oauth),
         mock.patch("soliplex.authn.authenticate"),
     ):
-        # Call the function
         result = await authn_views.get_auth_system(
             request=request,
             system="pydio",
             the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
             the_unauth_logger=the_unauth_logger,
         )
 
-    # Check that the redirect URL has standard query params
     assert isinstance(result, responses.RedirectResponse)
     redirect_url = result.headers.get("location")
 
-    # Should be /dashboard?token=xxx&refresh_token=xxx
-    assert redirect_url.startswith("/dashboard")
-    assert "?token=test_access_token" in redirect_url
-    assert "&refresh_token=test_refresh_token" in redirect_url
-    assert "#" not in redirect_url  # No hash fragment
+    # Tokens in fragment: /dashboard#token=xxx&refresh_token=xxx
+    assert redirect_url.startswith("/dashboard#")
+    assert "token=test_access_token" in redirect_url
+    assert "refresh_token=test_refresh_token" in redirect_url
 
 
 @pytest.mark.anyio

--- a/tests/unit/views/test_authn_views.py
+++ b/tests/unit/views/test_authn_views.py
@@ -406,6 +406,100 @@ async def test_get_authn_system_without_hash():
 
 
 @pytest.mark.anyio
+async def test_get_auth_system_invalid_state():
+    """Test that an invalid/expired OIDC state returns 401."""
+    state = "nonexistent_state"
+    the_installation = mock.create_autospec(installation.Installation)
+    the_installation.auth_disabled = False
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_authz_policy.consume_oidc_state = mock.AsyncMock(return_value=None)
+    the_unauth_logger = mock.create_autospec(loggers.LogWrapper)
+
+    request = fastapi.Request(
+        scope={
+            "type": "http",
+            "query_string": f"state={state}",
+            "session": {},
+        }
+    )
+
+    with (
+        mock.patch("soliplex.authn.get_oauth"),
+        pytest.raises(fastapi.HTTPException) as exc,
+    ):
+        await authn_views.get_auth_system(
+            request=request,
+            system="josce",
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_unauth_logger=the_unauth_logger,
+        )
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Invalid OIDC state"
+    the_authz_policy.consume_oidc_state.assert_awaited_once_with(
+        state=state,
+        system="josce",
+    )
+
+
+@pytest.mark.anyio
+async def test_get_auth_system_fragment_with_existing_query():
+    """Test token appending when fragment already has query params."""
+    state = "test_state"
+    nonce = "test_nonce"
+    redirect_uri = "http://test/authn/system"
+
+    request = mock.Mock()
+    request.query_params = {
+        "return_to": "/#/authn/callback?existing=param",
+        "state": state,
+    }
+    request.scope = {"session": {}}
+
+    the_installation = mock.create_autospec(installation.Installation)
+    the_installation.auth_disabled = False
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_authz_policy.consume_oidc_state = mock.AsyncMock(
+        return_value={"nonce": nonce, "redirect_uri": redirect_uri},
+    )
+    the_unauth_logger = mock.create_autospec(loggers.LogWrapper)
+
+    oauth = mock.Mock()
+    oauth_app = mock.Mock()
+    tokendict = {
+        "access_token": "test_access_token",
+        "refresh_token": "test_refresh_token",
+        "expires_in": 3600,
+        "refresh_expires_in": 86400,
+    }
+    oauth_app.authorize_access_token = mock.AsyncMock(return_value=tokendict)
+    oauth.create_client = mock.Mock(return_value=oauth_app)
+
+    with (
+        mock.patch("soliplex.authn.get_oauth", return_value=oauth),
+        mock.patch("soliplex.authn.authenticate"),
+    ):
+        result = await authn_views.get_auth_system(
+            request=request,
+            system="pydio",
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_unauth_logger=the_unauth_logger,
+        )
+
+    assert isinstance(result, responses.RedirectResponse)
+    redirect_url = result.headers.get("location")
+
+    # Fragment already had ?existing=param, tokens should be appended with &
+    parts = redirect_url.split("#")
+    assert len(parts) == 2
+    assert "existing=param" in parts[1]
+    assert "&token=test_access_token" in parts[1]
+    assert "&refresh_token=test_refresh_token" in parts[1]
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("w_auth_disabled", [False, True])
 async def test_get_user_info(w_auth_disabled):
     the_installation = mock.create_autospec(installation.Installation)

--- a/tests/unit/views/test_authn_views.py
+++ b/tests/unit/views/test_authn_views.py
@@ -241,9 +241,7 @@ async def test_get_auth_system(
                     the_unauth_logger=the_unauth_logger,
                 )
 
-            bound_logger.exception.assert_called_once_with(
-                loggers.AUTHN_JWT_INVALID,
-            )
+            bound_logger.exception.assert_called_once()
 
             assert exc.value.status_code == 401
         else:


### PR DESCRIPTION
This PR implements server-side OIDC state and nonce storage in the database, eliminating the dependency on session cookies for the OAuth handshake. This is a robust solution for SameSite cookie issues during cross-site redirects (e.g. CAC/ADFS flows) and is immune to infrastructure-level cookie overrides (like Nginx 'proxy_cookie_flags').

Key changes:
- Added 'oidc_states' table to the database schema.
- Updated OIDC login/callback views to use the database for state/nonce storage.
- Reverted session cookie to 'SameSite=Lax' for improved security posture.
- Pass tokens via URL fragment instead of query parameters to prevent leakage to logs/history.
- Added diagnostic logging for OAuth errors.
