### PR TITLE
fix: harden upload filenames against malicious client

### DIFF
--- a/src/soliplex/views/file_uploads.py
+++ b/src/soliplex/views/file_uploads.py
@@ -69,7 +69,8 @@ async def post_uploads_room(
 
     room_dir = pathlib.Path(uploads_path) / room_id
     room_dir.mkdir(parents=True, exist_ok=True)
-    upload_target = room_dir / upload_file.filename
+    stripped_filename = pathlib.Path(upload_file.filename).name
+    upload_target = room_dir / stripped_filename
     upload_target.write_bytes(await upload_file.read())
 
     return fastapi.Response(status_code=204)
@@ -127,7 +128,8 @@ async def post_uploads_room_thread(
 
     thread_dir = pathlib.Path(uploads_path) / thread_id
     thread_dir.mkdir(parents=True, exist_ok=True)
-    upload_target = thread_dir / upload_file.filename
+    stripped_filename = pathlib.Path(upload_file.filename).name
+    upload_target = thread_dir / stripped_filename
     upload_target.write_bytes(await upload_file.read())
 
     return fastapi.Response(status_code=204)

--- a/tests/unit/views/test_file_uploads.py
+++ b/tests/unit/views/test_file_uploads.py
@@ -49,6 +49,13 @@ def uploads_path(temp_dir):
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
+    "w_filename, exp_filename",
+    [
+        (TEST_FILENAME, TEST_FILENAME),
+        ("../../../../etc/passwd", "passwd"),
+    ],
+)
+@pytest.mark.parametrize(
     "w_upload_path, expectation",
     [
         (True, no_error(204)),
@@ -63,12 +70,14 @@ async def test_post_uploads_room(
     uploads_path,
     w_upload_path,
     expectation,
+    w_filename,
+    exp_filename,
 ):
     room_config = mock.create_autospec(config_rooms.RoomConfig)
     cuir.return_value = room_config
     upload_file = fastapi.UploadFile(
         file=io.BytesIO(TEST_CONTENT),
-        filename=TEST_FILENAME,
+        filename=w_filename,
         headers={"Content-Type": "text/plain"},
     )
 
@@ -121,7 +130,7 @@ async def test_post_uploads_room(
 
         if not isinstance(expected, pytest.ExceptionInfo):
             assert response.status_code == expected
-            exp_file = uploads_path / "rooms" / TEST_ROOM_ID / TEST_FILENAME
+            exp_file = uploads_path / "rooms" / TEST_ROOM_ID / exp_filename
             assert exp_file.read_bytes() == TEST_CONTENT
 
     the_authz_logger.debug.assert_called_once_with(
@@ -134,6 +143,13 @@ async def test_post_uploads_room(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    "w_filename, exp_filename",
+    [
+        (TEST_FILENAME, TEST_FILENAME),
+        ("../../../../etc/passwd", "passwd"),
+    ],
+)
 @pytest.mark.parametrize(
     "tsgt_side_effect, w_upload_path, expectation",
     [
@@ -158,12 +174,14 @@ async def test_post_uploads_room_thread(
     tsgt_side_effect,
     w_upload_path,
     expectation,
+    w_filename,
+    exp_filename,
 ):
     room_config = mock.create_autospec(config_rooms.RoomConfig)
     cuir.return_value = room_config
     upload_file = fastapi.UploadFile(
         file=io.BytesIO(TEST_CONTENT),
-        filename=TEST_FILENAME,
+        filename=w_filename,
         headers={"Content-Type": "text/plain"},
     )
 
@@ -196,7 +214,7 @@ async def test_post_uploads_room_thread(
 
     if not isinstance(expected, pytest.ExceptionInfo):
         assert response.status_code == expected
-        exp_file = uploads_path / "threads" / TEST_THREAD_ID / TEST_FILENAME
+        exp_file = uploads_path / "threads" / TEST_THREAD_ID / exp_filename
         assert exp_file.read_bytes() == TEST_CONTENT
 
     the_threads.get_thread.assert_called_once_with(


### PR DESCRIPTION
Strip any leading path elements before computing the  / upload path.

Closes #832.