### PR TITLE
chore: remove per-room agent cache

### DIFF
--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -63,10 +63,6 @@ class AgentFactory(typing.Protocol):
     ) -> SoliplexAgent: ...
 
 
-# Cache for agents to avoid recreating them
-_agent_cache: dict[str, pydantic_ai.Agent] = {}
-
-
 def make_ai_tool(tool_config: config_tools.ToolConfig) -> ai_tools.Tool:
     tool_func = tool_config.tool_with_config
 
@@ -171,23 +167,18 @@ def get_agent_from_configs(
 ) -> SoliplexAgent:
     """Get or create an agent from the specified agent and tool configs."""
 
-    if agent_config.id not in _agent_cache:
-        if agent_config.kind == "default":
-            agent = get_default_agent_from_configs(
-                agent_config=agent_config,
-                tool_configs=tool_configs,
-                mcp_client_toolset_configs=mcp_client_toolset_configs,
-                skill_toolset_config=skill_toolset_config,
-            )
+    if agent_config.kind == "default":
+        return get_default_agent_from_configs(
+            agent_config=agent_config,
+            tool_configs=tool_configs,
+            mcp_client_toolset_configs=mcp_client_toolset_configs,
+            skill_toolset_config=skill_toolset_config,
+        )
 
-        else:
-            # Treat 'agent_config' as an 'AgentFactory'
-            agent = agent_config.factory(
-                tool_configs=tool_configs,
-                mcp_client_toolset_configs=mcp_client_toolset_configs,
-                skill_toolset_config=skill_toolset_config,
-            )
-
-        _agent_cache[agent_config.id] = agent
-
-    return _agent_cache[agent_config.id]
+    else:
+        # Treat 'agent_config' as an 'AgentFactory'
+        return agent_config.factory(
+            tool_configs=tool_configs,
+            mcp_client_toolset_configs=mcp_client_toolset_configs,
+            skill_toolset_config=skill_toolset_config,
+        )

--- a/tests/functional/test_gemini_integration.py
+++ b/tests/functional/test_gemini_integration.py
@@ -79,7 +79,10 @@ async def close_cached_httpx_client(anyio_backend, monkeypatch):
     yield
 
     for client in created_clients:
-        await client.aclose()
+        try:
+            await client.aclose()
+        except RuntimeError:
+            pass
 
     original_cached_func.cache_clear()
 
@@ -98,31 +101,6 @@ async def reset_gemini_client():
     See: https://github.com/pydantic/pydantic-ai/issues/748
     """
     yield
-
-    # Close any google-genai httpx clients in cached agents
-    # Note: When using sync TestClient, the httpx client may be bound to a
-    # different event loop that's already closed. We catch RuntimeError to
-    # handle this gracefully.
-    for agent in agents._agent_cache.values():
-        model = getattr(agent, "_model", None)
-        if model is None:
-            continue
-        client = getattr(model, "client", None)
-        if client is None:
-            continue
-        api_client = getattr(client, "_api_client", None)
-        if api_client is None:
-            continue
-        httpx_client = getattr(api_client, "_async_httpx_client", None)
-        if httpx_client and not httpx_client.is_closed:
-            try:
-                await httpx_client.aclose()
-            except RuntimeError:
-                # Event loop may already be closed (e.g., sync TestClient)
-                pass
-
-    # Clear the agent cache so fresh agents are created per test
-    agents._agent_cache.clear()
 
 
 @pytest.fixture

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -322,7 +322,7 @@ def test_get_default_agent_from_configs(
 
 @pytest.mark.parametrize("w_room_skills", [False, True])
 @mock.patch("soliplex.agents.get_default_agent_from_configs")
-def test_get_agent_from_configs_wo_hit_w_default_kind(
+def test_get_agent_from_configs_w_default_kind(
     gdafc,
     tool_configs_tools,
     mcp_ct_configs_tools,
@@ -347,17 +347,12 @@ def test_get_agent_from_configs_wo_hit_w_default_kind(
     else:
         kwargs["skill_toolset_config"] = None
 
-    with (
-        mock.patch.dict("soliplex.agents._agent_cache", clear=True) as cache,
-    ):
-        found = agents.get_agent_from_configs(
-            agent_config=agent_config,
-            tool_configs=tool_configs,
-            mcp_client_toolset_configs=mcp_tc_configs,
-            **kwargs,
-        )
-
-        assert cache[ROOM_ID] is found
+    found = agents.get_agent_from_configs(
+        agent_config=agent_config,
+        tool_configs=tool_configs,
+        mcp_client_toolset_configs=mcp_tc_configs,
+        **kwargs,
+    )
 
     assert found is gdafc.return_value
 
@@ -370,7 +365,7 @@ def test_get_agent_from_configs_wo_hit_w_default_kind(
 
 
 @pytest.mark.parametrize("w_room_skills", [False, True])
-def test_get_agent_from_configs_wo_hit_w_python_kind(w_room_skills):
+def test_get_agent_from_configs_w_python_kind(w_room_skills):
     agent_config = mock.create_autospec(config_agents.FactoryAgentConfig)
     agent_config.kind = "factory"
     agent_config.id = ROOM_ID
@@ -389,17 +384,12 @@ def test_get_agent_from_configs_wo_hit_w_python_kind(w_room_skills):
     else:
         kwargs["skill_toolset_config"] = None
 
-    with (
-        mock.patch.dict("soliplex.agents._agent_cache", clear=True) as cache,
-    ):
-        found = agents.get_agent_from_configs(
-            agent_config=agent_config,
-            tool_configs=tool_configs,
-            mcp_client_toolset_configs=mcpcts_configs,
-            **kwargs,
-        )
-
-        assert cache[ROOM_ID] is found
+    found = agents.get_agent_from_configs(
+        agent_config=agent_config,
+        tool_configs=tool_configs,
+        mcp_client_toolset_configs=mcpcts_configs,
+        **kwargs,
+    )
 
     assert found is agent_config.factory.return_value
 
@@ -408,20 +398,3 @@ def test_get_agent_from_configs_wo_hit_w_python_kind(w_room_skills):
         mcp_client_toolset_configs=mcpcts_configs,
         **kwargs,
     )
-
-
-def test_get_agent_from_configs_w_hit():
-    expected = object()
-    a_config = mock.create_autospec(config_agents.AgentConfig)
-    a_config.id = ROOM_ID
-
-    with mock.patch.dict("soliplex.agents._agent_cache", clear=True) as ac:
-        ac[ROOM_ID] = expected
-
-        found = agents.get_agent_from_configs(
-            agent_config=a_config,
-            tool_configs={},
-            mcp_client_toolset_configs={},
-        )
-
-    assert found is expected


### PR DESCRIPTION
The expense of creating an agent instance is insignificant, and we have some potential usecases which make the cache problematic.