### PR TITLE
feat: 'RoomSkillsConfig.skill_preambles'

### DIFF
--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -28,11 +28,14 @@ ToolConfigMap = dict[str, typing.Any]
 
 
 class SkillToolsetConfig(typing.Protocol):
-    # contract for config.RoomSkillsConfig etc.
-    @abc.abstractproperty
+    """Contract for config.RoomSkillsConfig etc."""
+
+    @property
+    @abc.abstractmethod
     def skill_preambles(self) -> list[str]: ...
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def skill_toolset(self) -> hs_agent.SkillToolset: ...
 
 

--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -30,6 +30,9 @@ ToolConfigMap = dict[str, typing.Any]
 class SkillToolsetConfig(typing.Protocol):
     # contract for config.RoomSkillsConfig etc.
     @abc.abstractproperty
+    def skill_preambles(self) -> list[str]: ...
+
+    @abc.abstractproperty
     def skill_toolset(self) -> hs_agent.SkillToolset: ...
 
 
@@ -137,15 +140,20 @@ def get_default_agent_from_configs(
         for mctc in mcp_client_toolset_configs.values()
     ]
 
+    agent_prompt = agent_config.get_system_prompt()
+
     if skill_toolset_config is not None:
         toolset = skill_toolset_config.skill_toolset
         toolsets.append(toolset)
+        preamble = "\n\n".join(
+            [agent_prompt] + skill_toolset_config.skill_preambles
+        )
         instructions = hs_prompts.build_system_prompt(
-            preamble=agent_config.get_system_prompt(),
+            preamble=preamble,
             skill_catalog=toolset.skill_catalog,
         )
     else:
-        instructions = agent_config.get_system_prompt()
+        instructions = agent_prompt
 
     return pydantic_ai.Agent(
         model=model,

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -511,6 +511,23 @@ class RoomSkillsConfig(_SkillConfigModelBase):
         }
 
     @property
+    def skill_preambles(self) -> list[str]:
+        preambles = []
+
+        rag_skill_configs = [
+            skill_config
+            for skill_config in self.skill_configs.values()
+            if isinstance(skill_config, config_rag._RAGConfigBase)
+        ]
+
+        for rag_skill_config in rag_skill_configs:
+            skill_hr_config = rag_skill_config.haiku_rag_config
+            prompt = skill_hr_config.prompts.domain_preamble
+            preambles.append(prompt)
+
+        return [preamble for preamble in preambles if preamble]
+
+    @property
     def skill_toolset(self) -> hs_agent.SkillToolset:
         skill_map = self.skills
         return hs_agent.SkillToolset(

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -33,6 +33,7 @@ SKILL_METADATA = {
     "author": SKILL_AUTHOR,
     "version": SKILL_VERSION,
 }
+DOMAIN_PREAMBLE = "test domain preamble"
 
 BARE_SKILL_MD_KW = {
     "name": SKILL_NAME,
@@ -623,6 +624,18 @@ def haiku_rag_config():
 
 
 @pytest.fixture
+def lancedb(temp_dir):
+    result = temp_dir / "rag.lancedb"
+    result.mkdir()
+    return result
+
+
+@pytest.fixture
+def config_path(temp_dir):
+    return temp_dir / "config_file.yaml"
+
+
+@pytest.fixture
 def derived_hrskillconfig():
     skill_module = mock.Mock(
         spec_set=[
@@ -686,13 +699,11 @@ def test_hrskillconfigbbase_skill(derived_hrskillconfig):
 
 
 def test_hr_rag_skillconfig_metadata(
-    temp_dir,
     installation_config,
     haiku_rag_config,
+    lancedb,
+    config_path,
 ):
-    config_path = temp_dir / "config_file.yaml"
-    lancedb = temp_dir / "rag.lancedb"
-    lancedb.mkdir()
 
     inst = config_skills.HR_RAG_SkillConfig(
         rag_lancedb_override_path=lancedb,
@@ -707,14 +718,11 @@ def test_hr_rag_skillconfig_metadata(
 
 
 def test_hr_rag_skillconfig_skill(
-    temp_dir,
     installation_config,
     haiku_rag_config,
+    lancedb,
+    config_path,
 ):
-    config_path = temp_dir / "config_file.yaml"
-    lancedb = temp_dir / "rag.lancedb"
-    lancedb.mkdir()
-
     inst = config_skills.HR_RAG_SkillConfig(
         rag_lancedb_override_path=lancedb,
         _haiku_rag_config=haiku_rag_config,
@@ -751,15 +759,12 @@ def test_hr_rag_skillconfig_skill(
     ],
 )
 def test_hr_rag_skillconfig_from_yaml(
-    temp_dir,
+    lancedb,
+    config_path,
     installation_config,
     w_config,
     expectation,
 ):
-    config_path = temp_dir / "config_file.yaml"
-    lancedb = temp_dir / "rag.lancedb"
-    lancedb.mkdir()
-
     config_dict = {
         "rag_lancedb_override_path": lancedb,
     } | w_config
@@ -785,14 +790,11 @@ def test_hr_rag_skillconfig_from_yaml(
 
 
 def test_hr_rlm_skillconfig_metadata(
-    temp_dir,
     installation_config,
     haiku_rag_config,
+    lancedb,
+    config_path,
 ):
-    config_path = temp_dir / "config_file.yaml"
-    lancedb = temp_dir / "rag.lancedb"
-    lancedb.mkdir()
-
     inst = config_skills.HR_RLM_SkillConfig(
         rag_lancedb_override_path=lancedb,
         _haiku_rag_config=haiku_rag_config,
@@ -806,14 +808,11 @@ def test_hr_rlm_skillconfig_metadata(
 
 
 def test_hr_rlm_skillconfig_skill(
-    temp_dir,
     installation_config,
     haiku_rag_config,
+    lancedb,
+    config_path,
 ):
-    config_path = temp_dir / "config_file.yaml"
-    lancedb = temp_dir / "rag.lancedb"
-    lancedb.mkdir()
-
     inst = config_skills.HR_RLM_SkillConfig(
         rag_lancedb_override_path=lancedb,
         _haiku_rag_config=haiku_rag_config,
@@ -839,15 +838,12 @@ def test_hr_rlm_skillconfig_skill(
     ],
 )
 def test_hr_rlm_skillconfig_from_yaml(
-    temp_dir,
+    lancedb,
+    config_path,
     installation_config,
     w_config,
     expectation,
 ):
-    config_path = temp_dir / "config_file.yaml"
-    lancedb = temp_dir / "rag.lancedb"
-    lancedb.mkdir()
-
     config_dict = {
         "rag_lancedb_override_path": lancedb,
     } | w_config
@@ -961,33 +957,32 @@ def test_extractskillconfigs(
 )
 def test_roomskillsconfig_from_yaml(
     installation_config,
-    temp_dir,
+    config_path,
     config_yaml,
     expectation,
 ):
     installation_config.skill_configs = {SKILL_NAME: object()}
-    yaml_file = temp_dir / "test.yaml"
-    yaml_file.write_text(config_yaml)
+    config_path.write_text(config_yaml)
 
-    with yaml_file.open() as stream:
+    with config_path.open() as stream:
         config_dict = yaml.safe_load(stream)
 
     with expectation as expected:
         found = config_skills.RoomSkillsConfig.from_yaml(
             installation_config,
-            yaml_file,
+            config_path,
             config_dict,
         )
 
     if isinstance(expected, pytest.ExceptionInfo):
-        assert expected.value._config_path == yaml_file
+        assert expected.value._config_path == config_path
 
     else:
         expected = config_skills.RoomSkillsConfig(**expected)
         expected = dataclasses.replace(
             expected,
             _installation_config=installation_config,
-            _config_path=yaml_file,
+            _config_path=config_path,
         )
 
         assert found == expected
@@ -1032,6 +1027,35 @@ def test_roomskillsconfig_skills(installation_config):
     found = room_skill_config.skills
 
     assert found == {SKILL_NAME: skill_config.skill}
+
+
+def test_roomskillsconfig_skill_preambles(
+    installation_config,
+    haiku_rag_config,
+    lancedb,
+    config_path,
+):
+    haiku_rag_config.prompts.domain_preamble = DOMAIN_PREAMBLE
+    skill_config = config_skills.HR_RAG_SkillConfig(
+        rag_lancedb_override_path=lancedb,
+        _haiku_rag_config=haiku_rag_config,
+        _config_path=config_path,
+        _installation_config=installation_config,
+    )
+    installation_config.skill_configs = {
+        SKILL_NAME: skill_config,
+        "other_skill": object(),
+    }
+
+    room_skill_config_kw = {"installation_skill_names": [SKILL_NAME]}
+    room_skill_config = config_skills.RoomSkillsConfig(
+        **room_skill_config_kw,
+        _installation_config=installation_config,
+    )
+
+    found = room_skill_config.skill_preambles
+
+    assert found == [DOMAIN_PREAMBLE]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -32,6 +32,7 @@ MODEL_SETTINGS = {
 
 ROOM_ID = "test-room"
 RAG_LANCEDB_OVERRIDE_PATH = "/path/to/db/rag"
+DOMAIN_PREAMBLE = "test domain preamble"
 
 TOOL_ID = "test-tool-id"
 AI_TOOL_PARAM_NAME = "test-ai-tool-param-name"
@@ -228,7 +229,14 @@ def test_get_model_from_config(
 
 
 @pytest.mark.parametrize("w_capabilities", [False, True])
-@pytest.mark.parametrize("w_room_skills", [False, True])
+@pytest.mark.parametrize(
+    "w_room_skills, preambles",
+    [
+        (False, None),
+        (True, []),
+        (True, [DOMAIN_PREAMBLE]),
+    ],
+)
 @pytest.mark.parametrize("w_model_settings", [None, MODEL_SETTINGS])
 @mock.patch("soliplex.agents.get_model_from_config")
 @mock.patch("haiku.skills.prompts.build_system_prompt")
@@ -241,6 +249,7 @@ def test_get_default_agent_from_configs(
     mcp_ct_configs_tools,
     w_model_settings,
     w_room_skills,
+    preambles,
     w_capabilities,
 ):
     agent_config = mock.create_autospec(config_agents.AgentConfig)
@@ -263,15 +272,19 @@ def test_get_default_agent_from_configs(
     }
     exp_toolsets = [tool for (_, tool) in mcp_ct_configs_tools]
 
-    room_skills = mock.create_autospec(agents.SkillToolsetConfig)
     kwargs = {}
 
-    exp_instructions = SYSTEM_PROMPT
+    room_skills = mock.create_autospec(agents.SkillToolsetConfig)
+    room_skills.skill_preambles = preambles
 
     if w_room_skills:
         kwargs["skill_toolset_config"] = room_skills
         exp_toolsets.append(room_skills.skill_toolset)
         exp_instructions = build_system_prompt.return_value
+        if preambles:
+            exp_preamble = f"{SYSTEM_PROMPT}\n\n{DOMAIN_PREAMBLE}"
+        else:
+            exp_preamble = SYSTEM_PROMPT
     else:
         exp_instructions = SYSTEM_PROMPT
 
@@ -299,7 +312,7 @@ def test_get_default_agent_from_configs(
 
     if w_room_skills:
         build_system_prompt.assert_called_once_with(
-            preamble=SYSTEM_PROMPT,
+            preamble=exp_preamble,
             skill_catalog=room_skills.skill_toolset.skill_catalog,
         )
     else:
@@ -339,10 +352,10 @@ def test_get_agent_from_configs_w_default_kind(
         for mctc_id, (mctc, _) in enumerate(mcp_ct_configs_tools)
     }
 
-    room_skills = mock.create_autospec(agents.SkillToolsetConfig)
     kwargs = {}
 
     if w_room_skills:
+        room_skills = mock.create_autospec(agents.SkillToolsetConfig)
         kwargs["skill_toolset_config"] = room_skills
     else:
         kwargs["skill_toolset_config"] = None


### PR DESCRIPTION
  Returns 'prompts.domain' from HR config for skills which suppor it.

feat: 'agents.get_default_agent_from_configs' includes skill preambles

  ... in agent instructions.

Closes #838.