### PR TITLE
fix: stable sort for 'agui.schema.Run.events'

### DIFF
--- a/src/soliplex/agui/schema.py
+++ b/src/soliplex/agui/schema.py
@@ -216,7 +216,7 @@ class Run(Base):
 
     events: Mapped[list[RunEvent]] = relationship(
         back_populates="run",
-        order_by="RunEvent.created",
+        order_by="RunEvent.created, RunEvent.id_",
         cascade="all, delete",
         passive_deletes=True,
     )


### PR DESCRIPTION
Include 'id_' as a secondary key, because timestamp resolution may not be fine enough with some engines.

Closes #871.