### PR TITLE
chore: bump 'pydantic-ai-slim >= 1.79, < 1.80' (redux)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jsonpatch",
     "jwcrypto",
     "logfire[fastapi]",
-    "pydantic-ai-slim[google] >= 1.78.0, < 1.79",  # AG-UI 1.0.15 breakage
+    "pydantic-ai-slim[google] >= 1.79, < 1.80",
     "pyjwt",
     "python-keycloak",
     "sqlmodel",

--- a/tests/unit/test_titles.py
+++ b/tests/unit/test_titles.py
@@ -71,9 +71,11 @@ class TestFormatMessage:
             id="1",
             content=[
                 agui_core.TextInputContent(text="Part one"),
-                agui_core.BinaryInputContent(
-                    mime_type="image/png",
-                    data="abc",
+                agui_core.ImageInputContent(
+                    source=agui_core.InputContentDataSource(
+                        mime_type="image/png",
+                        value="abc",
+                    ),
                 ),
                 agui_core.TextInputContent(text="Part two"),
             ],
@@ -84,9 +86,11 @@ class TestFormatMessage:
         msg = agui_core.UserMessage(
             id="1",
             content=[
-                agui_core.BinaryInputContent(
-                    mime_type="image/png",
-                    data="abc",
+                agui_core.ImageInputContent(
+                    source=agui_core.InputContentDataSource(
+                        mime_type="image/png",
+                        value="abc",
+                    ),
                 ),
             ],
         )

--- a/uv.lock
+++ b/uv.lock
@@ -2681,7 +2681,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.78.0"
+version = "1.79.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -2692,9 +2692,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/84/4cf98c41a2019a5c5ed6aa5d5fa2bbc8b70b152b527c56d27dabbeaeb75c/pydantic_ai_slim-1.78.0.tar.gz", hash = "sha256:97c6467a6bb09f61fd48cd828db066204ae77419d14a4edf47f90f72d06ab11f", size = 531385, upload-time = "2026-04-08T05:20:36.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/c3/8f20558616b2b9aa26792e08727ac53baca2e80f87de0587da803a4784ac/pydantic_ai_slim-1.79.0.tar.gz", hash = "sha256:463c552e926e953f78fe8ff5f82545e98816f92c6620bfd8dc8675b35190b827", size = 540871, upload-time = "2026-04-10T01:22:29.242Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/91/487992a441c03f16525885ee541083f66f579500edd7aa8b838f3296455f/pydantic_ai_slim-1.78.0-py3-none-any.whl", hash = "sha256:36f88bab6016186b958363ca1254741999df276322d7066dd69793dcb2134b66", size = 680002, upload-time = "2026-04-08T05:20:27.508Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/8f/999efe177af0d6b244a478401790c7f8ea0b9e86ac9ad39e0e19c838a4fb/pydantic_ai_slim-1.79.0-py3-none-any.whl", hash = "sha256:2a79d47a3b74d82da83ae3a05db2d7c78c6a49d7ad8afedce1e2746a93d766b2", size = 693734, upload-time = "2026-04-10T01:22:21.33Z" },
 ]
 
 [package.optional-dependencies]
@@ -2792,7 +2792,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.78.0"
+version = "1.79.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2800,9 +2800,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/e4/eb52021f43f2ac495955af19219c1ab261d707bbd15f4dc229079c2276d4/pydantic_graph-1.78.0.tar.gz", hash = "sha256:dd627e37cb3adaf8c95cca6a4b33e0d1b7fc9bed075dc3b8ad5df2c2a3cb432b", size = 58682, upload-time = "2026-04-08T05:20:39.288Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/0c/13f0cd7f2dde132b7d8ea3f343f48f23913581139eafab1194744d9b7682/pydantic_graph-1.79.0.tar.gz", hash = "sha256:9b71916961b3ef5bcd1834560eda2928370d487785a15a3764298ffd26618e2e", size = 59239, upload-time = "2026-04-10T01:22:32.074Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/97/e3dd1a1c6f6b9c104c844c1a2383361a831d1b027c99c0ac1a20544f0b13/pydantic_graph-1.78.0-py3-none-any.whl", hash = "sha256:0302835f46da3ee70ba3602a4d886c41a76fa8750f23f4257b968163ba4bb89f", size = 72500, upload-time = "2026-04-08T05:20:31.237Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/17/7fa99ecd68c53082499226b69b59aab86fb3b30f489a08af6d1fe4c648bf/pydantic_graph-1.79.0-py3-none-any.whl", hash = "sha256:7818c4995b08ee72a998a9513b9601bab7fee7684f3368ebe56db418881f5efd", size = 73064, upload-time = "2026-04-10T01:22:24.228Z" },
 ]
 
 [[package]]
@@ -3513,7 +3513,7 @@ requires-dist = [
     { name = "jsonpatch" },
     { name = "jwcrypto" },
     { name = "logfire", extras = ["fastapi"] },
-    { name = "pydantic-ai-slim", extras = ["google"], specifier = ">=1.78.0,<1.79" },
+    { name = "pydantic-ai-slim", extras = ["google"], specifier = ">=1.79,<1.80" },
     { name = "pyjwt" },
     { name = "python-keycloak" },
     { name = "sqlmodel" },


### PR DESCRIPTION
tests: use 'ImageInputContent' in titles test

... rather than the now-dhprecated 'BinaryInputContent'.

Supersedes #867.