### PR TITLE
feat: GET enpoints for room / thread uploads

### DIFF
--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -21,6 +21,10 @@ AGUI_POST_RECENT_USER_FEEDBACK = "post recent room user feedback"
 AGUI_POST_REVIEW_RECENT_FEEDBACK = "post review recent agui feedback"
 AGUI_POST_RESOLVE_RECENT_FEEDBACK = "post resolve recent agui feedback"
 
+UPLOADS_GET_ROOM = "uploads get room"
+UPLOADS_GET_ROOM_FILE = "uploads get room file"
+UPLOADS_GET_ROOM_THREAD = "uploads get room thread"
+UPLOADS_GET_ROOM_THREAD_FILE = "uploads get room thread file"
 UPLOADS_POST_ROOM = "uploads post room"
 UPLOADS_POST_ROOM_THREAD = "uploads post room thread"
 

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -558,9 +558,25 @@ class RAGDocument(pydantic.BaseModel):
 RAGDocumentSet = dict[str, RAGDocument]
 
 
-class RoomDocuments(pydantic.BaseModel):
+class RoomRAGDocuments(pydantic.BaseModel):
     room_id: str
     document_set: RAGDocumentSet
+
+
+class FileUpload(pydantic.BaseModel):
+    filename: str
+    url: pydantic.HttpUrl
+
+
+class RoomUploads(pydantic.BaseModel):
+    room_id: str
+    uploads: list[FileUpload]
+
+
+class ThreadUploads(pydantic.BaseModel):
+    room_id: str
+    thread_id: str
+    uploads: list[FileUpload]
 
 
 # ----------------------------------------------------------------------------

--- a/src/soliplex/views/file_uploads.py
+++ b/src/soliplex/views/file_uploads.py
@@ -2,12 +2,14 @@ import pathlib
 
 import fastapi
 import pydantic
+from fastapi import responses
 
 from soliplex import agui as agui_package
 from soliplex import authn as authn_package
 from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import loggers
+from soliplex import models
 from soliplex import views as views_package
 from soliplex.views import agui as soliplex_views_agui
 from soliplex.views import authz as soliplex_views_authz
@@ -21,6 +23,115 @@ depend_the_authz = authz_package.depend_the_authz_policy
 depend_the_user_claims = views_package.depend_the_user_claims
 depend_the_logger = views_package.depend_the_logger
 depend_the_authz_logger = soliplex_views_authz.depend_the_authz_logger
+
+
+@soliplex_views_util.logfire_span(
+    "GET /v1/uploads/{room_id}",
+)
+@router.get("/v1/uploads/{room_id}")
+async def get_uploads_room(
+    request: fastapi.Request,
+    room_id: str,
+    the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
+    the_user_claims: authn_package.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> models.RoomUploads:
+    """Return a list of files uploaded to the room"""
+    the_logger.debug(loggers.UPLOADS_GET_ROOM)
+
+    _room_config = await soliplex_views_agui._check_user_in_room(
+        room_id=room_id,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=the_user_claims,
+        the_logger=the_logger,
+    )
+
+    uploads_path = the_installation.rooms_upload_path
+
+    if uploads_path is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="Room uploads not configured",
+        )
+
+    room_dir = pathlib.Path(uploads_path) / room_id
+    filename_urls = {}
+
+    if room_dir.is_dir():
+        for file_or_sub in room_dir.glob("*"):
+            if file_or_sub.is_file():
+                filename = file_or_sub.name
+                filename_urls[filename] = request.url_for(
+                    "/v1/uploads/{room_id}/{filename}",
+                    room_id=room_id,
+                    filename=filename,
+                )
+
+    return models.RoomUploads(
+        room_id=room_id,
+        uploads=[
+            models.FileUpload(
+                filename=key,
+                url=value,
+            )
+            for key, value in filename_urls.items()
+        ],
+    )
+
+
+@soliplex_views_util.logfire_span(
+    "GET /v1/uploads/{room_id}/{filename}",
+)
+@router.get(
+    "/v1/uploads/{room_id}/{filename}",
+    response_class=responses.FileResponse,
+)
+async def get_uploads_room_filename(
+    room_id: str,
+    filename: str,
+    the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
+    the_user_claims: authn_package.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> str:  # file path, converted to file response by FastAPI
+    """Download a file from the room uploads directory"""
+    the_logger.debug(loggers.UPLOADS_GET_ROOM_FILE)
+
+    _room_config = await soliplex_views_agui._check_user_in_room(
+        room_id=room_id,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=the_user_claims,
+        the_logger=the_logger,
+    )
+
+    uploads_path = the_installation.rooms_upload_path
+
+    if uploads_path is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="Room uploads not configured",
+        )
+
+    room_dir = pathlib.Path(uploads_path) / room_id
+
+    if not room_dir.is_dir():
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="No uploads in room: {room_id}",
+        )
+
+    file_path = room_dir / filename
+
+    if not file_path.is_file():
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f"No room upload: {filename}",
+        )
+
+    return str(file_path)
 
 
 @soliplex_views_util.logfire_span(
@@ -78,6 +189,123 @@ async def post_uploads_room(
 
 
 @soliplex_views_util.logfire_span(
+    "GET /v1/uploads/{room_id}/{thread_id}",
+)
+@router.get("/v1/uploads/{room_id}/{thread_id}")
+async def get_uploads_room_thread(
+    request: fastapi.Request,
+    room_id: str,
+    thread_id: pydantic.UUID4,
+    the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
+    the_user_claims: authn_package.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> models.RoomUploads:
+    """Return a list of files uploaded to the thread"""
+    thread_id = str(thread_id)
+
+    the_logger.debug(loggers.UPLOADS_GET_ROOM_THREAD)
+
+    _room_config = await soliplex_views_agui._check_user_in_room(
+        room_id=room_id,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=the_user_claims,
+        the_logger=the_logger,
+    )
+
+    uploads_path = the_installation.threads_upload_path
+
+    if uploads_path is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="Thread uploads not configured",
+        )
+
+    thread_dir = pathlib.Path(uploads_path) / thread_id
+    filename_urls = {}
+
+    if thread_dir.is_dir():
+        for file_or_sub in thread_dir.glob("*"):
+            if file_or_sub.is_file():
+                filename = file_or_sub.name
+                filename_urls[filename] = request.url_for(
+                    "/v1/uploads/{room_id}/{thread_id}/{filename}",
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    filename=filename,
+                )
+
+    return models.ThreadUploads(
+        room_id=room_id,
+        thread_id=thread_id,
+        uploads=[
+            models.FileUpload(
+                filename=key,
+                url=value,
+            )
+            for key, value in filename_urls.items()
+        ],
+    )
+
+
+@soliplex_views_util.logfire_span(
+    "GET /v1/uploads/{room_id}/{thread_id}/{filename}",
+)
+@router.get(
+    "/v1/uploads/{room_id}/{thread_id}/{filename}",
+    response_class=responses.FileResponse,
+)
+async def get_uploads_room_thread_filename(
+    room_id: str,
+    thread_id: pydantic.UUID4,
+    filename: str,
+    the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
+    the_user_claims: authn_package.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> str:  # file path, converted to file response by FastAPI
+    """Download a file from the room uploads directory"""
+    thread_id = str(thread_id)
+
+    the_logger.debug(loggers.UPLOADS_GET_ROOM_THREAD_FILE)
+
+    _room_config = await soliplex_views_agui._check_user_in_room(
+        room_id=room_id,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=the_user_claims,
+        the_logger=the_logger,
+    )
+
+    uploads_path = the_installation.threads_upload_path
+
+    if uploads_path is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="Thread uploads not configured",
+        )
+
+    thread_dir = pathlib.Path(uploads_path) / thread_id
+
+    if not thread_dir.is_dir():
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="No uploads in thread: {thread_id}",
+        )
+
+    file_path = thread_dir / filename
+
+    if not file_path.is_file():
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f"No thread upload: {filename}",
+        )
+
+    return str(file_path)
+
+
+@soliplex_views_util.logfire_span(
     "POST /v1/uploads/{room_id}/{thread_id}/",
 )
 @router.post("/v1/uploads/{room_id}/{thread_id}", status_code=204)
@@ -97,6 +325,7 @@ async def post_uploads_room_thread(
     of the request.
     """
     thread_id = str(thread_id)
+
     the_logger.debug(loggers.UPLOADS_POST_ROOM_THREAD)
 
     user_name = the_user_claims.get("preferred_username", "<unknown>")

--- a/src/soliplex/views/rooms.py
+++ b/src/soliplex/views/rooms.py
@@ -183,7 +183,7 @@ async def get_room_documents(
     the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
     the_user_claims: authn.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
-) -> models.RoomDocuments:
+) -> models.RoomRAGDocuments:
     """Return a list of the documents in the room's RAG database"""
     the_logger.debug(loggers.ROOM_GET_ROOM_DOCUMENTS)
 
@@ -220,7 +220,7 @@ async def get_room_documents(
                 updated_at=document.updated_at,
             )
 
-    return models.RoomDocuments(
+    return models.RoomRAGDocuments(
         room_id=room_id,
         document_set=document_set,
     )

--- a/tests/unit/views/test_file_uploads.py
+++ b/tests/unit/views/test_file_uploads.py
@@ -10,6 +10,7 @@ from soliplex import agui as agui_package
 from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import loggers
+from soliplex import models
 from soliplex.config import rooms as config_rooms
 from soliplex.views import file_uploads as file_uploads_views
 
@@ -25,6 +26,7 @@ TEST_THREAD_ID = uuid.uuid4()
 TEST_FILENAME = "test_file.txt"
 TEST_CONTENT = b"DEADBEEF"
 
+URL_PREFIX = "http://test.example.com/api"
 
 no_error = contextlib.nullcontext
 
@@ -50,6 +52,184 @@ def uploads_path(temp_dir):
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
+    "w_filenames",
+    [
+        [],
+        ["foo.txt"],
+        [f"file_{i_file:03}.txt" for i_file in range(10)],
+    ],
+)
+@pytest.mark.parametrize(
+    "w_upload_path, w_room_path, expectation",
+    [
+        (True, True, no_error(None)),
+        (True, False, no_error(None)),
+        (
+            False,
+            None,
+            raises_httpexc(code=404, match="Room uploads not configured"),
+        ),
+    ],
+)
+@mock.patch("soliplex.views.agui._check_user_in_room")
+async def test_get_uploads_room_only(
+    cuir,
+    uploads_path,
+    w_upload_path,
+    w_room_path,
+    expectation,
+    w_filenames,
+):
+    room_uploads_path = uploads_path / "rooms"
+    room_path = room_uploads_path / TEST_ROOM_ID
+    ROUTE_NAME = "/v1/uploads/{room_id}/{filename}"
+
+    def download_url(name, room_id, filename):
+        assert name == ROUTE_NAME
+        return f"{URL_PREFIX}/v1/uploads/{room_id}/{filename}"
+
+    exp_filename_urls = {}
+
+    if w_room_path:
+        room_path.mkdir(parents=True)
+        (room_path / "ignore_me").mkdir()
+        for filename in w_filenames:
+            file_path = room_path / filename
+            file_path.write_text(f"filename: {filename}")
+            exp_filename_urls[filename] = download_url(
+                ROUTE_NAME, TEST_ROOM_ID, filename
+            )
+
+    request = mock.create_autospec(fastapi.Request)
+    request.url_for.side_effect = download_url
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    cuir.return_value = room_config
+
+    the_installation = mock.create_autospec(
+        installation.Installation,
+    )
+
+    if w_upload_path:
+        the_installation.rooms_upload_path = str(room_uploads_path)
+    else:
+        the_installation.rooms_upload_path = None
+
+    the_authz_policy = mock.create_autospec(
+        authz_package.AuthorizationPolicy,
+    )
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    with expectation as expected:
+        found = await file_uploads_views.get_uploads_room(
+            request=request,
+            room_id=TEST_ROOM_ID,
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_user_claims=THE_USER_CLAIMS,
+            the_logger=the_logger,
+        )
+
+    if expected is None:
+        assert isinstance(found, models.RoomUploads)
+        assert found.room_id == TEST_ROOM_ID
+
+        if w_room_path:
+            found_files = {f_up.filename: f_up.url for f_up in found.uploads}
+            assert set(found_files) == set(w_filenames)
+
+            for filename in w_filenames:
+                exp_url = exp_filename_urls[filename]
+                assert str(found_files[filename]) == exp_url
+        else:
+            assert found.uploads == []
+
+    the_logger.debug.assert_called_once_with(
+        loggers.UPLOADS_GET_ROOM,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "w_upload_path, w_room_path, w_filename, expectation",
+    [
+        (True, True, True, no_error(None)),
+        (
+            True,
+            True,
+            False,
+            raises_httpexc(code=404, match=".*"),
+        ),
+        (
+            True,
+            False,
+            None,
+            raises_httpexc(code=404, match=".*"),
+        ),
+        (
+            False,
+            None,
+            None,
+            raises_httpexc(code=404, match="Room uploads not configured"),
+        ),
+    ],
+)
+@mock.patch("soliplex.views.agui._check_user_in_room")
+async def test_get_uploads_room_filename(
+    cuir,
+    uploads_path,
+    w_upload_path,
+    w_room_path,
+    w_filename,
+    expectation,
+):
+    room_uploads_path = uploads_path / "rooms"
+    room_path = room_uploads_path / TEST_ROOM_ID
+
+    if w_room_path:
+        room_path.mkdir(parents=True)
+
+        if w_filename:
+            file_path = room_path / TEST_FILENAME
+            file_path.write_text(f"filename: {TEST_FILENAME}")
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    cuir.return_value = room_config
+
+    the_installation = mock.create_autospec(
+        installation.Installation,
+    )
+
+    if w_upload_path:
+        the_installation.rooms_upload_path = str(room_uploads_path)
+    else:
+        the_installation.rooms_upload_path = None
+
+    the_authz_policy = mock.create_autospec(
+        authz_package.AuthorizationPolicy,
+    )
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    with expectation as expected:
+        found = await file_uploads_views.get_uploads_room_filename(
+            room_id=TEST_ROOM_ID,
+            filename=TEST_FILENAME,
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_user_claims=THE_USER_CLAIMS,
+            the_logger=the_logger,
+        )
+
+    if expected is None:
+        assert found == str(file_path)
+
+    the_logger.debug.assert_called_once_with(
+        loggers.UPLOADS_GET_ROOM_FILE,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
     "w_filename, exp_filename",
     [
         (TEST_FILENAME, TEST_FILENAME),
@@ -67,8 +247,8 @@ def uploads_path(temp_dir):
 @mock.patch("soliplex.views.agui._check_user_in_room")
 async def test_post_uploads_room(
     cuir,
-    w_admin_access,
     uploads_path,
+    w_admin_access,
     w_upload_path,
     expectation,
     w_filename,
@@ -140,6 +320,187 @@ async def test_post_uploads_room(
 
     the_logger.debug.assert_called_once_with(
         loggers.UPLOADS_POST_ROOM,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "w_filenames",
+    [
+        [],
+        ["foo.txt"],
+        [f"file_{i_file:03}.txt" for i_file in range(10)],
+    ],
+)
+@pytest.mark.parametrize(
+    "w_upload_path, w_thread_path, expectation",
+    [
+        (True, True, no_error(None)),
+        (True, False, no_error(None)),
+        (
+            False,
+            None,
+            raises_httpexc(code=404, match="Thread uploads not configured"),
+        ),
+    ],
+)
+@mock.patch("soliplex.views.agui._check_user_in_room")
+async def test_get_uploads_room_thread_only(
+    cuir,
+    uploads_path,
+    w_upload_path,
+    w_thread_path,
+    expectation,
+    w_filenames,
+):
+    thread_uploads_path = uploads_path / "threads"
+    thread_path = thread_uploads_path / str(TEST_THREAD_ID)
+    ROUTE_NAME = "/v1/uploads/{room_id}/{thread_id}/{filename}"
+
+    def download_url(name, room_id, thread_id, filename):
+        assert name == ROUTE_NAME
+        return f"{URL_PREFIX}/v1/uploads/{room_id}/{thread_id}/{filename}"
+
+    exp_filename_urls = {}
+
+    if w_thread_path:
+        thread_path.mkdir(parents=True)
+        (thread_path / "ignore_me").mkdir()
+        for filename in w_filenames:
+            file_path = thread_path / filename
+            file_path.write_text(f"filename: {filename}")
+            exp_filename_urls[filename] = download_url(
+                ROUTE_NAME, TEST_ROOM_ID, str(TEST_THREAD_ID), filename
+            )
+
+    request = mock.create_autospec(fastapi.Request)
+    request.url_for.side_effect = download_url
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    cuir.return_value = room_config
+
+    the_installation = mock.create_autospec(
+        installation.Installation,
+    )
+
+    if w_upload_path:
+        the_installation.threads_upload_path = str(thread_uploads_path)
+    else:
+        the_installation.threads_upload_path = None
+
+    the_authz_policy = mock.create_autospec(
+        authz_package.AuthorizationPolicy,
+    )
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    with expectation as expected:
+        found = await file_uploads_views.get_uploads_room_thread(
+            request=request,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_user_claims=THE_USER_CLAIMS,
+            the_logger=the_logger,
+        )
+
+    if expected is None:
+        assert isinstance(found, models.ThreadUploads)
+        assert found.room_id == TEST_ROOM_ID
+        assert found.thread_id == str(TEST_THREAD_ID)
+
+        if w_thread_path:
+            found_files = {f_up.filename: f_up.url for f_up in found.uploads}
+            assert set(found_files) == set(w_filenames)
+
+            for filename in w_filenames:
+                exp_url = exp_filename_urls[filename]
+                assert str(found_files[filename]) == exp_url
+        else:
+            assert found.uploads == []
+
+    the_logger.debug.assert_called_once_with(
+        loggers.UPLOADS_GET_ROOM_THREAD,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "w_upload_path, w_thread_path, w_filename, expectation",
+    [
+        (True, True, True, no_error(None)),
+        (
+            True,
+            True,
+            False,
+            raises_httpexc(code=404, match=".*"),
+        ),
+        (
+            True,
+            False,
+            None,
+            raises_httpexc(code=404, match=".*"),
+        ),
+        (
+            False,
+            None,
+            None,
+            raises_httpexc(code=404, match="Thread uploads not configured"),
+        ),
+    ],
+)
+@mock.patch("soliplex.views.agui._check_user_in_room")
+async def test_get_uploads_room_thread_filename(
+    cuir,
+    uploads_path,
+    w_upload_path,
+    w_thread_path,
+    w_filename,
+    expectation,
+):
+    thread_uploads_path = uploads_path / "threads"
+    thread_path = thread_uploads_path / str(TEST_THREAD_ID)
+
+    if w_thread_path:
+        thread_path.mkdir(parents=True)
+
+        if w_filename:
+            file_path = thread_path / TEST_FILENAME
+            file_path.write_text(f"filename: {TEST_FILENAME}")
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    cuir.return_value = room_config
+
+    the_installation = mock.create_autospec(
+        installation.Installation,
+    )
+
+    if w_upload_path:
+        the_installation.threads_upload_path = str(thread_uploads_path)
+    else:
+        the_installation.threads_upload_path = None
+
+    the_authz_policy = mock.create_autospec(
+        authz_package.AuthorizationPolicy,
+    )
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    with expectation as expected:
+        found = await file_uploads_views.get_uploads_room_thread_filename(
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            filename=TEST_FILENAME,
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_user_claims=THE_USER_CLAIMS,
+            the_logger=the_logger,
+        )
+
+    if expected is None:
+        assert found == str(file_path)
+
+    the_logger.debug.assert_called_once_with(
+        loggers.UPLOADS_GET_ROOM_THREAD_FILE,
     )
 
 

--- a/tests/unit/views/test_rooms_views.py
+++ b/tests/unit/views/test_rooms_views.py
@@ -393,7 +393,7 @@ async def test_get_room_documents(
             the_logger=the_logger,
         )
 
-        assert found == models.RoomDocuments(
+        assert found == models.RoomRAGDocuments(
             room_id=ROOM_ID,
             document_set=exp_docs,
         )


### PR DESCRIPTION
- 'GET /api/v1/uploads/{room_id}'
- 'GET /api/v1/uploads/{room_id}/{filename}'
- 'GET /api/v1/uploads/{room_id}/{thread_id}'
- 'GET /api/v1/uploads/{room_id}/{thread_id}/{filename}'

refactor: 's/models.Room{,RAG}Documents'

To disambiguate from room uploads.

Closes #833.

Note that #878 remains open, until we get the spec for the `DELETE` endpoints nailed down.