### PR TITLE
Support MCP SSE transport

### DIFF
--- a/src/soliplex/config/tools.py
+++ b/src/soliplex/config/tools.py
@@ -429,10 +429,9 @@ class Stdio_MCP_ClientToolsetConfig:
 
 
 @dataclasses.dataclass(kw_only=True)
-class HTTP_MCP_ClientToolsetConfig:
-    """Configure an MCP client toolset which makes calls over streaming HTTP"""
+class _Remote_MCP_ClientToolsetConfig:
+    """Base config for remote MCP client toolsets (HTTP and SSE)"""
 
-    kind: typing.ClassVar[str] = "http"
     url: str
     headers: dict[str, typing.Any] = _utils._default_dict_field()
 
@@ -459,7 +458,9 @@ class HTTP_MCP_ClientToolsetConfig:
             return cls(**config_dict)
         except Exception as exc:
             raise config_exc.FromYamlException(
-                config_path, "http_mcptc", config_dict
+                config_path,
+                f"{cls.kind}_mcptc",
+                config_dict,
             ) from exc
 
     @property
@@ -495,9 +496,24 @@ class HTTP_MCP_ClientToolsetConfig:
         }
 
 
+@dataclasses.dataclass(kw_only=True)
+class HTTP_MCP_ClientToolsetConfig(_Remote_MCP_ClientToolsetConfig):
+    """Configure an MCP client toolset over streamable HTTP"""
+
+    kind: typing.ClassVar[str] = "http"
+
+
+@dataclasses.dataclass(kw_only=True)
+class SSE_MCP_ClientToolsetConfig(_Remote_MCP_ClientToolsetConfig):
+    """Configure an MCP client toolset over SSE"""
+
+    kind: typing.ClassVar[str] = "sse"
+
+
 MCP_TOOLSET_CONFIG_CLASSES_BY_KIND = {
     "stdio": Stdio_MCP_ClientToolsetConfig,
     "http": HTTP_MCP_ClientToolsetConfig,
+    "sse": SSE_MCP_ClientToolsetConfig,
 }
 
 
@@ -523,7 +539,9 @@ def extract_mcp_client_toolset_configs(
 
 
 MCP_ClientToolsetConfig = (
-    Stdio_MCP_ClientToolsetConfig | HTTP_MCP_ClientToolsetConfig
+    Stdio_MCP_ClientToolsetConfig
+    | HTTP_MCP_ClientToolsetConfig
+    | SSE_MCP_ClientToolsetConfig
 )
 
 MCP_ClientToolsetConfigMap = dict[str, MCP_ClientToolsetConfig]

--- a/src/soliplex/mcp_client.py
+++ b/src/soliplex/mcp_client.py
@@ -88,7 +88,44 @@ class HTTP_MCP_Client_Toolset(ai_mcp.MCPServerStreamableHTTP):
         return _filter_tools(offered_tools, self.allowed_tools)
 
 
+class SSE_MCP_Client_Toolset(ai_mcp.MCPServerSSE):
+    def __init__(
+        self,
+        url: str,
+        headers: dict[str, typing.Any],
+        allowed_tools: list[str] = None,
+    ):  # pragma: NO COVER
+        super().__init__(url=url, headers=headers)
+        self._allowed_tools = allowed_tools or ()
+
+    @property
+    def _params(self):
+        return {
+            "url": self.url,
+            "headers": self.headers,
+            "allowed_tools": self.allowed_tools,
+        }
+
+    @property
+    def allowed_tools(self) -> list[str] | None:  # pragma: NO COVER
+        return list(self._allowed_tools)
+
+    async def list_tools(self) -> list[mcp_types.Tool]:  # pragma: NO COVER
+        """Retrieve tools that are currently active on the server.
+
+        Filter the tools offered by the server using our list of allowed
+        tools.
+
+        Note:
+        - We don't cache tools as they might change.
+        - We also don't subscribe to the server to avoid complexity.
+        """
+        offered_tools = await super().list_tools()
+        return _filter_tools(offered_tools, self.allowed_tools)
+
+
 TOOLSET_CLASS_BY_KIND = {
     "stdio": Stdio_MCP_Client_Toolset,
     "http": HTTP_MCP_Client_Toolset,
+    "sse": SSE_MCP_Client_Toolset,
 }

--- a/src/soliplex/mcp_client.py
+++ b/src/soliplex/mcp_client.py
@@ -52,7 +52,9 @@ class Stdio_MCP_Client_Toolset(ai_mcp.MCPServerStdio):
         return _filter_tools(offered_tools, self.allowed_tools)
 
 
-class HTTP_MCP_Client_Toolset(ai_mcp.MCPServerStreamableHTTP):
+class _Remote_MCP_Client_Toolset:
+    """Mixin for URL-based MCP client toolsets (HTTP and SSE)."""
+
     def __init__(
         self,
         url: str,
@@ -88,40 +90,18 @@ class HTTP_MCP_Client_Toolset(ai_mcp.MCPServerStreamableHTTP):
         return _filter_tools(offered_tools, self.allowed_tools)
 
 
-class SSE_MCP_Client_Toolset(ai_mcp.MCPServerSSE):
-    def __init__(
-        self,
-        url: str,
-        headers: dict[str, typing.Any],
-        allowed_tools: list[str] = None,
-    ):  # pragma: NO COVER
-        super().__init__(url=url, headers=headers)
-        self._allowed_tools = allowed_tools or ()
+class HTTP_MCP_Client_Toolset(
+    _Remote_MCP_Client_Toolset,
+    ai_mcp.MCPServerStreamableHTTP,
+):
+    pass
 
-    @property
-    def _params(self):
-        return {
-            "url": self.url,
-            "headers": self.headers,
-            "allowed_tools": self.allowed_tools,
-        }
 
-    @property
-    def allowed_tools(self) -> list[str] | None:  # pragma: NO COVER
-        return list(self._allowed_tools)
-
-    async def list_tools(self) -> list[mcp_types.Tool]:  # pragma: NO COVER
-        """Retrieve tools that are currently active on the server.
-
-        Filter the tools offered by the server using our list of allowed
-        tools.
-
-        Note:
-        - We don't cache tools as they might change.
-        - We also don't subscribe to the server to avoid complexity.
-        """
-        offered_tools = await super().list_tools()
-        return _filter_tools(offered_tools, self.allowed_tools)
+class SSE_MCP_Client_Toolset(
+    _Remote_MCP_Client_Toolset,
+    ai_mcp.MCPServerSSE,
+):
+    pass
 
 
 TOOLSET_CLASS_BY_KIND = {

--- a/tests/unit/config/test_config_completions.py
+++ b/tests/unit/config/test_config_completions.py
@@ -57,6 +57,13 @@ FULL_COMPLETION_CONFIG_KW = {
             },
             query_params=test_tools.HTTP_MCP_QUERY_PARAMS,
         ),
+        "sse_test": config_tools.SSE_MCP_ClientToolsetConfig(
+            url=test_tools.HTTP_MCP_URL,
+            headers={
+                "Authorization": "Bearer secret:BEARER_TOKEN",
+            },
+            query_params=test_tools.HTTP_MCP_QUERY_PARAMS,
+        ),
     },
 }
 FULL_COMPLETION_CONFIG_YAML = f"""\
@@ -77,6 +84,13 @@ mcp_client_toolsets:
         foo: "bar"
     http_test:
       kind: "http"
+      url: "{test_tools.HTTP_MCP_URL}"
+      headers:
+        Authorization: "Bearer secret:BEARER_TOKEN"
+      query_params:
+        {test_tools.HTTP_MCP_QP_KEY}: "{test_tools.HTTP_MCP_QP_VALUE}"
+    sse_test:
+      kind: "sse"
       url: "{test_tools.HTTP_MCP_URL}"
       headers:
         Authorization: "Bearer secret:BEARER_TOKEN"

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -168,6 +168,13 @@ FULL_ROOM_CONFIG_KW = {
             },
             query_params=test_tools.HTTP_MCP_QUERY_PARAMS,
         ),
+        "sse_test": config_tools.SSE_MCP_ClientToolsetConfig(
+            url=test_tools.HTTP_MCP_URL,
+            headers={
+                "Authorization": "Bearer secret:BEARER_TOKEN",
+            },
+            query_params=test_tools.HTTP_MCP_QUERY_PARAMS,
+        ),
     },
     "skills": config_skills.RoomSkillsConfig(
         model_name=test_skills.SKILL_MODEL_NAME,
@@ -201,6 +208,13 @@ mcp_client_toolsets:
         foo: "bar"
     http_test:
       kind: "http"
+      url: "{test_tools.HTTP_MCP_URL}"
+      headers:
+        Authorization: "Bearer secret:BEARER_TOKEN"
+      query_params:
+        {test_tools.HTTP_MCP_QP_KEY}: "{test_tools.HTTP_MCP_QP_VALUE}"
+    sse_test:
+      kind: "sse"
       url: "{test_tools.HTTP_MCP_URL}"
       headers:
         Authorization: "Bearer secret:BEARER_TOKEN"

--- a/tests/unit/config/test_config_tools.py
+++ b/tests/unit/config/test_config_tools.py
@@ -229,6 +229,38 @@ FULL_HTTP_MCTC_CONFIG_YAML = """
       - "some_tool"
 """
 
+# This one raises
+BOGUS_SSE_MCTC_CONFIG_YAML = ""
+
+BARE_SSE_MCTC_CONFIG_KW = {
+    "url": "https://example.com/sse",
+}
+BARE_SSE_MCTC_CONFIG_YAML = """
+    url: "https://example.com/sse"
+"""
+
+FULL_SSE_MCTC_CONFIG_KW = {
+    "url": "https://example.com/sse",
+    "headers": {
+        "Authorization": "Bearer DEADBEEF",
+    },
+    "query_params": {
+        "foo": "bar",
+    },
+    "allowed_tools": [
+        "some_tool",
+    ],
+}
+FULL_SSE_MCTC_CONFIG_YAML = """
+    url: "https://example.com/sse"
+    headers:
+        Authorization: "Bearer DEADBEEF"
+    query_params:
+        foo: "bar"
+    allowed_tools:
+      - "some_tool"
+"""
+
 
 @pytest.fixture
 def patched_soliplex_tools():
@@ -970,6 +1002,125 @@ def test_http_mctc_tool_kwargs(
 
     else:
         assert found["url"] == http_mctc.url
+
+    for (f_key, f_val), (cfg_key, cfg_value) in zip(
+        found["headers"].items(),
+        w_headers.items(),
+        strict=True,
+    ):
+        assert f_key == cfg_key
+        assert f_val is installation_config.interpolate_secrets.return_value
+        assert (
+            mock.call(cfg_value)
+            in installation_config.interpolate_secrets.call_args_list
+        )
+
+
+@pytest.mark.parametrize(
+    "config_yaml, exp_config",
+    [
+        (BOGUS_SSE_MCTC_CONFIG_YAML, None),
+        (BARE_SSE_MCTC_CONFIG_YAML, BARE_SSE_MCTC_CONFIG_KW),
+        (FULL_SSE_MCTC_CONFIG_YAML, FULL_SSE_MCTC_CONFIG_KW),
+    ],
+)
+def test_sse_mctc_from_yaml(
+    installation_config,
+    temp_dir,
+    config_yaml,
+    exp_config,
+):
+    config_dir = temp_dir / "rooms" / "test_room"
+    config_dir.mkdir(parents=True)
+
+    config_path = config_dir / "room_config.yaml"
+    config_path.write_text(config_yaml)
+
+    with config_path.open() as stream:
+        config_dict = yaml.safe_load(stream)
+
+    if exp_config is None:
+        with pytest.raises(config_exc.FromYamlException) as exc:
+            config_tools.SSE_MCP_ClientToolsetConfig.from_yaml(
+                installation_config=installation_config,
+                config_path=config_path,
+                config_dict=config_dict,
+            )
+
+        assert exc.value._config_path == config_path
+
+    else:
+        sse_mctc = config_tools.SSE_MCP_ClientToolsetConfig.from_yaml(
+            installation_config=installation_config,
+            config_path=config_path,
+            config_dict=config_dict,
+        )
+        expected = config_tools.SSE_MCP_ClientToolsetConfig(
+            _installation_config=installation_config,
+            _config_path=config_path,
+            **exp_config,
+        )
+        assert sse_mctc == expected
+
+
+@pytest.mark.parametrize("w_headers", [{}, HTTP_MCP_AUTH_HEADER])
+@pytest.mark.parametrize("w_query_params", [{}, HTTP_MCP_QUERY_PARAMS])
+def test_sse_mctc_toolset_params(w_query_params, w_headers):
+    sse_mctc = config_tools.SSE_MCP_ClientToolsetConfig(
+        url=HTTP_MCP_URL,
+        headers=w_headers,
+        query_params=w_query_params,
+    )
+
+    found = sse_mctc.toolset_params
+
+    assert found["url"] == sse_mctc.url
+    assert found["query_params"] == sse_mctc.query_params
+    assert found["headers"] == sse_mctc.headers
+    assert found["allowed_tools"] == sse_mctc.allowed_tools
+
+
+@pytest.mark.parametrize("w_headers", [{}, HTTP_MCP_AUTH_HEADER])
+@pytest.mark.parametrize("w_query_params", [{}, HTTP_MCP_QUERY_PARAMS])
+def test_sse_mctc_tool_kwargs(
+    installation_config,
+    w_query_params,
+    w_headers,
+):
+    installation_config.get_secret.return_value = "<secret>"
+    installation_config.interpolate_secrets.return_value = "<interp>"
+
+    sse_mctc = config_tools.SSE_MCP_ClientToolsetConfig(
+        url=HTTP_MCP_URL,
+        headers=w_headers,
+        query_params=w_query_params,
+        _installation_config=installation_config,
+    )
+
+    found = sse_mctc.tool_kwargs
+
+    assert found["allowed_tools"] == sse_mctc.allowed_tools
+
+    if w_query_params:
+        base, qs = found["url"].split("?")
+        assert base == sse_mctc.url
+
+        qp_dict = dict(url_parse.parse_qsl(qs))
+
+        for (f_key, f_val), (cfg_key, cfg_value) in zip(
+            qp_dict.items(),
+            w_query_params.items(),
+            strict=True,
+        ):
+            assert f_key == cfg_key
+            assert f_val == installation_config.get_secret.return_value
+            assert (
+                mock.call(cfg_value)
+                in installation_config.get_secret.call_args_list
+            )
+
+    else:
+        assert found["url"] == sse_mctc.url
 
     for (f_key, f_val), (cfg_key, cfg_value) in zip(
         found["headers"].items(),

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -57,6 +57,14 @@ HTTP_TOOL = mcp_client.HTTP_MCP_Client_Toolset(
     headers={},
 )
 
+SSE_MCTC = config_tools.SSE_MCP_ClientToolsetConfig(
+    url="https://example.com/sse",
+)
+SSE_TOOL = mcp_client.SSE_MCP_Client_Toolset(
+    url="https://example.com/sse",
+    headers={},
+)
+
 
 def test_tool():
     """This is a test"""
@@ -86,6 +94,7 @@ def tool_configs_tools(request):
         [],
         [(STDIO_MCTC, STDIO_TOOL)],
         [(HTTP_MCTC, HTTP_TOOL)],
+        [(SSE_MCTC, SSE_TOOL)],
     ],
 )
 def mcp_ct_configs_tools(request):
@@ -127,6 +136,7 @@ def test_make_ai_tool(w_aitp, exp_aitp):
     [
         (STDIO_MCTC, STDIO_TOOL),
         (HTTP_MCTC, HTTP_TOOL),
+        (SSE_MCTC, SSE_TOOL),
     ],
 )
 def test_make_mcp_client_toolset(mcp_toolset_config, expected):

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -887,6 +887,9 @@ async def test_installation_get_agent_for_room(
     mcp_http_streaming_config = mock.create_autospec(
         config_tools.HTTP_MCP_ClientToolsetConfig
     )
+    mcp_sse_config = mock.create_autospec(
+        config_tools.SSE_MCP_ClientToolsetConfig
+    )
 
     r_config = mock.create_autospec(config_rooms.RoomConfig)
     r_config.agent_config = a_config
@@ -907,6 +910,7 @@ async def test_installation_get_agent_for_room(
     mcp_configs = r_config.mcp_client_toolset_configs = {
         "test_stdio": mcp_stdio_config,
         "test_http": mcp_http_streaming_config,
+        "test_sse": mcp_sse_config,
     }
 
     r_configs = {"room_id": r_config}
@@ -997,6 +1001,9 @@ async def test_installation_get_agent_for_completion(
     mcp_http_streaming_config = mock.create_autospec(
         config_tools.HTTP_MCP_ClientToolsetConfig
     )
+    mcp_sse_config = mock.create_autospec(
+        config_tools.SSE_MCP_ClientToolsetConfig
+    )
 
     c_config = mock.create_autospec(config_completions.CompletionConfig)
     c_config.agent_config = a_config
@@ -1007,6 +1014,7 @@ async def test_installation_get_agent_for_completion(
     mcp_configs = c_config.mcp_client_toolset_configs = {
         "test_stdio": mcp_stdio_config,
         "test_http": mcp_http_streaming_config,
+        "test_sse": mcp_sse_config,
     }
 
     c_configs = {"completion_id": c_config}

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -401,6 +401,25 @@ def test_mcp_client_toolset_from_config_w_http():
     assert params["query_params"] == mcp_ct_config.query_params
 
 
+def test_mcp_client_toolset_from_config_w_sse():
+    mcp_ct_config = config_tools.SSE_MCP_ClientToolsetConfig(
+        url="https://example.com/sse",
+        headers={"Authorization": "Bearer env:{BEARER_TOKEN}"},
+        query_params={"foo": "env:not_in_my_environment_really"},
+    )
+
+    toolset_model = models.MCPClientToolset.from_config(mcp_ct_config)
+
+    assert toolset_model.kind == mcp_ct_config.kind
+    assert toolset_model.allowed_tools == mcp_ct_config.allowed_tools
+
+    params = toolset_model.toolset_params
+    assert params["url"] == mcp_ct_config.url
+    # No interpolation on either of these!
+    assert params["headers"] == mcp_ct_config.headers
+    assert params["query_params"] == mcp_ct_config.query_params
+
+
 @pytest.fixture(params=[None, SKILL_META])
 def w_metadata(request):
     return request.param


### PR DESCRIPTION
Soliplex mapped kind: "http" to `MCPServerStreamableHTTP`, which sends `POST` requests. MCP servers using the older SSE transport expect `GET` requests, resulting in `405 Method Not Allowed`.