### PR TITLE
feat: add support for resuming SSE streams

### DIFF
--- a/docs/server/sse_resume.md
+++ b/docs/server/sse_resume.md
@@ -1,0 +1,355 @@
+# SSE Stream Resume
+
+How Soliplex uses the AG-UI protocol and the `run_event` message store
+to let clients transparently reconnect to an in-flight run after a
+dropped network connection.
+
+## Why this exists
+
+AG-UI runs are long-lived, token-by-token SSE streams. A mobile radio
+flap, a proxy idle-timeout, or a sleeping laptop can tear the
+connection down mid-response. Without resume, the user sees a partial
+message and the run appears broken even though the agent is still
+running on the server. With resume, the agent keeps running, the
+client reconnects with a `Last-Event-ID`, and the UI catches up to the
+current state as if nothing happened.
+
+The mechanism is the browser-standard SSE resume primitive
+([WHATWG spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header))
+plus a persistent copy of every streamed event so the server can
+replay from an arbitrary point.
+
+## Architecture
+
+Three layers collaborate:
+
+1. **Protocol layer** — every `data:` frame on the wire carries an
+   `id:` prefix of the form `{run_id}:{event_index}`. The client
+   echoes the most recently seen id back on reconnect via the
+   `Last-Event-ID` HTTP header.
+2. **Storage layer** — every event the agent emits is written to the
+   `run_event` table (ordered by its autoincrement primary key)
+   before being flushed to the live SSE stream. A separate `finished`
+   timestamp on the `run` row tells reconnecting consumers when
+   polling can stop.
+3. **Client layer** — the Flutter `AgUiStreamClient` tracks the last
+   seen id, detects stream drops, reconnects with `Last-Event-ID`,
+   and emits lifecycle `CustomEvent`s (`stream.reconnecting`,
+   `stream.reconnected`, `stream.reconnect_failed`) so the UI can
+   show a toast.
+
+## Event identifier format
+
+```text
+id: {run_id}:{event_index}
+data: {<json-encoded AG-UI event>}
+```
+
+- `run_id` is the UUID of the `Run` row — identifies which stream
+  this event belongs to when multiple runs overlap in the same
+  thread.
+- `event_index` is a monotonically-increasing integer starting at 0,
+  scoped to a single run. It is **not** a global sequence number;
+  each run has its own. It is not stored as its own column — it is
+  the position of the event within its run's `events` list, whose
+  ordering is guaranteed by the autoincrement `id_` primary key on
+  `run_event`.
+- Keepalive comments (`: keepalive …`) and any non-`data:` frames
+  pass through without an `id:` prefix — they do not consume an
+  index and cannot be resumed against.
+
+`add_sse_event_ids()` in
+[src/soliplex/views/streaming.py](../src/soliplex/views/streaming.py)
+is the only place ids are written; on reconnect it is re-entered with
+`start_index = after_index + 1` so the replayed stream picks up
+exactly where the client left off.
+
+## Server side
+
+### Normal first-connect path
+
+`POST /v1/rooms/{room_id}/agui/{thread_id}/{run_id}` (no
+`Last-Event-ID`) — see
+[src/soliplex/views/agui.py](../src/soliplex/views/agui.py):
+
+1. Authorize the user for the room.
+2. Persist the `RunAgentInput` via `add_run_input()`.
+3. Spawn a **background task** `drive_llm_stream()` that consumes
+   the agent's event stream and:
+   - pushes each event onto an unbounded `asyncio.Queue` (for the
+     live SSE consumer), **and**
+   - writes each event to `run_event` with its monotonic
+     `event_index` via `save_single_event()`.
+4. When the agent completes (or errors), `drive_llm_stream()` puts
+   a sentinel on the queue and calls `finish_run()` which stamps
+   `run.finished` with the current time.
+5. The HTTP response streams events drained from the queue, encoded
+   by the AG-UI adapter, tagged with ids by `add_sse_event_ids()`,
+   wrapped with keepalives, and returned as a `StreamingResponse`.
+
+**Critical decoupling:** `drive_llm_stream()` is a `create_task()`
+coroutine, not awaited inline. The queue is **unbounded**. Together
+this means a client disconnect cancels only the SSE response — the
+background task keeps draining the agent, persisting events, and
+marking the run finished. A reconnecting client can then pick up
+the full tail, including events written after it disconnected.
+
+### Reconnect path
+
+When the request carries a `Last-Event-ID: {run_id}:{N}` header,
+[`post_room_agui_thread_id_run_id`](../src/soliplex/views/agui.py)
+takes a completely different path:
+
+1. `parse_last_event_id()` splits on the final `:` and extracts
+   `after_index = N`. Malformed values are treated as if the header
+   was absent (i.e. a fresh run is attempted).
+2. Authorize the user for the room (same check as first-connect).
+3. Skip `add_run_input`, skip the agent, skip `drive_llm_stream` —
+   the run is already executing (or finished) somewhere else.
+4. Create a `stream_from_db()` generator scoped to
+   `(user_name, room_id, thread_id, run_id, after_index=N)`.
+5. Feed that generator through the normal AG-UI encoder and
+   `add_sse_event_ids(start_index=N+1)` pipeline.
+6. Return the same `StreamingResponse` shape as first-connect; the
+   client cannot tell the difference on the wire.
+
+`stream_from_db()` loops: call `list_run_events_after(after_index)`
+(which loads `run.events` and returns the slice past
+`after_index`, paired with each row's position), yield everything
+it returns, update `after_index` to the last yielded index, then
+check `is_run_finished()`. If not finished, sleep
+`SSE_RECONNECT_POLL_INTERVAL_SECS` (0.2 s) and loop. If finished,
+do one final drain query (to catch events written between the
+last poll and the `finished` flag being set) and terminate.
+
+### Storage model
+
+```text
+run                       run_event
+─────────                 ─────────
+id_ (PK)           <──┐   id_ (PK, autoincrement) ← ordering key
+user_name             └── run_id_ (FK → run.id_, ON DELETE CASCADE)
+room_id                   data                    ← json-dumped AG-UI Event
+thread_id_                created
+...
+finished (nullable)
+```
+
+See `Run` and `RunEvent` in
+[src/soliplex/agui/schema.py](../src/soliplex/agui/schema.py). Notes:
+
+- Retention is **indefinite** — no TTL. Events live until the
+  parent `run` or `thread` row is deleted (both cascade).
+- `event_index` is not persisted; it is the position of the row
+  within `run.events` (loaded in `id_` order). On the write side,
+  `drive_llm_stream()` keeps a local counter only for log/wire
+  purposes. On the read side, `list_run_events_after()` slices
+  `run.events` from `after_index + 1` and pairs each row with its
+  position.
+- `run.finished` is the single source of truth for "no more events
+  coming". Crash-recovery after a process restart relies on it
+  being unset — those runs are effectively stuck (stale events in
+  `run_event`, no background task running) and will poll forever
+  unless cleaned up administratively.
+- Events are persisted **before** they are counted as delivered —
+  if the DB write fails, the error is logged but the event is
+  still pushed to the live queue. The client sees it; a reconnect
+  would not. This is a tradeoff in favor of live responsiveness.
+
+## Client side
+
+The Flutter client is in
+[frontend/packages/soliplex_client/lib/src/http/agui_stream_client.dart](../../frontend/packages/soliplex_client/lib/src/http/agui_stream_client.dart).
+
+### Tracking the last seen id
+
+`AgUiStreamClient.runAgent()` parses SSE via the `ag_ui` package's
+`SseParser`, which exposes `SseMessage.id` for every dispatched
+message. The client holds a local `String? lastEventId` and updates
+it on each non-empty id. The `SseParser` preserves `_lastEventId`
+across messages per the spec — individual `data:` frames do not
+need to repeat their own id.
+
+### When to resume
+
+Resume is triggered **only by stream errors**, not by clean EOF:
+
+| Termination condition | Client action |
+|---|---|
+| Normal close after `RUN_FINISHED`/`RUN_ERROR` | Done, return. |
+| Clean EOF without a terminal event | Done, return (log only). |
+| `CancelledException` (user cancel) | Propagate, never resume. |
+| Initial-connect `AuthException` (401/403) | Propagate. |
+| Initial-connect `NetworkException` | Propagate (no id to resume against). |
+| Stream error mid-body, `lastEventId != null` | **Resume.** |
+| `NetworkException` on reconnect attempt | Retry, counts toward budget. |
+| 5xx `ApiException` on reconnect attempt | Retry, counts toward budget. |
+| 4xx `ApiException` / `AuthException` on reconnect | Synthesize terminal failure, stop. |
+
+A resume attempt reissues the same `POST` to the same URL with
+the same body — **plus** a `Last-Event-ID` header. The server
+routes it to `stream_from_db`. The client does not know, and does
+not need to know, whether the agent is still running or has
+already finished.
+
+### Retry policy
+
+Configured by `ResumePolicy` (defaults):
+
+- 5 attempts per drop, 500 ms → 8 s exponential backoff (×2), ±20 %
+  jitter.
+- Attempt counter **resets to zero** after a successful resume — the
+  budget is per-drop, not cumulative over the lifetime of the run.
+- On exhaustion, the client yields a
+  `CustomEvent(name: 'stream.reconnect_failed', …)` followed by a
+  synthetic `RunErrorEvent(code: 'stream.resume_failed')`, then
+  returns cleanly. Downstream state machines see a terminal run via
+  the normal `RunErrorEvent` path — no resume-specific branches
+  needed in the UI state layer.
+
+### Surfacing the lifecycle to the UI
+
+The client emits three synthetic `CustomEvent`s interleaved with
+the real run events:
+
+| `name`                    | `value`                                 |
+|---------------------------|-----------------------------------------|
+| `stream.reconnecting`     | `{attempt, lastEventId, error}`         |
+| `stream.reconnected`      | `{attempt}`                             |
+| `stream.reconnect_failed` | `{attempts, error}`                     |
+
+These are **never** sent by the server and **never** written to the
+`run_event` table — they exist only within a single client run
+instance. `ReconnectStatus.tryParse()` parses them into a typed
+sealed class; `AgentSession` exposes a `reconnectStatus` signal
+that drives the `_ReconnectBanner` toast above the chat thread.
+
+### Logging
+
+All client-side resume activity logs under the
+`soliplex_client.agui_stream` logger name:
+
+- Level 800 (info): attempt start and success.
+- Level 900 (warning): stream drop detected, will attempt resume.
+- Level 1000 (severe): final give-up after exhausted attempts.
+
+Server-side activity is captured by `logfire` spans around
+`drive_llm_stream()` and the endpoint handler; reconnects surface
+as additional entries under the same endpoint span.
+
+## Sequence diagram
+
+Example: a run that starts normally, is interrupted mid-stream by a
+network drop, and resumes via `Last-Event-ID`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant UI as Flutter UI
+    participant C as AgUiStreamClient
+    participant S as FastAPI<br/>(agui endpoint)
+    participant T as drive_llm_stream<br/>(bg task)
+    participant DB as run_event table
+    participant A as Agent
+
+    Note over UI,A: Initial connect
+    UI->>C: runAgent(endpoint, input)
+    C->>S: POST .../{thread}/{run}<br/>Accept: text/event-stream
+    S->>DB: add_run_input
+    S->>T: create_task(drive_llm_stream)
+    S-->>C: 200 OK (stream opens)
+    T->>A: consume llm_stream
+    A-->>T: RunStarted
+    T->>DB: save_single_event(index=0)
+    T-->>S: queue.put(RunStarted)
+    S-->>C: id: run-1:0\ndata: {RUN_STARTED}
+    A-->>T: TextMessageContent("Hel")
+    T->>DB: save_single_event(index=1)
+    T-->>S: queue.put(...)
+    S-->>C: id: run-1:1\ndata: {..."Hel"}
+    C-->>UI: RunStartedEvent, TextMessageContentEvent
+
+    Note over C,S: Network drop after id=run-1:1
+    S-xC: TCP reset / proxy idle-close
+    C->>C: lastEventId = "run-1:1"<br/>attempt = 1
+    C-->>UI: CustomEvent(stream.reconnecting, attempt=1)
+    UI->>UI: show "Reconnecting…" toast
+
+    Note over T,DB: Agent keeps running in background
+    A-->>T: TextMessageContent("lo")
+    T->>DB: save_single_event(index=2)
+    A-->>T: RunFinished
+    T->>DB: save_single_event(index=3)
+    T->>DB: finish_run() (sets run.finished)
+
+    Note over UI,A: Resume (500ms backoff later)
+    C->>S: POST .../{thread}/{run}<br/>Last-Event-ID: run-1:1
+    S->>S: parse_last_event_id → after_index=1
+    S->>S: authorize user for room
+    S-->>C: 200 OK (stream_from_db path)
+    loop until run.finished and drained
+        S->>DB: list_run_events_after(after_index)
+        DB-->>S: [(2, "lo"), (3, RunFinished)]
+        S-->>C: id: run-1:2\ndata: {..."lo"}
+        S-->>C: id: run-1:3\ndata: {RUN_FINISHED}
+        S->>DB: is_run_finished?
+        DB-->>S: true
+    end
+    S-->>C: stream closes
+
+    C-->>UI: CustomEvent(stream.reconnected, attempt=1)
+    UI->>UI: toast → "Reconnected." (auto-dismiss 3s)
+    C-->>UI: TextMessageContentEvent("lo"),<br/>RunFinishedEvent
+    C->>C: sawTerminalEvent = true, return
+```
+
+## File reference
+
+### Backend
+
+| Concern | File | Symbols |
+|---|---|---|
+| Endpoint dispatch & Last-Event-ID parse | [src/soliplex/views/agui.py](../src/soliplex/views/agui.py) | `parse_last_event_id`, `post_room_agui_thread_id_run_id` |
+| Background event pump + DB writes | [src/soliplex/views/agui.py](../src/soliplex/views/agui.py) | `drive_llm_stream`, `save_single_event`, `finish_run` |
+| SSE id injection & DB replay | [src/soliplex/views/streaming.py](../src/soliplex/views/streaming.py) | `add_sse_event_ids`, `stream_from_db` |
+| Event persistence API | [src/soliplex/agui/persistence.py](../src/soliplex/agui/persistence.py) | `ThreadStorage.save_single_event`, `list_run_events_after`, `is_run_finished`, `finish_run` |
+| Storage schema | [src/soliplex/agui/schema.py](../src/soliplex/agui/schema.py) | `Run`, `RunEvent` |
+| Unit tests | tests/unit/views/test_agui_views.py | `test_post_room_agui_reconnect` |
+| End-to-end tests | tests/functional/test_agui_thread.py | `test_sse_resume_with_last_event_id` |
+
+### Frontend
+
+| Concern | File | Symbols |
+|---|---|---|
+| SSE client + resume loop | frontend/packages/soliplex_client/lib/src/http/agui_stream_client.dart | `AgUiStreamClient.runAgent` |
+| Retry config + typed status | frontend/packages/soliplex_client/lib/src/http/resume_policy.dart | `ResumePolicy`, `ReconnectEvent`, `ReconnectStatus` |
+| Session bridging | frontend/packages/soliplex_agent/lib/src/runtime/agent_session.dart | `AgentSession.reconnectStatus` |
+| Thread view state | frontend/lib/src/modules/room/thread_view_state.dart | `ThreadViewState.reconnectStatus` |
+| Toast widget | frontend/lib/src/modules/room/ui/room_screen.dart | `_ReconnectBanner` |
+
+## Design notes and limits
+
+- **Per-run, not per-thread.** `Last-Event-ID` scopes to one run.
+  Once a run ends, a new user turn creates a new run with a fresh
+  `event_index` counter — a client's `lastEventId` from the
+  previous run is not meaningful for the new one.
+- **Authorization is re-checked on every reconnect.** Revoked
+  permissions mid-run terminate the resume cleanly (4xx →
+  synthetic terminal event on the client).
+- **Event persistence is best-effort.** DB write failures during
+  `drive_llm_stream` are logged but do not stop live delivery —
+  the cost is that those specific events cannot be replayed. A
+  reconnect after such a failure will skip them.
+- **Polling cost.** Reconnect readers poll every 200 ms. For
+  long-lived resumes against a slow agent, this is cheap
+  (indexed query on `event_index`) but non-zero; an event-driven
+  notification would be more efficient at the cost of added
+  complexity.
+- **Crash recovery is partial.** A server crash mid-run leaves
+  `run.finished` unset. A reconnecting client will poll forever
+  (modulo its own retry budget). There is no watchdog that
+  force-finishes orphaned runs.
+- **Synthetic client events never round-trip.** `stream.*`
+  `CustomEvent`s are constructed in-memory by the Dart client;
+  the server neither emits nor persists them, so they will not
+  appear in a replay after a second drop.

--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -362,6 +362,56 @@ class ThreadStorage(abc.ABC):
         """
 
     @abc.abstractmethod
+    async def save_single_event(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+        event: agui_core.Event,
+        event_index: int,
+    ) -> None:
+        """Save a single event for a run (incremental persistence)"""
+
+    @abc.abstractmethod
+    async def finish_run(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+    ) -> None:
+        """Mark a run as finished"""
+
+    @abc.abstractmethod
+    async def list_run_events_after(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+        after_index: int,
+    ) -> list[tuple[int, agui_core.Event]]:
+        """Return events with event_index > after_index
+
+        Each element is a (event_index, event) tuple.
+        """
+
+    @abc.abstractmethod
+    async def is_run_finished(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+    ) -> bool:
+        """Return True if the run has a 'finished' timestamp"""
+
+    @abc.abstractmethod
     async def save_run_events(
         self,
         *,

--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -370,7 +370,6 @@ class ThreadStorage(abc.ABC):
         thread_id: str,
         run_id: str,
         event: agui_core.Event,
-        event_index: int,
     ) -> None:
         """Save a single event for a run (incremental persistence)"""
 
@@ -395,7 +394,7 @@ class ThreadStorage(abc.ABC):
         run_id: str,
         after_index: int,
     ) -> list[tuple[int, agui_core.Event]]:
-        """Return events with event_index > after_index
+        """Return events[after_index + 1:]
 
         Each element is a (event_index, event) tuple.
         """

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -347,7 +347,6 @@ class ThreadStorage(agui_package.ThreadStorage):
         thread_id: str,
         run_id: str,
         event: agui_core.Event,
-        event_index: int,
     ) -> None:
         """Save a single event for a run (incremental persistence)"""
         await self._session.commit()
@@ -366,7 +365,6 @@ class ThreadStorage(agui_package.ThreadStorage):
                 agui_schema.RunEvent(
                     run=run,
                     data=data,
-                    event_index=event_index,
                 )
             )
 
@@ -402,7 +400,10 @@ class ThreadStorage(agui_package.ThreadStorage):
         run_id: str,
         after_index: int,
     ) -> list[tuple[int, agui_core.Event]]:
-        """Return events with event_index > after_index"""
+        """Return events[after_index + 1:]
+
+        Each element is a (event_index, event) tuple.
+        """
         await self._session.commit()
 
         async with self.session as session:
@@ -414,19 +415,13 @@ class ThreadStorage(agui_package.ThreadStorage):
                 session=session,
             )
 
-            query = (
-                sqla_sql.select(agui_schema.RunEvent)
-                .where(agui_schema.RunEvent.run == run)
-                .where(
-                    agui_schema.RunEvent.event_index > after_index,
-                )
-                .order_by(agui_schema.RunEvent.event_index)
-            )
-
-            result = await session.scalars(query)
+            events = await run.awaitable_attrs.events
+            first_unseen = after_index + 1
+            unseen_events = events[first_unseen:]
 
             return [
-                (row.event_index, row.to_agui_model()) for row in result.all()
+                (first_unseen + i_unseen, unseen_event.to_agui_model())
+                for i_unseen, unseen_event in enumerate(unseen_events)
             ]
 
     async def is_run_finished(

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -339,6 +339,118 @@ class ThreadStorage(agui_package.ThreadStorage):
 
         return run
 
+    async def save_single_event(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+        event: agui_core.Event,
+        event_index: int,
+    ) -> None:
+        """Save a single event for a run (incremental persistence)"""
+        await self._session.commit()
+
+        async with self.session as session:
+            run = await self._find_thread_run(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                session=session,
+            )
+
+            data = event.model_dump(mode="json")
+            session.add(
+                agui_schema.RunEvent(
+                    run=run,
+                    data=data,
+                    event_index=event_index,
+                )
+            )
+
+    async def finish_run(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+    ) -> None:
+        """Mark a run as finished"""
+        await self._session.commit()
+
+        async with self.session as session:
+            run = await self._find_thread_run(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                session=session,
+            )
+
+            run.finished = agui_util._timestamp()
+            session.add(run)
+
+    async def list_run_events_after(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+        after_index: int,
+    ) -> list[tuple[int, agui_core.Event]]:
+        """Return events with event_index > after_index"""
+        await self._session.commit()
+
+        async with self.session as session:
+            run = await self._find_thread_run(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                session=session,
+            )
+
+            query = (
+                sqla_sql.select(agui_schema.RunEvent)
+                .where(agui_schema.RunEvent.run == run)
+                .where(
+                    agui_schema.RunEvent.event_index > after_index,
+                )
+                .order_by(agui_schema.RunEvent.event_index)
+            )
+
+            result = await session.scalars(query)
+
+            return [
+                (row.event_index, row.to_agui_model()) for row in result.all()
+            ]
+
+    async def is_run_finished(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+        thread_id: str,
+        run_id: str,
+    ) -> bool:
+        """Return True if the run has a 'finished' timestamp"""
+        await self._session.commit()
+
+        async with self.session as session:
+            run = await self._find_thread_run(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                session=session,
+            )
+
+            return run.finished is not None
+
     async def save_run_events(
         self,
         *,

--- a/src/soliplex/agui/schema.py
+++ b/src/soliplex/agui/schema.py
@@ -353,10 +353,6 @@ class RunEvent(Base):
     'run' is a many-to-one relationship to 'Run'
 
     'data' is the dumped state of the event.
-
-    'event_index' is a monotonically-increasing integer scoped to a
-    run, used for deterministic ordering and SSE reconnect via
-    Last-Event-ID.
     """
 
     __tablename__ = "run_event"
@@ -369,11 +365,8 @@ class RunEvent(Base):
 
     run_id_: Mapped[int] = mapped_column(
         ForeignKey("run.id_", ondelete="CASCADE"),
-        index=True,
     )
     run: Mapped[Run] = relationship(back_populates="events")
-
-    event_index: Mapped[int] = mapped_column(default=0)
 
     data: Mapped[JSON_Mapped_From] = mapped_column()
 

--- a/src/soliplex/agui/schema.py
+++ b/src/soliplex/agui/schema.py
@@ -353,6 +353,10 @@ class RunEvent(Base):
     'run' is a many-to-one relationship to 'Run'
 
     'data' is the dumped state of the event.
+
+    'event_index' is a monotonically-increasing integer scoped to a
+    run, used for deterministic ordering and SSE reconnect via
+    Last-Event-ID.
     """
 
     __tablename__ = "run_event"
@@ -365,8 +369,11 @@ class RunEvent(Base):
 
     run_id_: Mapped[int] = mapped_column(
         ForeignKey("run.id_", ondelete="CASCADE"),
+        index=True,
     )
     run: Mapped[Run] = relationship(back_populates="events")
+
+    event_index: Mapped[int] = mapped_column(default=0)
 
     data: Mapped[JSON_Mapped_From] = mapped_column()
 

--- a/src/soliplex/tui/main.py
+++ b/src/soliplex/tui/main.py
@@ -1100,6 +1100,9 @@ class RoomView(t_screen.Screen):
             if line:
                 decoded = line.decode("utf-8")
 
+                if decoded.startswith("id:"):  # SSE event indx
+                    continue
+
                 if decoded.startswith(":"):  # comment, i.e., keepalive
                     continue
 

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -586,7 +586,6 @@ async def save_single_event(
     thread_id: str,
     run_id: str,
     event,
-    event_index: int,
 ):
     """Save a single event to the database.
 
@@ -603,7 +602,6 @@ async def save_single_event(
             thread_id=thread_id,
             run_id=run_id,
             event=event,
-            event_index=event_index,
         )
 
 
@@ -672,7 +670,6 @@ async def drive_llm_stream(
                         thread_id=thread_id,
                         run_id=run_id,
                         event=event,
-                        event_index=event_index,
                     )
                 except sqla_exc.SQLAlchemyError as sa_exc:
                     logfire.error(

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -579,6 +579,58 @@ async def save_thread_run_events(
         )
 
 
+async def save_single_event(
+    sqla_engine,
+    user_name: str,
+    room_id: str,
+    thread_id: str,
+    run_id: str,
+    event,
+    event_index: int,
+):
+    """Save a single event to the database.
+
+    This function builds its own session, because the one bound
+    to the request lifetime in the `the_threads` dependency might
+    have been closed (e.g., with an early connection reset).
+    """
+    async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
+        the_threads = agui_persistence.ThreadStorage(session)
+
+        await the_threads.save_single_event(
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+            event=event,
+            event_index=event_index,
+        )
+
+
+async def finish_run(
+    sqla_engine,
+    user_name: str,
+    room_id: str,
+    thread_id: str,
+    run_id: str,
+):
+    """Mark a run as finished in the database.
+
+    This function builds its own session, because the one bound
+    to the request lifetime in the `the_threads` dependency might
+    have been closed (e.g., with an early connection reset).
+    """
+    async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
+        the_threads = agui_persistence.ThreadStorage(session)
+
+        await the_threads.finish_run(
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+        )
+
+
 async def drive_llm_stream(
     llm_stream,
     sqla_engine,
@@ -593,6 +645,9 @@ async def drive_llm_stream(
     """Primary consumer of LLM event stream
 
     Always runs to completion.
+
+    Events are pushed to the queue (for the live SSE client) and
+    saved to the database incrementally (for reconnect).
     """
     with logfire.span(
         "AG-UI event stream: {room_id}/{thread_id}/{run_id}",
@@ -603,17 +658,36 @@ async def drive_llm_stream(
         event_list = []
         error_message = None
         status = None
+        event_index = 0
         try:
             async for event in llm_stream:
                 event_list.append(event)
                 await event_queue.put(event)
+
+                try:
+                    await save_single_event(
+                        sqla_engine,
+                        user_name=user_name,
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        run_id=run_id,
+                        event=event,
+                        event_index=event_index,
+                    )
+                except sqla_exc.SQLAlchemyError as sa_exc:
+                    logfire.error(
+                        "Error saving event {event_index}: {error_message}",
+                        event_index=event_index,
+                        error_message=str(sa_exc),
+                    )
+
+                event_index += 1
         finally:
             await event_queue.put(None)  # sentinel
 
             try:
-                await save_thread_run_events(
-                    event_list=event_list,
-                    sqla_engine=sqla_engine,
+                await finish_run(
+                    sqla_engine,
                     user_name=user_name,
                     room_id=room_id,
                     thread_id=thread_id,
@@ -621,7 +695,7 @@ async def drive_llm_stream(
                 )
             except sqla_exc.SQLAlchemyError as sa_exc:
                 logfire.error(
-                    "Error saving run events: {error_message}",
+                    "Error finishing run: {error_message}",
                     error_message=str(sa_exc),
                 )
                 raise
@@ -698,6 +772,27 @@ async def init_agent_stream(
         await drive_llm_stream(llm_stream=compacted, **drive_kwargs)
 
 
+def parse_last_event_id(header_value: str | None):
+    """Parse a ``Last-Event-ID`` header value.
+
+    Expected format: ``{run_id}:{event_index}``
+
+    Returns ``(run_id, event_index)`` or ``None`` if the header is
+    absent or malformed.
+    """
+    if header_value is None:
+        return None
+
+    parts = header_value.rsplit(":", 1)
+    if len(parts) != 2:
+        return None
+
+    try:
+        return parts[0], int(parts[1])
+    except ValueError:
+        return None
+
+
 @util.logfire_span("POST /v1/rooms/{room_id}/agui/{thread_id}/{run_id}")
 @router.post("/v1/rooms/{room_id}/agui/{thread_id}/{run_id}")
 async def post_room_agui_thread_id_run_id(
@@ -714,12 +809,75 @@ async def post_room_agui_thread_id_run_id(
     """Execute an AGUI run
 
     Stream AGUI events in the response.
+
+    If the request includes a ``Last-Event-ID`` header, the handler
+    reconnects to an existing (possibly still in-progress) run by
+    replaying persisted events from the database.
     """
     thread_id = str(thread_id)
     run_id = str(run_id)
     the_logger.debug(loggers.AGUI_POST_ROOM_THREAD_RUN)
 
     user_name = the_user_claims.get("preferred_username", "<unknown>")
+
+    # --- SSE Reconnect path ---
+    last_event_id = parse_last_event_id(
+        request.headers.get("last-event-id"),
+    )
+
+    if last_event_id is not None:
+        _, after_index = last_event_id
+
+        await _check_user_in_room(
+            room_id=room_id,
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_user_claims=the_user_claims,
+            the_logger=the_logger,
+        )
+
+        agui_adapter = await ai_ag_ui.AGUIAdapter.from_request(
+            request=request,
+            agent=(
+                await the_installation.get_agent_for_room(
+                    room_id=room_id,
+                    user=the_user_claims,
+                    the_authz_policy=the_authz_policy,
+                    the_logger=the_logger,
+                )
+            ),
+        )
+
+        db_event_stream = streaming_views.stream_from_db(
+            the_threads,
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+            after_index=after_index,
+        )
+
+        sse_stream = agui_adapter.encode_stream(db_event_stream)
+
+        w_ids_stream = streaming_views.add_sse_event_ids(
+            sse_stream,
+            run_id=run_id,
+            start_index=after_index + 1,
+        )
+
+        w_keepalive_stream = streaming_views.stream_sse_with_keepalive(
+            w_ids_stream,
+            request=request,
+            log_info=logfire.info,
+        )
+
+        return responses.StreamingResponse(
+            w_keepalive_stream,
+            media_type=agui_adapter.accept,
+            headers=streaming_views.HEADERS_DO_NOT_BUFFER_SSE,
+        )
+
+    # --- Normal (first-connect) path ---
     user, agent = await _check_user_room_agent(
         room_id=room_id,
         the_installation=the_installation,
@@ -803,9 +961,15 @@ async def post_room_agui_thread_id_run_id(
         stream_llm_events(event_queue),
     )
 
+    # Inject SSE event IDs for reconnect support
+    w_ids_stream = streaming_views.add_sse_event_ids(
+        sse_stream,
+        run_id=run_id,
+    )
+
     # Wrap the response stream w/ keepalives, cancellation detection
     w_keepalive_stream = streaming_views.stream_sse_with_keepalive(
-        sse_stream,
+        w_ids_stream,
         request=request,
         log_info=logfire.info,
     )

--- a/src/soliplex/views/streaming.py
+++ b/src/soliplex/views/streaming.py
@@ -98,6 +98,84 @@ async def stream_sse_with_keepalive(
             pending.cancel()
 
 
+SSE_RECONNECT_POLL_INTERVAL_SECS = 0.2
+
+
+async def add_sse_event_ids(
+    encoded_stream,
+    run_id: str,
+    start_index: int = 0,
+):
+    """Wrap an encoded SSE stream to inject ``id:`` fields.
+
+    Each ``data:`` frame is prefixed with
+    ``id: {run_id}:{event_index}\\n`` so that clients can reconnect
+    using the ``Last-Event-ID`` header.
+
+    Non-data frames (keepalives, comments) pass through unchanged.
+    """
+    index = start_index
+    async for encoded in encoded_stream:
+        if encoded.startswith("data:"):
+            yield f"id: {run_id}:{index}\n{encoded}"
+            index += 1
+        else:
+            yield encoded
+
+
+async def stream_from_db(
+    the_threads,
+    *,
+    user_name: str,
+    room_id: str,
+    thread_id: str,
+    run_id: str,
+    after_index: int = -1,
+    poll_interval_secs: float = SSE_RECONNECT_POLL_INTERVAL_SECS,
+):
+    """Yield ``(event_index, event)`` tuples by polling the DB.
+
+    Used for SSE reconnect: reads persisted events written by the
+    background ``drive_llm_stream`` task.  Stops when the run is
+    marked finished and all remaining events have been drained.
+    """
+    while True:
+        pairs = await the_threads.list_run_events_after(
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+            after_index=after_index,
+        )
+
+        for idx, event in pairs:
+            yield event
+            after_index = idx
+
+        finished = await the_threads.is_run_finished(
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+        )
+
+        if finished:
+            # Drain any final events written between the last
+            # query and the finished flag being set.
+            final = await the_threads.list_run_events_after(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                after_index=after_index,
+            )
+            for _idx, event in final:
+                yield event
+            break
+
+        await asyncio.sleep(poll_interval_secs)
+
+
 @util.logfire_span("GET /ssetest")
 @router.get("/ssetest", tags=["streaming"])
 async def sse_endpoint():  # pragma: NO COVER

--- a/tests/functional/test_agui_thread.py
+++ b/tests/functional/test_agui_thread.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 import uuid
 
@@ -10,6 +11,9 @@ from soliplex.agui import parser as agui_parser
 EVENT_DESERIALIZER = pydantic.TypeAdapter(agui_core.Event)
 
 IDENTITY_QUERY = "Who am I?"
+
+SSE_ID_PREFIX = "id: "
+SSE_DATA_PREFIX = "data: "
 
 
 def test_post_rooms_roomid_agui_etc(client_no_llm):
@@ -63,7 +67,7 @@ def test_post_rooms_roomid_agui_etc(client_no_llm):
         esp = agui_parser.EventStreamParser(event_log=event_log)
 
         for raw_line in response.iter_lines():
-            if raw_line:
+            if raw_line and raw_line.startswith(pfx):
                 event_json = json.loads(raw_line[pfx_len:])
                 # Work around ag_ui issue #756??
                 # agui_event = EVENT_DESERIALIZER.validate_python(
@@ -96,3 +100,129 @@ def test_post_rooms_roomid_agui_etc(client_no_llm):
         json=new_thread_request,
     )
     assert response.status_code == 200
+
+
+def _parse_sse_stream(response):
+    """Parse an SSE response into a list of (event_id, event_json) pairs.
+
+    ``event_id`` is the integer index from the ``id:`` line (or
+    ``None`` if the frame had no ``id:`` field).
+    """
+    current_id = None
+    pairs = []
+
+    for raw_line in response.iter_lines():
+        if not raw_line:
+            continue
+
+        if raw_line.startswith(SSE_ID_PREFIX):
+            # e.g.  "id: <run_id>:3"
+            id_value = raw_line[len(SSE_ID_PREFIX) :]
+            match = re.search(r":(\d+)$", id_value)
+            current_id = int(match.group(1)) if match else None
+
+        elif raw_line.startswith(SSE_DATA_PREFIX):
+            event_json = json.loads(raw_line[len(SSE_DATA_PREFIX) :])
+            pairs.append((current_id, event_json))
+            current_id = None
+
+    return pairs
+
+
+def test_sse_resume_with_last_event_id(client_no_llm):
+    """Demonstrate SSE resume: start a run, let it finish, then
+    reconnect with Last-Event-ID and verify that only the events
+    after the given index are replayed.
+    """
+    room_id = "faux"
+
+    # --- 1. Create a thread ---
+    response = client_no_llm.post(
+        f"/api/v1/rooms/{room_id}/agui",
+        json={"metadata": {"name": "sse-resume-test"}},
+    )
+    assert response.status_code == 200
+
+    new_thread = response.json()
+    thread_id = new_thread["thread_id"]
+    (run_id,) = new_thread["runs"]
+
+    run_request = {
+        "thread_id": thread_id,
+        "run_id": run_id,
+        "state": None,
+        "messages": [
+            {
+                "id": str(uuid.uuid4()),
+                "role": "user",
+                "content": IDENTITY_QUERY,
+            },
+        ],
+        "context": [],
+        "tools": [],
+        "forwarded_props": None,
+    }
+
+    # --- 2. Stream the full run (first-connect) ---
+    with client_no_llm.stream(
+        method="POST",
+        url=f"/api/v1/rooms/{room_id}/agui/{thread_id}/{run_id}",
+        json=run_request,
+    ) as response:
+        assert response.status_code == 200
+        all_pairs = _parse_sse_stream(response)
+
+    # Wait for the background task to finish persisting events
+    time.sleep(0.5)
+
+    # Verify we got events with sequential IDs
+    assert len(all_pairs) > 2
+    all_ids = [eid for eid, _ in all_pairs]
+    assert all_ids == list(range(len(all_pairs)))
+
+    first_type = all_pairs[0][1]["type"]
+    last_type = all_pairs[-1][1]["type"]
+    assert first_type == "RUN_STARTED"
+    assert last_type == "RUN_FINISHED"
+
+    # --- 3. Reconnect with Last-Event-ID ---
+    # Pretend we only received the first 2 events (index 0, 1)
+    # and ask the server to resume from index 1
+    resume_after = 1
+
+    last_event_id = f"{run_id}:{resume_after}"
+
+    with client_no_llm.stream(
+        method="POST",
+        url=f"/api/v1/rooms/{room_id}/agui/{thread_id}/{run_id}",
+        json=run_request,
+        headers={"Last-Event-ID": last_event_id},
+    ) as response:
+        assert response.status_code == 200
+        resumed_pairs = _parse_sse_stream(response)
+
+    # --- 4. Verify the resumed stream ---
+    # The resumed stream should contain only events after index 1
+    expected_events = [
+        event_json for eid, event_json in all_pairs if eid > resume_after
+    ]
+    resumed_events = [event_json for _, event_json in resumed_pairs]
+
+    assert len(resumed_events) == len(expected_events)
+    assert len(resumed_events) > 0
+
+    for resumed, original in zip(resumed_events, expected_events, strict=True):
+        assert resumed["type"] == original["type"]
+
+    # The resumed IDs should start from resume_after + 1
+    resumed_ids = [eid for eid, _ in resumed_pairs]
+    expected_ids = list(range(resume_after + 1, len(all_pairs)))
+    assert resumed_ids == expected_ids
+
+    # Last event in the resumed stream should still be RUN_FINISHED
+    assert resumed_events[-1]["type"] == "RUN_FINISHED"
+
+    # Clean up
+    client_no_llm.delete(
+        f"/api/v1/rooms/{room_id}/agui/{thread_id}",
+    )

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -1061,3 +1061,135 @@ async def test_threadstorage_save_run_events(
     ):
         assert found_event == exp_event
         assert db_event == exp_event
+
+
+@pytest.mark.asyncio
+async def test_threadstorage_save_single_event(the_async_session):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    thread = await ts.new_thread(
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+    )
+
+    thread_id = await thread.awaitable_attrs.thread_id
+
+    (run,) = await thread.list_runs()
+
+    run_id = await run.awaitable_attrs.run_id
+
+    await the_async_session.commit()
+
+    event_0 = agui_constants.TEXT_MESSAGE_START_EVENT
+    event_1 = agui_constants.TEXT_MESSAGE_CONTENT_EVENT
+
+    await ts.save_single_event(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=run_id,
+        event=event_0,
+        event_index=0,
+    )
+
+    await the_async_session.commit()
+
+    await ts.save_single_event(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=run_id,
+        event=event_1,
+        event_index=1,
+    )
+
+    await the_async_session.commit()
+
+    # Verify events were persisted
+    pairs = await ts.list_run_events_after(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=run_id,
+        after_index=-1,
+    )
+
+    assert len(pairs) == 2
+    assert pairs[0][0] == 0
+    assert pairs[0][1] == event_0
+    assert pairs[1][0] == 1
+    assert pairs[1][1] == event_1
+
+    # Query with after_index=0 should only return the second
+    pairs_after = await ts.list_run_events_after(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=run_id,
+        after_index=0,
+    )
+
+    assert len(pairs_after) == 1
+    assert pairs_after[0][0] == 1
+    assert pairs_after[0][1] == event_1
+
+
+@pytest.mark.asyncio
+@mock.patch("soliplex.agui.util._timestamp")
+async def test_threadstorage_finish_run(
+    ts_mock,
+    the_async_session,
+):
+    ts_mock.return_value = NOW
+
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    thread = await ts.new_thread(
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+    )
+
+    thread_id = await thread.awaitable_attrs.thread_id
+
+    (run,) = await thread.list_runs()
+
+    run_id = await run.awaitable_attrs.run_id
+
+    await the_async_session.commit()
+
+    # Run not yet finished
+    is_fin = await ts.is_run_finished(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=run_id,
+    )
+    assert is_fin is False
+
+    await the_async_session.commit()
+
+    # Mark it finished
+    await ts.finish_run(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=run_id,
+    )
+
+    await the_async_session.commit()
+
+    # Now it should be finished
+    is_fin = await ts.is_run_finished(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+        thread_id=thread_id,
+        run_id=run_id,
+    )
+    assert is_fin is True
+
+    await the_async_session.commit()
+
+    finished = await run.awaitable_attrs.finished
+    assert finished == NOW.replace(tzinfo=None)

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -1090,7 +1090,6 @@ async def test_threadstorage_save_single_event(the_async_session):
         thread_id=thread_id,
         run_id=run_id,
         event=event_0,
-        event_index=0,
     )
 
     await the_async_session.commit()
@@ -1101,7 +1100,6 @@ async def test_threadstorage_save_single_event(the_async_session):
         thread_id=thread_id,
         run_id=run_id,
         event=event_1,
-        event_index=1,
     )
 
     await the_async_session.commit()

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1067,9 +1067,89 @@ async def test_save_thread_run_events(a_session, t_storage):
 
 
 @pytest.mark.asyncio
+@mock.patch("soliplex.agui.persistence.ThreadStorage")
+@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
+async def test_save_single_event_helper(a_session, t_storage):
+    w_session = a_session.return_value.__aenter__.return_value
+    the_threads = t_storage.return_value
+    the_threads.save_single_event = mock.AsyncMock(spec_set=())
+    sqla_engine = object()
+    event = object()
+
+    await agui_views.save_single_event(
+        sqla_engine,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID_STR,
+        run_id=TEST_RUN_ID_STR,
+        event=event,
+        event_index=7,
+    )
+
+    the_threads.save_single_event.assert_called_once_with(
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID_STR,
+        run_id=TEST_RUN_ID_STR,
+        event=event,
+        event_index=7,
+    )
+
+    t_storage.assert_called_once_with(w_session)
+    a_session.assert_called_once_with(bind=sqla_engine)
+
+
+@pytest.mark.asyncio
+@mock.patch("soliplex.agui.persistence.ThreadStorage")
+@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
+async def test_finish_run_helper(a_session, t_storage):
+    w_session = a_session.return_value.__aenter__.return_value
+    the_threads = t_storage.return_value
+    the_threads.finish_run = mock.AsyncMock(spec_set=())
+    sqla_engine = object()
+
+    await agui_views.finish_run(
+        sqla_engine,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID_STR,
+        run_id=TEST_RUN_ID_STR,
+    )
+
+    the_threads.finish_run.assert_called_once_with(
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID_STR,
+        run_id=TEST_RUN_ID_STR,
+    )
+
+    t_storage.assert_called_once_with(w_session)
+    a_session.assert_called_once_with(bind=sqla_engine)
+
+
+@pytest.mark.parametrize(
+    "header, expected",
+    [
+        (None, None),
+        ("", None),
+        ("malformed", None),
+        ("run-1:abc", None),
+        ("run-1:0", ("run-1", 0)),
+        ("run-1:42", ("run-1", 42)),
+        (
+            "a1b2c3d4-e5f6-7890-abcd-ef1234567890:99",
+            ("a1b2c3d4-e5f6-7890-abcd-ef1234567890", 99),
+        ),
+    ],
+)
+def test_parse_last_event_id(header, expected):
+    assert agui_views.parse_last_event_id(header) == expected
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("w_event_count", [0, 1, 10])
 @pytest.mark.parametrize(
-    "w_stre_error, stre_expectation",
+    "w_finish_error, finish_expectation",
     [
         (False, contextlib.nullcontext()),
         (True, pytest.raises(sqla_exc.SQLAlchemyError)),
@@ -1078,16 +1158,18 @@ async def test_save_thread_run_events(a_session, t_storage):
 @pytest.mark.parametrize("w_finished_error", [None, "finished", "error"])
 @pytest.mark.parametrize("w_title_config", [False, True])
 @mock.patch("soliplex.views.agui.titles.maybe_generate_title")
-@mock.patch("soliplex.views.agui.save_thread_run_events")
+@mock.patch("soliplex.views.agui.finish_run")
+@mock.patch("soliplex.views.agui.save_single_event")
 @mock.patch("soliplex.views.agui.logfire")
 async def test_drive_llm_stream(
     logfire,
-    stre,
+    sse,
+    fr,
     maybe_gen_title,
     w_title_config,
     w_finished_error,
-    w_stre_error,
-    stre_expectation,
+    w_finish_error,
+    finish_expectation,
     w_event_count,
 ):
     sqla_engine = mock.AsyncMock(spec_set=())
@@ -1102,8 +1184,8 @@ async def test_drive_llm_stream(
     )
     error_event = agui_core.events.RunErrorEvent(message="test error")
 
-    if w_stre_error:
-        stre.side_effect = sqla_exc.SQLAlchemyError("stre error")
+    if w_finish_error:
+        fr.side_effect = sqla_exc.SQLAlchemyError("finish error")
 
     async def event_iter():
         for i_event in range(w_event_count):
@@ -1117,7 +1199,7 @@ async def test_drive_llm_stream(
 
     expected = [event async for event in event_iter()]
 
-    with stre_expectation as stre_expected:
+    with finish_expectation as finish_expected:
         await agui_views.drive_llm_stream(
             event_iter(),
             sqla_engine=sqla_engine,
@@ -1145,16 +1227,28 @@ async def test_drive_llm_stream(
 
     assert await event_queue.get() is None  # sentinel
 
-    stre.assert_called_once_with(
-        event_list=expected,
-        sqla_engine=sqla_engine,
+    # Each event should have been saved incrementally
+    assert sse.call_count == len(expected)
+    for i_call, exp_event in enumerate(expected):
+        sse.assert_any_call(
+            sqla_engine,
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID_STR,
+            run_id=TEST_RUN_ID_STR,
+            event=exp_event,
+            event_index=i_call,
+        )
+
+    fr.assert_called_once_with(
+        sqla_engine,
         user_name=USER_NAME,
         room_id=TEST_ROOM_ID,
         thread_id=TEST_THREAD_ID_STR,
         run_id=TEST_RUN_ID_STR,
     )
 
-    if stre_expected is None:
+    if finish_expected is None:
         if len(expected) == 0:
             logfire.info.assert_called_once_with(
                 "Stream status: {status}",
@@ -1173,12 +1267,12 @@ async def test_drive_llm_stream(
 
     else:
         logfire.error.assert_called_once_with(
-            "Error saving run events: {error_message}",
-            error_message="stre error",
+            "Error finishing run: {error_message}",
+            error_message="finish error",
         )
 
     should_generate_title = (
-        stre_expected is None
+        finish_expected is None
         and w_finished_error == "finished"
         and w_title_config
     )
@@ -1195,6 +1289,47 @@ async def test_drive_llm_stream(
         )
     else:
         maybe_gen_title.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@mock.patch("soliplex.views.agui.titles.maybe_generate_title")
+@mock.patch("soliplex.views.agui.finish_run")
+@mock.patch("soliplex.views.agui.save_single_event")
+@mock.patch("soliplex.views.agui.logfire")
+async def test_drive_llm_stream_save_event_error(
+    logfire,
+    sse,
+    fr,
+    maybe_gen_title,
+):
+    """save_single_event errors are logged but don't stop the stream."""
+    sse.side_effect = sqla_exc.SQLAlchemyError("db write failed")
+    sqla_engine = mock.AsyncMock(spec_set=())
+    event_queue = asyncio.Queue()
+
+    async def event_iter():
+        yield agui_core.events.RunFinishedEvent(
+            thread_id=TEST_THREAD_ID_STR,
+            run_id=TEST_RUN_ID_STR,
+        )
+
+    await agui_views.drive_llm_stream(
+        event_iter(),
+        sqla_engine=sqla_engine,
+        event_queue=event_queue,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID_STR,
+        run_id=TEST_RUN_ID_STR,
+    )
+
+    # Event still queued despite save error
+    assert event_queue.qsize() == 2  # event + sentinel
+    logfire.error.assert_any_call(
+        "Error saving event {event_index}: {error_message}",
+        event_index=0,
+        error_message="db write failed",
+    )
 
 
 @pytest.mark.asyncio
@@ -1336,6 +1471,7 @@ async def test_init_agent_stream_with_skills(rags, ces, dls):
 )
 @mock.patch("fastapi.responses.StreamingResponse")
 @mock.patch("soliplex.views.streaming.stream_sse_with_keepalive")
+@mock.patch("soliplex.views.streaming.add_sse_event_ids")
 @mock.patch("soliplex.views.agui.stream_llm_events")
 @mock.patch("soliplex.views.agui.init_agent_stream")
 @mock.patch("soliplex.views.agui.capture_usage_after_stream")
@@ -1351,6 +1487,7 @@ async def test_post_room_agui_thread_id_run_id_streaming(
     cuas,
     ias,
     sle,
+    asei,
     sswk,
     frsr,
     the_threads,
@@ -1368,7 +1505,13 @@ async def test_post_room_agui_thread_id_run_id_streaming(
     state = mock.Mock()
     global_agui_bg_tasks = state.agui_background_tasks = set()
     app = mock.create_autospec(fastapi.FastAPI, state=state)
-    request = fastapi.Request(scope={"type": "http", "app": app})
+    request = fastapi.Request(
+        scope={
+            "type": "http",
+            "app": app,
+            "headers": [],
+        },
+    )
     sqla_engine = request.state.threads_engine = object()
 
     the_installation = mock.create_autospec(installation.Installation)
@@ -1416,9 +1559,14 @@ async def test_post_room_agui_thread_id_run_id_streaming(
         )
 
         sswk.assert_called_once_with(
-            exp_sse_stream,
+            asei.return_value,
             request=request,
             log_info=logfire.info,
+        )
+
+        asei.assert_called_once_with(
+            exp_sse_stream,
+            run_id=TEST_RUN_ID_STR,
         )
 
         exp_adapter.encode_stream.assert_called_once_with(sle.return_value)
@@ -1496,6 +1644,104 @@ async def test_post_room_agui_thread_id_run_id_streaming(
         assert len(global_agui_bg_tasks) == 1
 
     the_logger.debug.assert_called_once_with(loggers.AGUI_POST_ROOM_THREAD_RUN)
+
+
+@pytest.mark.asyncio
+@mock.patch("fastapi.responses.StreamingResponse")
+@mock.patch("soliplex.views.streaming.stream_sse_with_keepalive")
+@mock.patch("soliplex.views.streaming.add_sse_event_ids")
+@mock.patch("soliplex.views.streaming.stream_from_db")
+@mock.patch("pydantic_ai.ui.ag_ui.AGUIAdapter")
+@mock.patch("soliplex.views.agui._check_user_in_room")
+@mock.patch("soliplex.views.agui.logfire")
+async def test_post_room_agui_reconnect(
+    logfire,
+    cuir,
+    aga,
+    sfdb,
+    asei,
+    sswk,
+    frsr,
+    the_threads,
+):
+    """Reconnect path: Last-Event-ID present."""
+    agent = object()
+
+    the_installation = mock.create_autospec(installation.Installation)
+    the_installation.get_agent_for_room = mock.AsyncMock(
+        return_value=agent,
+    )
+    the_authz_policy = mock.create_autospec(
+        authz_package.AuthorizationPolicy,
+    )
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    aga.from_request = mock.AsyncMock()
+    exp_adapter = aga.from_request.return_value
+    exp_adapter.encode_stream = mock.MagicMock()
+
+    last_event_id = f"{TEST_RUN_ID_STR}:5"
+    request = fastapi.Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"last-event-id", last_event_id.encode()),
+            ],
+        },
+    )
+
+    found = await agui_views.post_room_agui_thread_id_run_id(
+        request,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID_UUID,
+        run_id=TEST_RUN_ID_UUID,
+        the_installation=the_installation,
+        the_threads=the_threads,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found is frsr.return_value
+
+    frsr.assert_called_once_with(
+        sswk.return_value,
+        media_type=exp_adapter.accept,
+        headers=streaming_views.HEADERS_DO_NOT_BUFFER_SSE,
+    )
+
+    sswk.assert_called_once_with(
+        asei.return_value,
+        request=request,
+        log_info=logfire.info,
+    )
+
+    asei.assert_called_once_with(
+        exp_adapter.encode_stream.return_value,
+        run_id=TEST_RUN_ID_STR,
+        start_index=6,
+    )
+
+    sfdb.assert_called_once_with(
+        the_threads,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID_STR,
+        run_id=TEST_RUN_ID_STR,
+        after_index=5,
+    )
+
+    exp_adapter.encode_stream.assert_called_once_with(
+        sfdb.return_value,
+    )
+
+    cuir.assert_called_once_with(
+        room_id=TEST_ROOM_ID,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1083,7 +1083,6 @@ async def test_save_single_event_helper(a_session, t_storage):
         thread_id=TEST_THREAD_ID_STR,
         run_id=TEST_RUN_ID_STR,
         event=event,
-        event_index=7,
     )
 
     the_threads.save_single_event.assert_called_once_with(
@@ -1092,7 +1091,6 @@ async def test_save_single_event_helper(a_session, t_storage):
         thread_id=TEST_THREAD_ID_STR,
         run_id=TEST_RUN_ID_STR,
         event=event,
-        event_index=7,
     )
 
     t_storage.assert_called_once_with(w_session)
@@ -1228,16 +1226,14 @@ async def test_drive_llm_stream(
     assert await event_queue.get() is None  # sentinel
 
     # Each event should have been saved incrementally
-    assert sse.call_count == len(expected)
-    for i_call, exp_event in enumerate(expected):
-        sse.assert_any_call(
+    for sse_call, exp_event in zip(sse.call_args_list, expected, strict=True):
+        assert sse_call == mock.call(
             sqla_engine,
             user_name=USER_NAME,
             room_id=TEST_ROOM_ID,
             thread_id=TEST_THREAD_ID_STR,
             run_id=TEST_RUN_ID_STR,
             event=exp_event,
-            event_index=i_call,
         )
 
     fr.assert_called_once_with(

--- a/tests/unit/views/test_streaming.py
+++ b/tests/unit/views/test_streaming.py
@@ -135,3 +135,188 @@ async def test_stream_sse_with_keepalive_w_cancellation(w_request):
         "SSE generator cancelled {thread_id}/{run_id}",
         **exp_params,
     )
+
+
+# --- add_sse_event_ids tests ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "events, start_index, expected",
+    [
+        ([], 0, []),
+        (
+            ["data: {}\n\n"],
+            0,
+            ["id: run-1:0\ndata: {}\n\n"],
+        ),
+        (
+            ["data: a\n\n", "data: b\n\n"],
+            0,
+            ["id: run-1:0\ndata: a\n\n", "id: run-1:1\ndata: b\n\n"],
+        ),
+        (
+            [": keepalive\n\n", "data: x\n\n"],
+            0,
+            [": keepalive\n\n", "id: run-1:0\ndata: x\n\n"],
+        ),
+        (
+            ["data: a\n\n", "data: b\n\n"],
+            5,
+            ["id: run-1:5\ndata: a\n\n", "id: run-1:6\ndata: b\n\n"],
+        ),
+    ],
+)
+async def test_add_sse_event_ids(events, start_index, expected):
+    async def event_stream():
+        for event in events:
+            yield event
+
+    found = [
+        event
+        async for event in views_streaming.add_sse_event_ids(
+            event_stream(),
+            run_id="run-1",
+            start_index=start_index,
+        )
+    ]
+
+    assert found == expected
+
+
+# --- stream_from_db tests ---
+
+
+@pytest.mark.asyncio
+async def test_stream_from_db_finished_run():
+    """Run is already finished: replay events and stop."""
+    the_threads = mock.AsyncMock()
+
+    events = [
+        (0, mock.Mock(name="evt0")),
+        (1, mock.Mock(name="evt1")),
+    ]
+
+    the_threads.list_run_events_after = mock.AsyncMock(
+        side_effect=[events, []],
+    )
+    the_threads.is_run_finished = mock.AsyncMock(
+        return_value=True,
+    )
+
+    found = [
+        event
+        async for event in views_streaming.stream_from_db(
+            the_threads,
+            user_name="user",
+            room_id="room",
+            thread_id="thread",
+            run_id="run",
+            after_index=-1,
+        )
+    ]
+
+    assert found == [events[0][1], events[1][1]]
+
+
+@pytest.mark.asyncio
+async def test_stream_from_db_in_progress_run():
+    """Run is in progress: poll until finished."""
+    the_threads = mock.AsyncMock()
+
+    evt0 = (0, mock.Mock(name="evt0"))
+    evt1 = (1, mock.Mock(name="evt1"))
+
+    # First poll: one event, not finished
+    # Second poll: one more event, now finished
+    # Final drain: empty
+    the_threads.list_run_events_after = mock.AsyncMock(
+        side_effect=[
+            [evt0],
+            [evt1],
+            [],
+        ],
+    )
+    the_threads.is_run_finished = mock.AsyncMock(
+        side_effect=[False, True],
+    )
+
+    found = [
+        event
+        async for event in views_streaming.stream_from_db(
+            the_threads,
+            user_name="user",
+            room_id="room",
+            thread_id="thread",
+            run_id="run",
+            after_index=-1,
+            poll_interval_secs=0.01,
+        )
+    ]
+
+    assert found == [evt0[1], evt1[1]]
+
+
+@pytest.mark.asyncio
+async def test_stream_from_db_final_drain_has_events():
+    """Events arrive between last poll and finished flag."""
+    the_threads = mock.AsyncMock()
+
+    evt0 = (0, mock.Mock(name="evt0"))
+    evt1 = (1, mock.Mock(name="evt1"))
+
+    # First poll: one event, not finished
+    # Second poll: empty, now finished
+    # Final drain: one late event
+    the_threads.list_run_events_after = mock.AsyncMock(
+        side_effect=[
+            [evt0],
+            [],
+            [evt1],
+        ],
+    )
+    the_threads.is_run_finished = mock.AsyncMock(
+        side_effect=[False, True],
+    )
+
+    found = [
+        event
+        async for event in views_streaming.stream_from_db(
+            the_threads,
+            user_name="user",
+            room_id="room",
+            thread_id="thread",
+            run_id="run",
+            after_index=-1,
+            poll_interval_secs=0.01,
+        )
+    ]
+
+    assert found == [evt0[1], evt1[1]]
+
+
+@pytest.mark.asyncio
+async def test_stream_from_db_empty_finished_run():
+    """Run finished with no events."""
+    the_threads = mock.AsyncMock()
+
+    the_threads.list_run_events_after = mock.AsyncMock(
+        side_effect=[[], []],
+    )
+    the_threads.is_run_finished = mock.AsyncMock(
+        return_value=True,
+    )
+
+    found = [
+        event
+        async for event in views_streaming.stream_from_db(
+            the_threads,
+            user_name="user",
+            room_id="room",
+            thread_id="thread",
+            run_id="run",
+            after_index=-1,
+        )
+    ]
+
+    assert found == []


### PR DESCRIPTION
Adds support for resuming sse streams by  saving every event instead of batching.  agents are separated from sse streams via database and queue