### PR TITLE
chore: tweak 'pymarkdown' pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: pip-audit
         name: pip-audit
-        #ignore CVE-2025-69872 as not fixed        
+        #ignore CVE-2025-69872 as not fixed
         entry: uv run --with pip-audit pip-audit  --ignore-vuln CVE-2025-69872
         language: system
         pass_filenames: false
@@ -36,9 +36,5 @@ repos:
     hooks:
       - id: pymarkdown
         args:
-          - "--set"
-          - "extensions.front-matter.enabled=$!True"
-          - "--disable-rules"
-          - "MD013,MD024,MD033,MD036,MD041,MD060"
           - "scan"
         exclude: ^ios/Runner/Assets\.xcassets/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,3 +127,14 @@ force-single-line = true
 
 [tool.ruff.lint.flake8-pytest-style]
 parametrize-names-type = "csv"
+
+[tool.pymarkdown]
+extensions.front-matter.enabled = true
+plugins.line-length.enabled = false             # md013
+plugins.no-duplicate-heading.enabled = false    # md024
+plugins.no-inline-html.enabled = false          # md033
+plugins.no-emphasis-as-heading.enabled = false  # md036
+plugins.first-line-heading.enabled = false      # md041
+plugins.code-block-style.enabled = false        # md046
+# There is no rule 'md060'
+# plugins.md060.enabled = false                 # md060

--- a/src/soliplex/skills/bwrap_sandbox/SKILL.md
+++ b/src/soliplex/skills/bwrap_sandbox/SKILL.md
@@ -5,9 +5,6 @@ description: |
 
     All environments include filesystem access, with configurable volumes
     mounted under '/sandbox/volumes'.
-
-    Available environments include 'bare' (no third-party packages installed)
-    and 'pandas-only' (pandas and related packages installed).
 ---
 
 # Sandbox
@@ -16,16 +13,13 @@ You are a coding agent with access to a bubblewrap sandbox running
 Python. When given a task, write Python code, execute it, and return
 the results.
 
-## Environment
+## Sandbox file layout
 
 - Working directory: `/sandbox/work/` (read/write, for script output
   and temporary files)
 - Uploaded files are mounted under `/sandbox/volumes/` (read-only):
   - `/sandbox/volumes/thread/` — files uploaded to this thread
   - `/sandbox/volumes/room/` — files shared across the room
-- `bare` environment includes no pre-installed packages
-- `pandas-only` environment includes pre-installed packages: pandas,
-  numpy, scipy, matplotlib
 
 ## Tools
 


### PR DESCRIPTION
- Move option configuration to 'pyproject.toml'
- Disable rule 'm046': it incorrectly flags fenced code in 'SKILL.md' files.

fix: remove specific environment names from 'bwrap_sandbox' skill

... they are propoerties of an installation, not intrinsic to the skill itself.