### PR TITLE
chore: bump 'haiku.rag-slim >= 0.42.0, < 0.43'

### DIFF
--- a/docs/config/meta.md
+++ b/docs/config/meta.md
@@ -88,7 +88,7 @@ we configured explicitly:
 meta:
   skill_configs:
   - "soliplex.config.HR_RAG_SkillConfig"
-  - "soliplex.config.HR_RLM_SkillConfig"
+  - "soliplex.config.HR_Analysis_SkillConfig"
 ```
 
 ## Registering MCP Server Tool Wrapper Types

--- a/docs/config/rooms.md
+++ b/docs/config/rooms.md
@@ -143,7 +143,7 @@ E.g.:
             - "list_documents"
             - "research"
 
-        - skill_name: "rlm"
+        - skill_name: "analysis"
           kind: "haiku.rag.skill.rag"
           rag_lancedb_stem: "rag"
   ```
@@ -152,7 +152,7 @@ E.g.:
 
 Soliplex provides two such skill configuration classes by default:
 one of kind `haiku.rag.skill.rag` and one of kind
-`haiku.rag.skill.rlm`.  Both of these configurations have options for
+`haiku.rag.skill.analysis`.  Both of these configurations have options for
 configuring the RAG database and RAG client:
 
 - One of the following (exactly one must be provided):
@@ -215,7 +215,7 @@ additional options:
   - `"analysis"` — formerly equivalent to the `haiku.rag.skills.rml`
     skill below.  This feature is no longer supported.
 
-The `haiku.rag.skills.rlm` skill gives the agent an `analyze` tool that
+The `haiku.rag.skills.analysis` skill gives the agent an `analyze` tool that
 iteratively writes and executes Python code in a Docker sandbox with
 access to `haiku.rag` functions (`search`, `list_documents`, `get_document`,
 `llm`, etc.).  Suited for aggregation, multi-document comparison, and

--- a/docs/config/skills.md
+++ b/docs/config/skills.md
@@ -44,7 +44,7 @@ in the installation configuration file.
 ## Configuring Room-Specific Skills
 
 Soliplex provides two custom skill configuration types, based on the
-skills defined in `haiku.rag.skills.rag` and `haiku.rag.skills.rlm`.
+skills defined in `haiku.rag.skills.rag` and `haiku.rag.skills.analysis`.
 Because these skills require additional parameters available in
 a room configuration, they are defined using the
 [`skill_configs` stanza](rooms.md#skill-configuration)

--- a/example/haiku.rag.yaml
+++ b/example/haiku.rag.yaml
@@ -78,7 +78,6 @@ processing:
 
 #search:
 #  limit: 10
-#  max_context_items: 10
 #  max_context_chars: 10000
 #  vector_index_metric: cosine
 #  vector_refine_factor: 30

--- a/example/installation-openai.yaml
+++ b/example/installation-openai.yaml
@@ -57,12 +57,12 @@ meta:
   # their 'kind'
   #
   # 'soliplex.config.HR_RAG_SkillConfig' and
-  # 'soliplex.config.HR_RLM_SkillConfig' are registered by default,
+  # 'soliplex.config.HR_Analysis_SkillConfig' are registered by default,
   # just as if we configured here:
   #
   # skill_configs:
   # - "soliplex.config.HR_RAG_SkillConfig"
-  # - "soliplex.config.HR_RLM_SkillConfig"
+  # - "soliplex.config.HR_Analysis_SkillConfig"
   #------------------------------------------------------------------------
 
   #------------------------------------------------------------------------

--- a/example/installation.yaml
+++ b/example/installation.yaml
@@ -57,12 +57,12 @@ meta:
   # their 'kind'
   #
   # 'soliplex.config.HR_RAG_SkillConfig' and
-  # 'soliplex.config.HR_RLM_SkillConfig' are registered by default,
+  # 'soliplex.config.HR_Analysis_SkillConfig' are registered by default,
   # just as if we configured here:
   #
   # skill_configs:
   # - "soliplex.config.HR_RAG_SkillConfig"
-  # - "soliplex.config.HR_RLM_SkillConfig"
+  # - "soliplex.config.HR_Analysis_SkillConfig"
   #------------------------------------------------------------------------
 
   #------------------------------------------------------------------------

--- a/example/minimal-openai.yaml
+++ b/example/minimal-openai.yaml
@@ -56,12 +56,12 @@ meta:
   # their 'kind'
   #
   # 'soliplex.config.HR_RAG_SkillConfig' and
-  # 'soliplex.config.HR_RLM_SkillConfig' are registered by default,
+  # 'soliplex.config.HR_Analysis_SkillConfig' are registered by default,
   # just as if we configured here:
   #
   # skill_configs:
   # - "soliplex.config.HR_RAG_SkillConfig"
-  # - "soliplex.config.HR_RLM_SkillConfig"
+  # - "soliplex.config.HR_Analysis_SkillConfig"
   #------------------------------------------------------------------------
 
   #------------------------------------------------------------------------

--- a/example/minimal.yaml
+++ b/example/minimal.yaml
@@ -56,12 +56,12 @@ meta:
   # their 'kind'
   #
   # 'soliplex.config.HR_RAG_SkillConfig' and
-  # 'soliplex.config.HR_RLM_SkillConfig' are registered by default,
+  # 'soliplex.config.HR_Analysis_SkillConfig' are registered by default,
   # just as if we configured here:
   #
   # skill_configs:
   # - "soliplex.config.HR_RAG_SkillConfig"
-  # - "soliplex.config.HR_RLM_SkillConfig"
+  # - "soliplex.config.HR_Analysis_SkillConfig"
   #------------------------------------------------------------------------
 
   #------------------------------------------------------------------------

--- a/example/rooms/analysis/room_config.yaml
+++ b/example/rooms/analysis/room_config.yaml
@@ -13,7 +13,7 @@ skills:
   skill_configs:
     - kind: "haiku.rag.skills.rag"
       rag_lancedb_stem: "rag"
-    - kind: "haiku.rag.skills.rlm"
+    - kind: "haiku.rag.skills.analysis"
       rag_lancedb_stem: "rag"
 
 allow_mcp: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ dependencies = [
     "fastmcp >= 2.14.0, < 2.15",
     "fakeredis != 2.35.0",  # brownbag
     "greenlet",
-    "haiku.rag-slim >= 0.40.0, < 0.41",
-    "haiku-skills >= 0.14.0, < 0.15",
+    "haiku.rag-slim >= 0.42.0, < 0.43",
+    "haiku-skills >= 0.15.0, < 0.16",
     "itsdangerous",
     "jsonpatch",
     "jwcrypto",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "fastmcp >= 2.14.0, < 2.15",
     "fakeredis != 2.35.0",  # brownbag
     "greenlet",
-    "haiku.rag-slim >= 0.42.0, < 0.43",
+    "haiku.rag-slim >= 0.42.1, < 0.43",
     "haiku-skills >= 0.15.0, < 0.16",
     "itsdangerous",
     "jsonpatch",

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -201,10 +201,7 @@
         },
         "citations": {
           "items": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
+            "type": "string"
           },
           "title": "Citations",
           "type": "array"
@@ -481,10 +478,7 @@
         },
         "citations": {
           "items": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
+            "type": "string"
           },
           "title": "Citations",
           "type": "array"

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -2,50 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "image-generation": {
-      "$defs": {
-        "GeneratedImage": {
-          "properties": {
-            "prompt": {
-              "title": "Prompt",
-              "type": "string"
-            },
-            "path": {
-              "title": "Path",
-              "type": "string"
-            },
-            "width": {
-              "title": "Width",
-              "type": "integer"
-            },
-            "height": {
-              "title": "Height",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "prompt",
-            "path",
-            "width",
-            "height"
-          ],
-          "title": "GeneratedImage",
-          "type": "object"
-        }
-      },
-      "properties": {
-        "images": {
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/GeneratedImage"
-          },
-          "title": "Images",
-          "type": "array"
-        }
-      },
-      "title": "ImageState",
-      "type": "object"
-    },
     "rag": {
       "$defs": {
         "Citation": {
@@ -123,10 +79,18 @@
           "title": "Citation",
           "type": "object"
         },
-        "DocumentInfo": {
-          "description": "Document info for list_documents response.",
+        "SearchResult": {
+          "description": "Search result with optional provenance information for citations.",
           "properties": {
-            "id": {
+            "content": {
+              "title": "Content",
+              "type": "string"
+            },
+            "score": {
+              "title": "Score",
+              "type": "number"
+            },
+            "chunk_id": {
               "anyOf": [
                 {
                   "type": "string"
@@ -136,57 +100,70 @@
                 }
               ],
               "default": null,
-              "title": "Id"
+              "title": "Chunk Id"
             },
-            "title": {
-              "title": "Title",
-              "type": "string"
+            "document_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Document Id"
             },
-            "uri": {
-              "title": "Uri",
-              "type": "string"
+            "document_uri": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Document Uri"
             },
-            "created": {
-              "title": "Created",
-              "type": "string"
-            }
-          },
-          "required": [
-            "title",
-            "uri",
-            "created"
-          ],
-          "title": "DocumentInfo",
-          "type": "object"
-        },
-        "QAHistoryEntry": {
-          "description": "A Q&A pair with optional cached embedding for similarity matching.",
-          "properties": {
-            "question": {
-              "title": "Question",
-              "type": "string"
+            "document_title": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Document Title"
             },
-            "answer": {
-              "title": "Answer",
-              "type": "string"
+            "order": {
+              "default": 0,
+              "title": "Order",
+              "type": "integer"
             },
-            "confidence": {
-              "default": 0.9,
-              "title": "Confidence",
-              "type": "number"
-            },
-            "citations": {
+            "doc_item_refs": {
+              "default": [],
               "items": {
-                "$ref": "#/$defs/Citation"
+                "type": "string"
               },
-              "title": "Citations",
+              "title": "Doc Item Refs",
               "type": "array"
             },
-            "question_embedding": {
+            "page_numbers": {
+              "default": [],
+              "items": {
+                "type": "integer"
+              },
+              "title": "Page Numbers",
+              "type": "array"
+            },
+            "headings": {
               "anyOf": [
                 {
                   "items": {
-                    "type": "number"
+                    "type": "string"
                   },
                   "type": "array"
                 },
@@ -195,37 +172,172 @@
                 }
               ],
               "default": null,
-              "title": "Question Embedding"
+              "title": "Headings"
+            },
+            "labels": {
+              "default": [],
+              "items": {
+                "type": "string"
+              },
+              "title": "Labels",
+              "type": "array"
             }
           },
           "required": [
-            "question",
-            "answer"
+            "content",
+            "score"
           ],
-          "title": "QAHistoryEntry",
+          "title": "SearchResult",
+          "type": "object"
+        }
+      },
+      "properties": {
+        "citation_index": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Citation"
+          },
+          "title": "Citation Index",
           "type": "object"
         },
-        "ResearchEntry": {
+        "citations": {
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": "Citations",
+          "type": "array"
+        },
+        "document_filter": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Document Filter"
+        },
+        "searches": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/$defs/SearchResult"
+            },
+            "type": "array"
+          },
+          "title": "Searches",
+          "type": "object"
+        }
+      },
+      "title": "RAGState",
+      "type": "object"
+    },
+    "analysis": {
+      "$defs": {
+        "Citation": {
+          "description": "Resolved citation with full metadata for display/visual grounding.\n\nUsed by research graph and chat applications. The optional index field\nsupports UI display ordering in chat contexts.",
           "properties": {
-            "question": {
-              "title": "Question",
+            "index": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Index"
+            },
+            "document_id": {
+              "title": "Document Id",
               "type": "string"
             },
-            "title": {
-              "title": "Title",
+            "chunk_id": {
+              "title": "Chunk Id",
               "type": "string"
             },
-            "executive_summary": {
-              "title": "Executive Summary",
+            "document_uri": {
+              "title": "Document Uri",
+              "type": "string"
+            },
+            "document_title": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Document Title"
+            },
+            "page_numbers": {
+              "items": {
+                "type": "integer"
+              },
+              "title": "Page Numbers",
+              "type": "array"
+            },
+            "headings": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Headings"
+            },
+            "content": {
+              "title": "Content",
               "type": "string"
             }
           },
           "required": [
-            "question",
-            "title",
-            "executive_summary"
+            "document_id",
+            "chunk_id",
+            "document_uri",
+            "content"
           ],
-          "title": "ResearchEntry",
+          "title": "Citation",
+          "type": "object"
+        },
+        "CodeExecutionEntry": {
+          "properties": {
+            "code": {
+              "title": "Code",
+              "type": "string"
+            },
+            "stdout": {
+              "title": "Stdout",
+              "type": "string"
+            },
+            "stderr": {
+              "default": "",
+              "title": "Stderr",
+              "type": "string"
+            },
+            "success": {
+              "default": true,
+              "title": "Success",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "stdout"
+          ],
+          "title": "CodeExecutionEntry",
           "type": "object"
         },
         "SearchResult": {
@@ -287,6 +399,11 @@
               "default": null,
               "title": "Document Title"
             },
+            "order": {
+              "default": 0,
+              "title": "Order",
+              "type": "integer"
+            },
             "doc_item_refs": {
               "default": [],
               "items": {
@@ -336,20 +453,6 @@
         }
       },
       "properties": {
-        "citations": {
-          "items": {
-            "$ref": "#/$defs/Citation"
-          },
-          "title": "Citations",
-          "type": "array"
-        },
-        "qa_history": {
-          "items": {
-            "$ref": "#/$defs/QAHistoryEntry"
-          },
-          "title": "Qa History",
-          "type": "array"
-        },
         "document_filter": {
           "anyOf": [
             {
@@ -362,6 +465,30 @@
           "default": null,
           "title": "Document Filter"
         },
+        "executions": {
+          "items": {
+            "$ref": "#/$defs/CodeExecutionEntry"
+          },
+          "title": "Executions",
+          "type": "array"
+        },
+        "citation_index": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Citation"
+          },
+          "title": "Citation Index",
+          "type": "object"
+        },
+        "citations": {
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": "Citations",
+          "type": "array"
+        },
         "searches": {
           "additionalProperties": {
             "items": {
@@ -371,69 +498,9 @@
           },
           "title": "Searches",
           "type": "object"
-        },
-        "documents": {
-          "items": {
-            "$ref": "#/$defs/DocumentInfo"
-          },
-          "title": "Documents",
-          "type": "array"
-        },
-        "reports": {
-          "items": {
-            "$ref": "#/$defs/ResearchEntry"
-          },
-          "title": "Reports",
-          "type": "array"
         }
       },
-      "title": "RAGState",
-      "type": "object"
-    },
-    "rlm": {
-      "$defs": {
-        "AnalysisEntry": {
-          "properties": {
-            "question": {
-              "title": "Question",
-              "type": "string"
-            },
-            "answer": {
-              "title": "Answer",
-              "type": "string"
-            },
-            "program": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Program"
-            }
-          },
-          "required": [
-            "question",
-            "answer"
-          ],
-          "title": "AnalysisEntry",
-          "type": "object"
-        }
-      },
-      "properties": {
-        "analyses": {
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/AnalysisEntry"
-          },
-          "title": "Analyses",
-          "type": "array"
-        }
-      },
-      "title": "RLMState",
+      "title": "AnalysisState",
       "type": "object"
     }
   }

--- a/scripts/generate_feature_schemas.sh
+++ b/scripts/generate_feature_schemas.sh
@@ -6,8 +6,7 @@ soliplex-cli agui-feature-schemas "$repo_root/example/installation.yaml" | jq '{
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "properties": {
-              "image-generation": .["image-generation"].json_schema,
               "rag": .rag.json_schema,
-              "rlm": .rlm.json_schema
+              "analysis": .analysis.json_schema
             }
           }' >"$repo_root/schemas/schema.json"

--- a/src/soliplex/config/__init__.py
+++ b/src/soliplex/config/__init__.py
@@ -42,7 +42,7 @@ from soliplex.config.secrets import (  # noqa F401 API
 )
 from soliplex.config.skills import (  # noqa F401 API
     HR_RAG_SkillConfig,
-    HR_RLM_SkillConfig,
+    HR_Analysis_SkillConfig,
     SkillConfigTypes,
     RoomSkillsConfig,
 )

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -8,8 +8,8 @@ import warnings
 import pydantic
 from bubble_sandbox import config as bs_config
 from bubble_sandbox import models as bs_models
+from haiku.rag.skills import analysis as hr_skills_analysis
 from haiku.rag.skills import rag as hr_skills_rag
-from haiku.rag.skills import rlm as hr_skills_rlm
 from haiku.skills import agent as hs_agent
 from haiku.skills import discovery as hs_discovery
 from haiku.skills import models as hs_models
@@ -361,11 +361,11 @@ class HR_RAG_SkillConfig(_HR_SkillConfigBase):
 
 
 @dataclasses.dataclass(kw_only=True)
-class HR_RLM_SkillConfig(_HR_SkillConfigBase):
-    """Configuration for an agent skill from 'haiku.rag.skills.rlm"""
+class HR_Analysis_SkillConfig(_HR_SkillConfigBase):
+    """Configuration for an agent skill from 'haiku.rag.skills.analysis"""
 
-    kind: typing.ClassVar[hs_models.SkillSource] = "haiku.rag.skills.rlm"
-    _hr_skill_module = hr_skills_rlm
+    kind: typing.ClassVar[hs_models.SkillSource] = "haiku.rag.skills.analysis"
+    _hr_skill_module = hr_skills_analysis
 
     @classmethod
     def from_yaml(
@@ -461,7 +461,7 @@ SKILL_CONFIG_CLASSES_BY_KIND = {
         FilesystemSkillConfig,
         EntrypointSkillConfig,
         HR_RAG_SkillConfig,
-        HR_RLM_SkillConfig,
+        HR_Analysis_SkillConfig,
         BwrapSandboxSkillConfig,
     ]
 }
@@ -470,7 +470,7 @@ SkillConfigTypes = (
     FilesystemSkillConfig
     | EntrypointSkillConfig
     | HR_RAG_SkillConfig
-    | HR_RLM_SkillConfig
+    | HR_Analysis_SkillConfig
     | BwrapSandboxSkillConfig
 )
 SkillConfigMap = dict[str, SkillConfigTypes]

--- a/tests/unit/config/test_config_installation.py
+++ b/tests/unit/config/test_config_installation.py
@@ -94,7 +94,7 @@ W_FULL_META_INSTALLATION_CONFIG_KW = {
                 config_klass=config_skills.HR_RAG_SkillConfig
             ),
             config_meta.ConfigMeta(
-                config_klass=config_skills.HR_RLM_SkillConfig
+                config_klass=config_skills.HR_Analysis_SkillConfig
             ),
         ],
         "agent_configs": [
@@ -128,7 +128,7 @@ meta:
       wrapper_klass: "soliplex.config.tools.NoArgsMCPWrapper"
   skill_configs:
       - "soliplex.config.skills.HR_RAG_SkillConfig"
-      - "soliplex.config.skills.HR_RLM_SkillConfig"
+      - "soliplex.config.skills.HR_Analysis_SkillConfig"
   agent_configs:
       - "soliplex.config.agents.AgentConfig"
       - "soliplex.config.agents.FactoryAgentConfig"

--- a/tests/unit/config/test_config_meta.py
+++ b/tests/unit/config/test_config_meta.py
@@ -180,7 +180,9 @@ FULL_ICMETA_KW = {
     ],
     "skill_configs": [
         config_meta.ConfigMeta(config_klass=config_skills.HR_RAG_SkillConfig),
-        config_meta.ConfigMeta(config_klass=config_skills.HR_RLM_SkillConfig),
+        config_meta.ConfigMeta(
+            config_klass=config_skills.HR_Analysis_SkillConfig
+        ),
     ],
     "agent_configs": [
         config_meta.ConfigMeta(config_klass=config_agents.AgentConfig),
@@ -209,7 +211,7 @@ meta:
       wrapper_klass: "soliplex.config.tools.NoArgsMCPWrapper"
   skill_configs:
       - "soliplex.config.skills.HR_RAG_SkillConfig"
-      - "soliplex.config.skills.HR_RLM_SkillConfig"
+      - "soliplex.config.skills.HR_Analysis_SkillConfig"
   agent_configs:
       - "soliplex.config.agents.AgentConfig"
       - "soliplex.config.agents.FactoryAgentConfig"

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -9,8 +9,8 @@ import yaml
 from bubble_sandbox import config as bs_config
 from bubble_sandbox import models as bs_models
 from haiku.rag import config as hr_config
+from haiku.rag.skills import analysis as hr_skills_analysis
 from haiku.rag.skills import rag as hr_skills_rag
-from haiku.rag.skills import rlm as hr_skills_rlm
 from haiku.skills import models as hs_models
 from pydantic_ai.models import openai as openai_models
 from pydantic_ai.providers import ollama as ollama_providers
@@ -796,13 +796,13 @@ def test_hr_rag_skillconfig_from_yaml(
         assert inst.tool_names == []  # See #773
 
 
-def test_hr_rlm_skillconfig_metadata(
+def test_hr_analysis_skillconfig_metadata(
     installation_config,
     haiku_rag_config,
     lancedb,
     config_path,
 ):
-    inst = config_skills.HR_RLM_SkillConfig(
+    inst = config_skills.HR_Analysis_SkillConfig(
         rag_lancedb_override_path=lancedb,
         _haiku_rag_config=haiku_rag_config,
         _config_path=config_path,
@@ -811,16 +811,16 @@ def test_hr_rlm_skillconfig_metadata(
 
     found = inst.skill_metadata
 
-    assert found.name == "rag-rlm"
+    assert found.name == "rag-analysis"
 
 
-def test_hr_rlm_skillconfig_skill(
+def test_hr_analysis_skillconfig_skill(
     installation_config,
     haiku_rag_config,
     lancedb,
     config_path,
 ):
-    inst = config_skills.HR_RLM_SkillConfig(
+    inst = config_skills.HR_Analysis_SkillConfig(
         rag_lancedb_override_path=lancedb,
         _haiku_rag_config=haiku_rag_config,
         _config_path=config_path,
@@ -830,7 +830,7 @@ def test_hr_rlm_skillconfig_skill(
     found = inst.skill
 
     assert isinstance(found, hs_models.Skill)
-    assert found.metadata == hr_skills_rlm.skill_metadata()
+    assert found.metadata == hr_skills_analysis.skill_metadata()
 
 
 @pytest.mark.parametrize(
@@ -844,7 +844,7 @@ def test_hr_rlm_skillconfig_skill(
         ({}, contextlib.nullcontext(0)),
     ],
 )
-def test_hr_rlm_skillconfig_from_yaml(
+def test_hr_analysis_skillconfig_from_yaml(
     lancedb,
     config_path,
     installation_config,
@@ -859,7 +859,7 @@ def test_hr_rlm_skillconfig_from_yaml(
         warnings.catch_warnings(record=True) as warned,
         expectation as expected,
     ):
-        inst = config_skills.HR_RLM_SkillConfig.from_yaml(
+        inst = config_skills.HR_Analysis_SkillConfig.from_yaml(
             installation_config=installation_config,
             config_path=config_path,
             config_dict=config_dict,
@@ -999,7 +999,7 @@ def test_extractskillconfigs(
                 "rag_lancedb_stem": "test-foo",
             },
             {
-                "kind": "haiku.rag.skills.rlm",
+                "kind": "haiku.rag.skills.analysis",
                 "rag_lancedb_stem": "test-bar",
             },
         ]
@@ -1030,8 +1030,10 @@ def test_extractskillconfigs(
         assert isinstance(found["rag"], config_skills.HR_RAG_SkillConfig)
         assert found["rag"].rag_lancedb_stem == "test-foo"
 
-        assert isinstance(found["rag-rlm"], config_skills.HR_RLM_SkillConfig)
-        assert found["rag-rlm"].rag_lancedb_stem == "test-bar"
+        assert isinstance(
+            found["rag-analysis"], config_skills.HR_Analysis_SkillConfig
+        )
+        assert found["rag-analysis"].rag_lancedb_stem == "test-bar"
 
         assert "skill_configs" not in config_dict
 

--- a/uv.lock
+++ b/uv.lock
@@ -1073,7 +1073,7 @@ wheels = [
 
 [[package]]
 name = "haiku-rag-slim"
-version = "0.40.0"
+version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docling-core" },
@@ -1093,14 +1093,14 @@ dependencies = [
     { name = "watchfiles" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/52/33eb0fdb5377d5d8f555c5067594dc2de8fd36aac713f8e38a83c2380da3/haiku_rag_slim-0.40.0.tar.gz", hash = "sha256:be071827b9596c3df7eb5cf686acab5838291fb5a3d2647749bb189db2772478", size = 115651, upload-time = "2026-04-16T09:42:39.046Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/57/e919d94096eaca08843b4cf9096bd954411f25790e1cdd23190e3110aa9a/haiku_rag_slim-0.42.0.tar.gz", hash = "sha256:36b0ffeed2127e72f30d46694cf47111671452339f828ccc1eb5d4864f3a64d5", size = 117799, upload-time = "2026-04-22T13:19:19.764Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/54/918b3c5aeef86a8b94d52ec95440345f261099a70b460f8fb9050967236c/haiku_rag_slim-0.40.0-py3-none-any.whl", hash = "sha256:843e3087b1e3cce35ad3d7fc537d5dccc40e387cccb72d9d9e6c871572c45117", size = 164436, upload-time = "2026-04-16T09:42:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e7/21463489599a109705fbd1ece639f80f72e4c0372336164f6131e4c5fa30/haiku_rag_slim-0.42.0-py3-none-any.whl", hash = "sha256:15d37a387b8449edcf491ca4d09b4a42f316aa19525666234674d80e8cc3646b", size = 166289, upload-time = "2026-04-22T13:19:18.189Z" },
 ]
 
 [[package]]
 name = "haiku-skills"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -1110,9 +1110,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "skills-ref" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/c4/82a6b82f70726a2e759aad4c6c553309f2cc2ca7f3c157b8a15fd14da709/haiku_skills-0.14.0.tar.gz", hash = "sha256:27074a171060a0ecae6b89c6b7756b3b8ed0dfb957a3f5076ab1d158e68feb82", size = 250637, upload-time = "2026-04-16T08:47:33.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/a1/e2bd00a72d002f9db1c53c068167ed436a457dae0f8996399f116c087f6a/haiku_skills-0.15.0.tar.gz", hash = "sha256:ce93e6846e05397f5d96c144f956edd395b9e7308cb5cef6213c49c183a08bbc", size = 252030, upload-time = "2026-04-22T09:00:13.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/bc53abcbae8bf1aa013379f49f6690fbaff55f80a7b997824103a5f44384/haiku_skills-0.14.0-py3-none-any.whl", hash = "sha256:698d0012bcf06f43499c30aaf6a3b7b772c66737696bfa3f93a6b113fb0f6b17", size = 31613, upload-time = "2026-04-16T08:47:31.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/68/3df2c9761fc0b0592b60f4723c87adeda5f335ea0835b4cf77ca07784379/haiku_skills-0.15.0-py3-none-any.whl", hash = "sha256:a1771b16e0ffe7da775f28d38c704e029f8e8757791616d7f27e73feb2c16fd0", size = 32041, upload-time = "2026-04-22T09:00:12.824Z" },
 ]
 
 [[package]]
@@ -3506,8 +3506,8 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=2.14.0,<2.15" },
     { name = "greenlet" },
-    { name = "haiku-rag-slim", specifier = ">=0.40.0,<0.41" },
-    { name = "haiku-skills", specifier = ">=0.14.0,<0.15" },
+    { name = "haiku-rag-slim", specifier = ">=0.42.0,<0.43" },
+    { name = "haiku-skills", specifier = ">=0.15.0,<0.16" },
     { name = "itsdangerous" },
     { name = "jsonpatch" },
     { name = "jwcrypto" },

--- a/uv.lock
+++ b/uv.lock
@@ -1073,7 +1073,7 @@ wheels = [
 
 [[package]]
 name = "haiku-rag-slim"
-version = "0.42.0"
+version = "0.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docling-core" },
@@ -1093,9 +1093,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/57/e919d94096eaca08843b4cf9096bd954411f25790e1cdd23190e3110aa9a/haiku_rag_slim-0.42.0.tar.gz", hash = "sha256:36b0ffeed2127e72f30d46694cf47111671452339f828ccc1eb5d4864f3a64d5", size = 117799, upload-time = "2026-04-22T13:19:19.764Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a7/5c8647d7464baf943e9ebc2e8ab00e60798184dc2c97820b1865af4161da/haiku_rag_slim-0.42.1.tar.gz", hash = "sha256:f9e1fafa89aa45d8db6092f0b6bfb41ff69b65520cb31480c7d255ce212e7a90", size = 117803, upload-time = "2026-04-22T14:00:36.705Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e7/21463489599a109705fbd1ece639f80f72e4c0372336164f6131e4c5fa30/haiku_rag_slim-0.42.0-py3-none-any.whl", hash = "sha256:15d37a387b8449edcf491ca4d09b4a42f316aa19525666234674d80e8cc3646b", size = 166289, upload-time = "2026-04-22T13:19:18.189Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/5b/bf5249a5865a89f2052be8ad009bf54283d7056662e000aa06a2fceab394/haiku_rag_slim-0.42.1-py3-none-any.whl", hash = "sha256:3e7ee3a81800cb9d7b912c8466817c72998433e1600be6494651a11cb53297a2", size = 166281, upload-time = "2026-04-22T14:00:35.166Z" },
 ]
 
 [[package]]
@@ -3506,7 +3506,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=2.14.0,<2.15" },
     { name = "greenlet" },
-    { name = "haiku-rag-slim", specifier = ">=0.42.0,<0.43" },
+    { name = "haiku-rag-slim", specifier = ">=0.42.1,<0.43" },
     { name = "haiku-skills", specifier = ">=0.15.0,<0.16" },
     { name = "itsdangerous" },
     { name = "jsonpatch" },


### PR DESCRIPTION
haiku.rag 0.41 renames the RLM skill to the Analysis skill across every layer of its public API: module path (`skills.rlm` -> `skills.analysis`), skill entrypoint (`rag-rlm` -> `rag-analysis`), YAML kind (`haiku.rag.skills.rlm` -> `haiku.rag.skills.analysis`), and state namespace (`rlm` -> `analysis`).

This updates soliplex's `HR_RLM_SkillConfig` to `HR_Analysis_SkillConfig` and propagates the rename through source, tests, docs, example YAMLs, and the generated `schemas/schema.json`.

haiku.rag 0.42 moves the skill lifecycle onto the `haiku.skills>=0.15.0` `lifespan` hook — one `HaikuRAG` client per invocation, state scoped to the current turn, and sandbox variables persisted across `execute_code` calls within a single invocation. The state schema shape is unchanged, so `schemas/schema.json` is identical between 0.41 and 0.42. This PR also bumps `haiku-skills` to `>= 0.15.0, < 0.16`, required by 0.42's lifespan hook.

Also:

- `search.max_context_items` was removed in haiku.rag 0.41; drop from `example/haiku.rag.yaml`.

- `image-generation` is dropped from `scripts/generate_feature_schemas.sh` since it requires the optional `haiku-skills-image-generation` package and previously emitted a null entry when absent; put it back in the jq expression if you want it in the schema.

The RAG skill state shape also changed in 0.41 (`qa_history` / `reports` removed; `citation_index` / `citations` added); the new shape is reflected in the regenerated schema and will flow through to Flutter in a follow-up PR.
