### PR TITLE
fix: use view function name to look up route

### DIFF
--- a/src/soliplex/views/file_uploads.py
+++ b/src/soliplex/views/file_uploads.py
@@ -64,7 +64,8 @@ async def get_uploads_room(
             if file_or_sub.is_file():
                 filename = file_or_sub.name
                 filename_urls[filename] = request.url_for(
-                    "/v1/uploads/{room_id}/{filename}",
+                    # View function name, not the route path.
+                    "get_uploads_room_filename",
                     room_id=room_id,
                     filename=filename,
                 )
@@ -74,7 +75,7 @@ async def get_uploads_room(
         uploads=[
             models.FileUpload(
                 filename=key,
-                url=value,
+                url=str(value),  # The two URL types are not compatible
             )
             for key, value in filename_urls.items()
         ],
@@ -230,7 +231,8 @@ async def get_uploads_room_thread(
             if file_or_sub.is_file():
                 filename = file_or_sub.name
                 filename_urls[filename] = request.url_for(
-                    "/v1/uploads/{room_id}/{thread_id}/{filename}",
+                    # View function name, not the route path.
+                    "get_uploads_room_thread_filename",
                     room_id=room_id,
                     thread_id=thread_id,
                     filename=filename,
@@ -242,7 +244,7 @@ async def get_uploads_room_thread(
         uploads=[
             models.FileUpload(
                 filename=key,
-                url=value,
+                url=str(value),  # The two URL types are not compatible
             )
             for key, value in filename_urls.items()
         ],

--- a/tests/unit/views/test_file_uploads.py
+++ b/tests/unit/views/test_file_uploads.py
@@ -82,7 +82,9 @@ async def test_get_uploads_room_only(
 ):
     room_uploads_path = uploads_path / "rooms"
     room_path = room_uploads_path / TEST_ROOM_ID
-    ROUTE_NAME = "/v1/uploads/{room_id}/{filename}"
+    # Note: this is the name of the view function, and not the path
+    #       to which it is bound.
+    ROUTE_NAME = "get_uploads_room_filename"
 
     def download_url(name, room_id, filename):
         assert name == ROUTE_NAME
@@ -355,7 +357,9 @@ async def test_get_uploads_room_thread_only(
 ):
     thread_uploads_path = uploads_path / "threads"
     thread_path = thread_uploads_path / str(TEST_THREAD_ID)
-    ROUTE_NAME = "/v1/uploads/{room_id}/{thread_id}/{filename}"
+    # Note: this is the name of the view function, and not the path
+    #       to which it is bound.
+    ROUTE_NAME = "get_uploads_room_thread_filename"
 
     def download_url(name, room_id, thread_id, filename):
         assert name == ROUTE_NAME


### PR DESCRIPTION
... not the route path.

fix: convert between incompatible URL types.

Closes #907.