### PR TITLE
feat: symlink '/var/empty' into room/thread volumes if missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "ag-ui-protocol >= 0.1.15, < 0.2",
     "aiosqlite",
     "authlib",
-    "bubble-sandbox >= 0.3.0, < 0.4",
+    "bubble-sandbox >= 0.5.0, < 0.6",
     "fastapi",
     "fastmcp >= 2.14.0, < 2.15",
     "fakeredis != 2.35.0",  # brownbag

--- a/src/soliplex/skills/bwrap_sandbox/__init__.py
+++ b/src/soliplex/skills/bwrap_sandbox/__init__.py
@@ -91,6 +91,7 @@ async def skill_execute(
     workdir: pathlib.Path | None = None,
     timeout: float = None,  # seconds
     extra_volumes: bs_models.VolumeMap = None,
+    extra_args: list[str] = None,
 ) -> str:
     """Execute a shell command in the working directory.
 
@@ -112,6 +113,7 @@ async def skill_execute(
             workdir=workdir,
             timeout=timeout,
             extra_volumes=extra_volumes,
+            extra_args=extra_args,
         )
     except RuntimeError as e:
         return f"Error: {e}"
@@ -158,6 +160,7 @@ async def skill_execute_script(
     workdir: pathlib.Path | None = None,
     timeout: float = None,  # seconds
     extra_volumes: bs_models.VolumeMap = None,
+    extra_args: list[str] = None,
 ) -> str:
     """Execute a python script in the working directory.
 
@@ -176,6 +179,7 @@ async def skill_execute_script(
             workdir=workdir,
             timeout=timeout,
             extra_volumes=extra_volumes,
+            extra_args=extra_args,
         )
     except RuntimeError as e:
         return f"Error: {e}"
@@ -210,26 +214,38 @@ def get_extra_volumes(
     threads_upload_path: pathlib.Path | None,
     room_id: str,
     thread_id: str,
-):
-    result = {}
+) -> tuple[dict[str, bs_models.VolumeInfo], list[str]]:
+    volume_map = {}
+    extra_args = [
+        # empty room uploads dir
+        "--symlink",
+        "/var/empty",
+        f"/sandbox/volumes/room/{room_id}",
+        # empty thread uploads dir
+        "--symlink",
+        "/var/empty",
+        f"/sandbox/volumes/thread/{thread_id}",
+    ]
 
     if rooms_upload_path is not None:
         room_dir = rooms_upload_path / room_id
         if room_dir.exists():
-            result["room"] = bs_models.VolumeInfo(
+            volume_map["room"] = bs_models.VolumeInfo(
                 host_path=room_dir,
                 writable=False,
             )
+            del extra_args[0:3]
 
     if threads_upload_path is not None:
         thread_dir = threads_upload_path / str(thread_id)
         if thread_dir.exists():
-            result["thread"] = bs_models.VolumeInfo(
+            volume_map["thread"] = bs_models.VolumeInfo(
                 host_path=thread_dir,
                 writable=False,
             )
+            del extra_args[-3:]
 
-    return result
+    return volume_map, extra_args
 
 
 def create_sandbox_toolset(
@@ -310,7 +326,7 @@ def create_sandbox_toolset(
             state.run_id or "",
         )
 
-        extra_volumes = get_extra_volumes(
+        extra_volumes, extra_args = get_extra_volumes(
             rooms_upload_path,
             threads_upload_path,
             state.room_id or "",
@@ -324,6 +340,7 @@ def create_sandbox_toolset(
             workdir=workdir,
             timeout=timeout,
             extra_volumes=extra_volumes,
+            extra_args=extra_args,
         )
 
     @toolset.tool(description=EXECUTE_SCRIPT_DESCRIPTION)
@@ -341,7 +358,7 @@ def create_sandbox_toolset(
             state.run_id or "",
         )
 
-        extra_volumes = get_extra_volumes(
+        extra_volumes, extra_args = get_extra_volumes(
             rooms_upload_path,
             threads_upload_path,
             state.room_id or "",
@@ -355,6 +372,7 @@ def create_sandbox_toolset(
             workdir=workdir,
             timeout=timeout,
             extra_volumes=extra_volumes,
+            extra_args=extra_args,
         )
 
     return toolset

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -1,3 +1,4 @@
+import itertools
 import pathlib
 import uuid
 from unittest import mock
@@ -158,6 +159,7 @@ async def test_skill_execute_w_errors_truncation(
         workdir=None,
         timeout=None,
         extra_volumes=None,
+        extra_args=None,
     )
 
 
@@ -176,6 +178,9 @@ async def test_skill_execute_w_errors_truncation(
                 ),
             },
         },
+        {
+            "extra_args": ["--foo", 1],
+        },
     ],
 )
 @pytest.mark.parametrize(
@@ -185,7 +190,7 @@ async def test_skill_execute_w_errors_truncation(
         (["/bin/true"], ["/bin/true"]),
     ],
 )
-async def test_skill_execute_w_extra_args(
+async def test_skill_execute_w_non_default_args(
     ctx_w_deps,
     bwrap_sandbox,
     w_command,
@@ -213,6 +218,7 @@ async def test_skill_execute_w_extra_args(
         "workdir": None,
         "timeout": None,
         "extra_volumes": None,
+        "extra_args": None,
     } | w_kw
 
     bwrap_sandbox.execute.assert_awaited_once_with(
@@ -263,6 +269,7 @@ async def test_skill_execute_script_w_errors_truncation(
         workdir=None,
         timeout=None,
         extra_volumes=None,
+        extra_args=None,
     )
 
 
@@ -281,9 +288,12 @@ async def test_skill_execute_script_w_errors_truncation(
                 ),
             },
         },
+        {
+            "extra_args": ["--foo", 1],
+        },
     ],
 )
-async def test_skill_execute_script_w_extra_args(
+async def test_skill_execute_script_w_non_default_args(
     ctx_w_deps,
     bwrap_sandbox,
     w_kw,
@@ -309,6 +319,7 @@ async def test_skill_execute_script_w_extra_args(
         "workdir": None,
         "timeout": None,
         "extra_volumes": None,
+        "extra_args": None,
     } | w_kw
 
     bwrap_sandbox.execute_script.assert_awaited_once_with(
@@ -347,17 +358,22 @@ def test_get_extra_volumes(
     w_room_path,
     w_thread_path,
 ):
-    expected = {}
+    exp_volume_map = {}
+    exp_symlinks = [
+        ("--symlink", "/var/empty", f"/sandbox/volumes/room/{ROOM_ID}"),
+        ("--symlink", "/var/empty", f"/sandbox/volumes/thread/{THREAD_ID}"),
+    ]
 
     if w_room_path is not None:
         ru_path = rooms_upload_path
         if w_room_path:
             room_path = ru_path / ROOM_ID
             room_path.mkdir(parents=True)
-            expected["room"] = bs_models.VolumeInfo(
+            exp_volume_map["room"] = bs_models.VolumeInfo(
                 host_path=room_path,
                 writable=False,
             )
+            exp_symlinks.pop(0)
     else:
         ru_path = None
 
@@ -366,12 +382,16 @@ def test_get_extra_volumes(
         if w_thread_path:
             thread_path = tu_path / str(THREAD_ID)
             thread_path.mkdir(parents=True)
-            expected["thread"] = bs_models.VolumeInfo(
+            exp_volume_map["thread"] = bs_models.VolumeInfo(
                 host_path=thread_path,
                 writable=False,
             )
+            exp_symlinks.pop(-1)
     else:
         tu_path = None
+
+    exp_extra_args = list(itertools.chain(*exp_symlinks))
+    expected = (exp_volume_map, exp_extra_args)
 
     found = skills_bwrap_sandbox.get_extra_volumes(
         ru_path,
@@ -496,6 +516,8 @@ async def test_create_sandbox_toolset_execute(
     else:
         toolset = skills_bwrap_sandbox.create_sandbox_toolset()
 
+    volume_map, extra_args = gev.return_value = ({"foo": object()}, ["--bar"])
+
     sandbox = bs_klass.return_value
     tool = toolset.tools["execute"]
 
@@ -511,7 +533,8 @@ async def test_create_sandbox_toolset_execute(
         "environment_name": None,
         "timeout": None,
         "workdir": gw.return_value,
-        "extra_volumes": gev.return_value,
+        "extra_volumes": volume_map,
+        "extra_args": extra_args,
     } | w_kw
 
     skill_execute.assert_called_once_with(
@@ -582,6 +605,8 @@ async def test_create_sandbox_toolset_execute_script(
     else:
         toolset = skills_bwrap_sandbox.create_sandbox_toolset()
 
+    volume_map, extra_args = gev.return_value = ({"foo": object()}, ["--bar"])
+
     sandbox = bs_klass.return_value
     tool = toolset.tools["execute_script"]
 
@@ -597,7 +622,8 @@ async def test_create_sandbox_toolset_execute_script(
         "environment_name": None,
         "timeout": None,
         "workdir": gw.return_value,
-        "extra_volumes": gev.return_value,
+        "extra_volumes": volume_map,
+        "extra_args": extra_args,
     } | w_kw
 
     skill_execute_script.assert_called_once_with(

--- a/uv.lock
+++ b/uv.lock
@@ -304,7 +304,7 @@ wheels = [
 
 [[package]]
 name = "bubble-sandbox"
-version = "0.3.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-backend" },
@@ -312,9 +312,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/24/7c9f559622e4ce24e48c386508c5c4407891c1d730a84c91cb80750d8a6f/bubble_sandbox-0.3.0.tar.gz", hash = "sha256:5c6d3e95f862adb3c6a5c0c2f0cd91535c2037c306fcbef170fca92befaa01a6", size = 7649, upload-time = "2026-04-13T22:02:56.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/a1/8db13b5b299dc69963641035ad967ab6fe2cdc399e846c743f152a380f9e/bubble_sandbox-0.5.0.tar.gz", hash = "sha256:1141c38ba3a25be079698f4161b753bc14f64b127732af30e7100b1dfd5215c2", size = 7710, upload-time = "2026-04-20T17:50:22.321Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/d2/0eaaadae34511a78926515fce21a36046c1a3eaa1a08709000fc7bf562bd/bubble_sandbox-0.3.0-py3-none-any.whl", hash = "sha256:33a78a2f84ac1dc76d1dce9f6acb023b1adf81513dbff0b06d9d1b876e54896e", size = 9607, upload-time = "2026-04-13T22:02:55.335Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/53/90a41854a170955cf9a7f583771b3f27faff8cd53b37d5c6760ac0ee514a/bubble_sandbox-0.5.0-py3-none-any.whl", hash = "sha256:692c9ca83e88a5228724036061bb3888f1ae29394edae20f958c4af5b7654e30", size = 9660, upload-time = "2026-04-20T17:50:21.349Z" },
 ]
 
 [[package]]
@@ -3500,7 +3500,7 @@ requires-dist = [
     { name = "ag-ui-protocol", specifier = ">=0.1.15,<0.2" },
     { name = "aiosqlite" },
     { name = "authlib" },
-    { name = "bubble-sandbox", specifier = ">=0.3.0,<0.4" },
+    { name = "bubble-sandbox", specifier = ">=0.5.0,<0.6" },
     { name = "certifi", specifier = ">=2025.11.12" },
     { name = "fakeredis", specifier = "!=2.35.0" },
     { name = "fastapi" },


### PR DESCRIPTION
chore: bump 'bubble-sandbox >= 0.5.0, < 0.6'

- Ensure '/var/empty' is present in sandbox (0.4.0).

- Pass 'extra_args' to 'BwrapSandbox.execute{,_script}' (0.5.0)

Closes #906.