### PR TITLE
fix: ensure 'room'/'thread' sandbox volume dirs exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "ag-ui-protocol >= 0.1.16, < 0.1.18",
     "aiosqlite",
     "authlib",
-    "bubble-sandbox >= 0.3.0, < 0.4",
+    "bubble-sandbox >= 0.6.0, < 0.7",
     "fastapi",
     "fastmcp >= 2.14.0, < 2.15",
     "fakeredis != 2.35.0",  # brownbag

--- a/src/soliplex/skills/bwrap_sandbox/__init__.py
+++ b/src/soliplex/skills/bwrap_sandbox/__init__.py
@@ -220,12 +220,22 @@ def get_extra_volumes(
                 host_path=room_dir,
                 writable=False,
             )
+        else:
+            result["room"] = bs_models.VolumeInfo(
+                host_path=None,
+                writable=False,
+            )
 
     if threads_upload_path is not None:
         thread_dir = threads_upload_path / str(thread_id)
         if thread_dir.exists():
             result["thread"] = bs_models.VolumeInfo(
                 host_path=thread_dir,
+                writable=False,
+            )
+        else:
+            result["thread"] = bs_models.VolumeInfo(
+                host_path=None,
                 writable=False,
             )
 

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -358,6 +358,11 @@ def test_get_extra_volumes(
                 host_path=room_path,
                 writable=False,
             )
+        else:
+            expected["room"] = bs_models.VolumeInfo(
+                host_path=None,
+                writable=False,
+            )
     else:
         ru_path = None
 
@@ -368,6 +373,11 @@ def test_get_extra_volumes(
             thread_path.mkdir(parents=True)
             expected["thread"] = bs_models.VolumeInfo(
                 host_path=thread_path,
+                writable=False,
+            )
+        else:
+            expected["thread"] = bs_models.VolumeInfo(
+                host_path=None,
                 writable=False,
             )
     else:

--- a/uv.lock
+++ b/uv.lock
@@ -304,7 +304,7 @@ wheels = [
 
 [[package]]
 name = "bubble-sandbox"
-version = "0.3.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-backend" },
@@ -312,9 +312,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/24/7c9f559622e4ce24e48c386508c5c4407891c1d730a84c91cb80750d8a6f/bubble_sandbox-0.3.0.tar.gz", hash = "sha256:5c6d3e95f862adb3c6a5c0c2f0cd91535c2037c306fcbef170fca92befaa01a6", size = 7649, upload-time = "2026-04-13T22:02:56.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/66/72edf42dacb03eb4dfc9f66f111de43a4ed72ac39f759bbff37aae97ad49/bubble_sandbox-0.6.0.tar.gz", hash = "sha256:108b01bdce4dfb7765030849e128e3201393678ff17cab5cd5930da1ff581ca7", size = 8205, upload-time = "2026-04-21T18:07:39.125Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/d2/0eaaadae34511a78926515fce21a36046c1a3eaa1a08709000fc7bf562bd/bubble_sandbox-0.3.0-py3-none-any.whl", hash = "sha256:33a78a2f84ac1dc76d1dce9f6acb023b1adf81513dbff0b06d9d1b876e54896e", size = 9607, upload-time = "2026-04-13T22:02:55.335Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/25d59b413410d3e4603de2b6ed2d0168b57ddfdd69b4ff257e92cf0fc5de/bubble_sandbox-0.6.0-py3-none-any.whl", hash = "sha256:bb70c6dd566cd2c36c01867a18afb3e500b88c799d18efbd8238a55773110aa3", size = 10216, upload-time = "2026-04-21T18:07:38.282Z" },
 ]
 
 [[package]]
@@ -3500,7 +3500,7 @@ requires-dist = [
     { name = "ag-ui-protocol", specifier = ">=0.1.16,<0.1.18" },
     { name = "aiosqlite" },
     { name = "authlib" },
-    { name = "bubble-sandbox", specifier = ">=0.3.0,<0.4" },
+    { name = "bubble-sandbox", specifier = ">=0.6.0,<0.7" },
     { name = "certifi", specifier = ">=2025.11.12" },
     { name = "fakeredis", specifier = "!=2.35.0" },
     { name = "fastapi" },


### PR DESCRIPTION
  If the host path is not a directory, pass 'None' for the volume
  'host_path', so that the sandbox creates it as empty.

chore: bump 'bubble-sandbox >= 0.6.0, < 0.7

  Pick up ability to pass 'None' for a volume's 'host_path' as a signal
  that the sandbox should have the target as an empty directory.

Closes #906.

Supersedes PR #910.