### PR TITLE
docs: configuration docs cleanup [ci skip]

### DIFF
--- a/docs/config/agents.md
+++ b/docs/config/agents.md
@@ -8,7 +8,6 @@ type is used:
 |---------------|-------------|
 | `"default"`   | Pydantic AI agent with direct LLM access (default) |
 | `"factory"`   | Agent created by a custom Python callable |
-| `"haiku_chat"`| Conversational RAG agent powered by `haiku.rag` |
 
 When `kind` is omitted, it defaults to `"default"`.
 
@@ -40,6 +39,11 @@ agent:
 - `system_prompt` is the "instructions" for the LLM serving the room.
   If it starts with a `./`, it will be treated as a filename in the
   same directory, whose contents will be read in its place.
+
+**Template exception:** When an agent config uses `template_id` to
+inherit from an entry in the installation-level `agent_configs`, both
+`model_name` and `system_prompt` may be omitted locally -- they will be
+supplied by the template.  Any fields set locally override the template.
 
 A minimal configuration, without an external prompt file:
 
@@ -94,6 +98,22 @@ agent:
 
 - `model_settings`: a mapping, whose keys are determined by
   the `provider_type` above (see below).
+
+- `retries` (an integer, default `3`):  number of retries for LLM calls
+  on recoverable errors.
+
+  **NOTE**: this value is stored on the agent configuration and is
+            returned via the public API, but is not currently applied
+            at agent construction time.  See
+            <https://github.com/soliplex/soliplex/issues/926>.
+
+- `agui_feature_names` (a list of strings, default empty):  AG-UI feature
+  names this agent contributes to the room's aggregate feature set.  Each
+  name must be registered in the AG-UI feature registry (typically via a
+  skill or via an entry under `meta.agui_features`; see
+  [meta.md](meta.md#registering-ag-ui-feature-classes)).  The room's
+  effective feature set is the union of features declared on the agent,
+  the room, its tools, and its skills.
 
 ### Example Ollama Configuration
 
@@ -180,6 +200,14 @@ agent:
   passed through to the factory.  The structure is determined by the
   factory implementation.
 
+- `agui_feature_names` (a list of strings, default empty):  AG-UI feature
+  names this agent contributes to the room's aggregate feature set.  Each
+  name must be registered in the AG-UI feature registry (typically via a
+  skill or via an entry under `meta.agui_features`; see
+  [meta.md](meta.md#registering-ag-ui-feature-classes)).  The room's
+  effective feature set is the union of features declared on the agent,
+  the room, its tools, and its skills.
+
 ### Example
 
 ```yaml
@@ -188,41 +216,7 @@ agent:
   factory_name: "mypackage.agents.build_agent"
   with_agent_config: true
   extra_config:
+    # Additional arguments passed to the factory function
     temperature: 0.8
     max_retries: 5
-```
-
-### haiku.rag Configuration
-
-The LLM model, search settings, and other RAG behavior are controlled
-via haiku.rag's own configuration, not via the agent config.  See the
-[haiku.rag configuration page](rag.md) for details.
-
-A room directory may contain a `haiku.rag.yaml` file whose settings
-override the installation-level haiku.rag configuration for that room.
-
-### Example
-
-A full-featured room using `haiku_chat`:
-
-```yaml
-agent:
-  kind: "haiku_chat"
-  rag_lancedb_stem: "rag"
-  rag_features: ["search", "documents", "qa"]
-  preamble: |
-    You are a knowledgeable assistant that answers questions
-    using a document knowledge base.
-  background_context: |
-    This knowledge base contains internal documentation
-    about the Soliplex platform.
-```
-
-A minimal search-only room:
-
-```yaml
-agent:
-  kind: "haiku_chat"
-  rag_lancedb_stem: "rag"
-  rag_features: ["search"]
 ```

--- a/docs/config/installation.md
+++ b/docs/config/installation.md
@@ -164,7 +164,7 @@ oidc_paths:
 Non-absolute paths will be evaluated relative to the installation directory.
 
 By default, Soliplex loads provider configurations found under the path
-'./oicd', just as though we had configured:
+'./oidc', just as though we had configured:
 
 ```yaml
 oidc_paths:
@@ -282,8 +282,8 @@ Each path can be either:
 - a directory containing its own `completion_config.yaml` file:  this
   directory will be mapped as a single completion.
 
-- a directory whose immediate subdirectories will be treated as rooms
-  IFF they contain a `room_config.yaml` file.
+- a directory whose immediate subdirectories will be treated as
+  completions IFF they contain a `completion_config.yaml` file.
 
 Non-absolute paths will be evaluated relative to the installation directory.
 
@@ -308,4 +308,4 @@ completion_paths:
 
 ## Logfire Configuration
 
-See the [Solipex logfire configuration](logfire.md) page.
+See the [Soliplex logfire configuration](logfire.md) page.

--- a/docs/config/logging.md
+++ b/docs/config/logging.md
@@ -79,7 +79,7 @@ logging_headers_map:
 
 ## Configure Logging `extra` Values from OIDC Claims
 
-OIDC cliams values may be useful in logging:  for instance,
+OIDC claims values may be useful in logging:  for instance,
 we might want to display that `email` claim of the authenticated user
 in a formatted log record.
 

--- a/docs/config/meta.md
+++ b/docs/config/meta.md
@@ -123,7 +123,7 @@ we configured explicitly:
 
 ```yaml
 meta:
-  tool_configs:
+  agent_configs:
   - "soliplex.config.AgentConfig"
 ```
 

--- a/docs/config/rooms.md
+++ b/docs/config/rooms.md
@@ -83,8 +83,28 @@ A minimal room configuration must include the above elements, e.g.:
   ```
 
 - `agui_feature_names` (list of strings); if set these values are added
-  to the feature names defined on the individual tools to create an
-  aggregate set for the room.
+  to the feature names defined on the room's agent, tools, and skills
+  to create an aggregate set for the room.
+
+- `logo_image` (a string, default unset) is a path to an image file that
+  the UI can display as the room's logo.  Relative paths are resolved
+  against the room's configuration directory.  The image is served via
+  the `/v1/rooms/{room_id}/image` endpoint.  E.g.:
+
+  ```yaml
+  logo_image: "./logo.png"
+  ```
+
+- `_order` (a string, default unset) overrides the sort key used when
+  listing rooms.  When unset, rooms are sorted by their `id`.  This is
+  an advanced escape hatch -- note the leading underscore in the YAML
+  key, which is deliberate to mark it as an internal override rather
+  than a normal user-facing option.  E.g., to make a room appear first
+  in a list regardless of its `id`:
+
+  ```yaml
+  _order: "000-welcome"
+  ```
 
 ### Agent configuration
 

--- a/docs/config/skills.md
+++ b/docs/config/skills.md
@@ -28,7 +28,7 @@ Discovered filesystem skills can be queried using the
 
 ## Configuring Entrypoint Skills
 
-Entrypoint skills are loaded automatically.  There is currently n
+Entrypoint skills are loaded automatically.  There is currently no
 option to configure or suppress this feature.
 
 Discovered entrypoint skills can be queried using the


### PR DESCRIPTION
- Document 'RoomConfig.{logo_image,_order}'.

- Drop mention of long-removed 'haiku_chat' agent kind.

- Note that 'AgentConfig.{model_name,system_prompt}' are allowed to be omitted to serve the case of defining an agent config as an overlay on a "template" agent config.  Once the overlay has been applied, both fields should be set in order for the agent config to be useful.

- Clarify semantics for 'agui_feature_names' on both agent and room configs.

- Document the 'AgentConfig.retries' field as intended, but note the issue that it is not wired up: https://github.com/soliplex/soliplex/issues/926

- Fix typos, copy-pasta.