### PR TITLE
chore: bump 'bubble-sandbox >= 0.8.0, < 0.9'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "ag-ui-protocol >= 0.1.16, < 0.1.18",
     "aiosqlite",
     "authlib",
-    "bubble-sandbox >= 0.7.0, < 0.8",
+    "bubble-sandbox >= 0.8.0, < 0.9",
     "fastapi",
     "fastmcp >= 2.14.0, < 2.15",
     "fakeredis != 2.35.0",  # brownbag

--- a/uv.lock
+++ b/uv.lock
@@ -304,7 +304,7 @@ wheels = [
 
 [[package]]
 name = "bubble-sandbox"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-backend" },
@@ -312,9 +312,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/94/d1dc702863b56c8c22b657f5d5244bc7c0a7c0501eda27267bbbc6002905/bubble_sandbox-0.7.0.tar.gz", hash = "sha256:0a1693c4c197ad75474538e0adaf52cb5b79a1c4bf5254b9f938d3829e22d62e", size = 8278, upload-time = "2026-04-21T23:08:28.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/ec/6c28d4b9a6e0e38b4a318aea486be8a1390af75fa8f4f42ce0864bbda0f1/bubble_sandbox-0.8.0.tar.gz", hash = "sha256:6b1a2d86222037c8bb14bcbd5bd68bae2f49d60208d23d0c840f70b9b56c0595", size = 8528, upload-time = "2026-04-23T05:07:54.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/52/db15787e7b3810e9f8e2877d9bc7550a58d05edab6b722910e552e03cf22/bubble_sandbox-0.7.0-py3-none-any.whl", hash = "sha256:fdb60b142e55ad4e0e8bbf995776bb08612abadf30da7c90e27a77ec632da77a", size = 10251, upload-time = "2026-04-21T23:08:27.551Z" },
+    { url = "https://files.pythonhosted.org/packages/60/da/a00394cee5bfcc4160ac425366fd37d5a816023ecffa1000eba5575b6271/bubble_sandbox-0.8.0-py3-none-any.whl", hash = "sha256:c2612ffcbb95e2c97dc7124ce759608af77825709d8c158abbe29338e2c76c8c", size = 10496, upload-time = "2026-04-23T05:07:53.555Z" },
 ]
 
 [[package]]
@@ -3500,7 +3500,7 @@ requires-dist = [
     { name = "ag-ui-protocol", specifier = ">=0.1.16,<0.1.18" },
     { name = "aiosqlite" },
     { name = "authlib" },
-    { name = "bubble-sandbox", specifier = ">=0.7.0,<0.8" },
+    { name = "bubble-sandbox", specifier = ">=0.8.0,<0.9" },
     { name = "certifi", specifier = ">=2025.11.12" },
     { name = "fakeredis", specifier = "!=2.35.0" },
     { name = "fastapi" },


### PR DESCRIPTION
Pick up '--agent-mode' option for 'bubble-wrap' subcommands, stripping extraneous console output and returning JSON from 'list-environments'.