### PR TITLE
refactor: tune `bwrap-sandbox` skill prompt FBO smaller models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "ag-ui-protocol >= 0.1.16, < 0.1.18",
     "aiosqlite",
     "authlib",
-    "bubble-sandbox >= 0.8.0, < 0.9",
+    "bubble-sandbox >= 0.9.0, < 0.10",
     "fastapi",
     "fastmcp >= 2.14.0, < 2.15",
     "fakeredis != 2.35.0",  # brownbag

--- a/src/soliplex/skills/bwrap_sandbox/SKILL.md
+++ b/src/soliplex/skills/bwrap_sandbox/SKILL.md
@@ -1,102 +1,163 @@
 ---
 name: bwrap-sandbox
 description: |
-    Write and execute Python code (and shell commands) in a bubblewrap
+    This skill runs Python in a bubblewrap
     sandbox. Each run has a persistent working directory and read-only
     access to uploaded files mounted under '/sandbox/volumes'.
 ---
 
 # Sandbox
 
-You are a coding agent with access to a bubblewrap sandbox running
-Python. Use it to do real computation — data analysis, file
-processing, calculations, running scripts — rather than guessing
-answers or describing what code *would* do.
+This skill runs Python in a bubblewrap sandbox.
+Use it to compute results from files.
 
 ## When to use the sandbox
 
-Reach for the sandbox when the task involves:
+Use the sandbox if **any** of these is true:
 
-- Computing a value from data (aggregations, transformations,
-  statistics, derived metrics).
-- Reading, parsing, or summarizing files the user has uploaded.
-- Running Python to verify a claim before stating it as fact.
+- The task references one or mor files uploaded
+  under `sandbox/volumes/thread` or `sandbox/volumes/room`.
+- The task asks for a number, count, table, or other value derived from data.
+- You were about to state a computed result without actually computing it.
 
-Do NOT use the sandbox for questions you can answer directly from
-context (definitions, explanations, looking up something already
-stated in the conversation).
+Do NOT use the sandbox if **any** of these is true:
+
+- The question is about definitions, explanations, or concepts.
+- The answer is a already stated in the conversation.
+- The task is to write code for the user to run, not to execute code yourself.
+- The task is value ("analyze the files", "take a look")
+  with no concrete question. Ask the user what they want to know
+  before running anything.
 
 ## Sandbox file layout
 
-- **Working directory** — `/sandbox/work/` (read/write). Scripts run
-  here. Files written here persist across tool calls within the same
-  run, so you can build on earlier outputs.
-- **Mounted volumes** — `/sandbox/volumes/<name>/` (read-only). The
-  common ones are:
-  - `/sandbox/volumes/thread/` — files the user uploaded to this
-    thread. These are usually the inputs for the task.
-  - `/sandbox/volumes/room/` — files shared across the room. Often
-    contain instructions, reference data, formulas, or business rules
-    that must be applied to answer correctly.
-  - Other named volumes may be present depending on configuration.
+- `/sandbox/work/` — read/write scratch space inside the sandbox.
+  Intermediate artifacts written by a script go here.
+- `/sandbox/volumes/thread/` —  read-only;
+  files the user uploaded to this thread. Usually the inputs for the task.
+- `/sandbox/volumes/room/` — read-only;
+  files shared across the room. Often contain rules, formulas,
+  or reference data required for a correct answer.
 
 ## Tools
 
-- **`list_environments`** — returns available Python environments,
-  each with a `name` and `description`. Call this once at the start
-  if you might need third-party packages, so you can pick the right
-  one.
-- **`execute_script`** — runs a Python script string. This is your
-  primary tool. Pass `environment_name` to select a non-default
-  environment.
-- **`execute`** — runs a shell command. Use only when you need shell
-  functionality: package listing, git, file manipulation with
-  system tools, running non-Python executables.
+- `list_environments()` — returns available Python environments,
+  each with a `name`, `description`, and set of installed `dependencies`.
+- `list_volume_files(volume_name)` — returns a list of absolue paths of files
+  within the given volume (`"thread"` or `"room"`).
+- `run(environment, *command_args)` — run a an arbitrary shell command
+   in the sandbox.
+- `run_python(environment, script_text)` — run a Python script string.
 
 ## Workflow
 
-1. **Pick an environment.** When first using the sandbox,
-   call `list_environments` to get information on the available
-   environments, If the task needs third-party packages,
-   choose the one whose description and dependencies match
-   task. Pass its `name` as `environment_name` to
-   `execute_script`.
-
-2. **Discover inputs — only if the task involves uploaded files.**
-   List what is in the relevant volume(s) first; do not dump full
-   file contents blindly. For example:
+1. **Pick an environment.** Run `list_environments`, which returns a list
+   of dictionaries shaped like:
 
    ```python
-   import pathlib
-   for vol in ['/sandbox/volumes/room', '/sandbox/volumes/thread']:
-       p = pathlib.Path(vol)
-       if p.exists():
-           for f in sorted(p.rglob('*')):
-               if f.is_file():
-                   print(f, f.stat().st_size)
+   {
+      "name": "bare",
+      "description": "Minimal Python",
+      "dependencies": ["pandas"],
+   }
    ```
 
-   Then read specific files you actually need. Always check the
-   `/sandbox/volumes/room` volume too — it may contain rules
-   or formulas required for a correct answer, not just the obvious
-   `thread` inputs.
+   Apply these rules in order:
+   - If the list is empty, stop and tell the user the skill
+     is not configured — do not proceed.
+   - If the list contains exactly one environment, use its `name`.
+   - Otherwise, pick the `name` of the first environment whose `dependencies`
+     include a library the task needs (e.g, `pandas` for tabular data,
+     `numpy` for numeric work, `pillow` for images).  If no environments match,
+     use 'name' of the first entry in the list.
 
-3. **Write a self-contained script** that solves the task. Read its
-   inputs from the volumes, apply any rules from room files, and
-   print results to stdout. Save intermediate artifacts (CSVs,
-   plots, cleaned data) to `/sandbox/work/` when the user might want
-   them or when a later step will reuse them.
+2. **List files in both volumes.**  This step is mandatory — do not skip it,
+   even if the task seems to involve one volume.  Run both:
 
-4. **Iterate on failures.** Read the full error — the root cause is
-   often mid-traceback, not the last line. Change one thing at a
-   time. If the same approach fails three times, stop and try a
-   different strategy rather than retrying variations.
+   ```python
+   list_volume_files("thread")
+   list_volume_files("room")
+   ```
+
+   Each tool prints one absolute path line, or nothing if the volume is empty:
+
+   ```python
+   /sandbox/volumes/thread/orders.csv
+   /sandbox/volumes/thread/notes.txt
+   ```
+
+   If both commands print no files, proceed without inputs.
+
+3. **Read only the files you need.** Do not dump every file — pick the
+   ones the task actually requires. If `room` has any files, read them too:
+   they often contain rules or reference data the task depends on.
+
+   To peek at a file's shape before writing analysis code, use the `run` tool,
+   e.g. `run(environment, "head", "-n", "5", <path>)` (or `"wc", "-l"`,
+   `"file"`, etc.).  For anything beyond a quick peek — parsing, filtering,
+   joining — read it inside a the script call in step 4 rather than running
+   `"cat"` on the whole file.
+
+4. **Run a Python script in the sandbox.** Pass the source as the `script_text`
+   argument to `run_python`:
+
+   ```python
+   run_python(environment, script_text="<python source>")
+   ```
+
+   Write the whole program as a single string, and use real newlines between
+   separate statements. `;` only works for simple statements — compound
+   statements like `def`, `class`, `with`, `for`, `if`, `try` must
+   start on their own line.
+
+   Start from this skeleton and replace the `TODO`:
+
+   ```python
+   from pathlib import Path
+
+   # Inputs (read-only): /sandbox/volumes/thread/, /sandbox/volumes/room/
+   # Scratch (read-write): /sandbox/work/
+
+   # TODO: read inputs, apply any rules from room files, compute `result`.
+
+   print(result)
+   ```
+
+5. **On failure.**
+   - Change exactly one thing per retry.
+   - After 3 failed runs, stop. Report the error to the user (paste the
+     `Exited with code: <N>` line and any traceback), instead of retrying
+     further.
 
 ## Output
 
-- Print what the user asked for to stdout; that is what they will
-  see.
-- For large results, print a summary plus a pointer to the file in
-  `/sandbox/work/` rather than dumping everything.
-- Don't narrate the script ("I will now load the data…") — just run
-  it and report the result.
+- Print the answer to stdout; only stdout is shown to the user.
+- If the answer is more than ~20 rows or lines, print a short summary
+  (head, counts, totals), and write the full detail to a file under
+  `/sandbox/work/`.
+- Do not print narration lines like "Loading data…" or "Processing…".
+  Just run the script.
+- After the script succeeds, report the result to the user
+  in one or two sentences.
+
+## Example
+
+Task: user uploads `orders.csv` and asks "what's the total order value?".
+A full run looks like:
+
+1. `list_environments()` — shows one environment named `default`
+   with `pandas` in its dependencies. Use it.
+
+2. `list_volume_files("thread")` — lists `/sandbox/volumes/thread/orders.csv`.
+   `list_volume_files("room")` — prints no files.
+   Continue with just the thread input.
+
+3. Run:
+
+   ```python
+   run_python("default", script_text="import pandas as pd; df = pd.read_csv('/sandbox/volumes/thread/orders.csv'); print(f\"Total: {df['amount'].sum():.2f}\")"
+   ```
+
+   — prints `Total: 48215.00`.
+
+4. Report to the user: "Total order value: $48,215.00."

--- a/src/soliplex/skills/bwrap_sandbox/__init__.py
+++ b/src/soliplex/skills/bwrap_sandbox/__init__.py
@@ -36,10 +36,12 @@ LIST_ENVIRONMENTS_DESCRIPTION = """
 Return a list of information about available sandbox environments
 
 Each entry will contain these fields:
-- 'name' (string) pass this value to the ``execute`` and ``execute_script`` \
+- 'name' (string) pass this value to the ``run`` and ``run_python`` \
 tools to run the tool in the environment.
 - 'description' (string) describes the purposes for which the environment is \
 configured.
+- 'dependencies' (list of string): names of Python projects on which the \
+environment depends.
 """
 
 
@@ -49,7 +51,7 @@ async def skill_list_environments(
     return bwrap_sandbox.config.list_environments()
 
 
-EXECUTE_DESCRIPTION = """\
+RUN_DESCRIPTION = """\
 Execute a shell command in the working directory.
 
 IMPORTANT: This tool is for operations that REQUIRE a real shell — \
@@ -84,7 +86,7 @@ verify the target path/object before executing.
 """
 
 
-async def skill_execute(
+async def skill_run(
     bwrap_sandbox: bs_sandbox.BwrapSandbox,
     command: str | list[str],
     environment_name: str = None,
@@ -126,7 +128,7 @@ async def skill_execute(
     return str(output)
 
 
-EXECUTE_SCRIPT_DESCRIPTION = """\
+RUN_PYTHON_DESCRIPTION = """\
 Execute a Python script in the sandbox environment.
 
 IMPORTANT: The ``script`` parameter must be valid Python source code. \
@@ -151,7 +153,7 @@ completely different strategy.
 """
 
 
-async def skill_execute_script(
+async def skill_run_python(
     bwrap_sandbox: bs_sandbox.BwrapSandbox,
     script: str,
     environment_name: str = None,
@@ -170,7 +172,7 @@ async def skill_execute_script(
             the toolset.
     """
     try:
-        result = await bwrap_sandbox.execute_script(
+        result = await bwrap_sandbox.execute_python(
             script=script,
             environment_name=environment_name,
             workdir=workdir,
@@ -270,7 +272,7 @@ def create_sandbox_toolset(
             up to this many times. Defaults to 1.
 
     Returns:
-        FunctionToolset with 'execute' and 'execute_script' tools.
+        FunctionToolset with 'list_environments, 'run' and 'run_python' tools.
     """
     if sandbox_config is None:
         sandbox_config = bs_config.Config()
@@ -305,8 +307,8 @@ def create_sandbox_toolset(
     ) -> list[EnvironmentInfo]:
         return await skill_list_environments(bwrap_sandbox=bwrap_sandbox)
 
-    @toolset.tool(description=EXECUTE_DESCRIPTION)
-    async def execute(
+    @toolset.tool(description=RUN_DESCRIPTION)
+    async def run(
         ctx: pydantic_ai.RunContext,
         command: str | list[str],
         environment_name: str = None,
@@ -327,7 +329,7 @@ def create_sandbox_toolset(
             state.thread_id or "",
         )
 
-        return await skill_execute(
+        return await skill_run(
             bwrap_sandbox=bwrap_sandbox,
             command=command,
             environment_name=environment_name,
@@ -336,8 +338,8 @@ def create_sandbox_toolset(
             extra_volumes=extra_volumes,
         )
 
-    @toolset.tool(description=EXECUTE_SCRIPT_DESCRIPTION)
-    async def execute_script(
+    @toolset.tool(description=RUN_PYTHON_DESCRIPTION)
+    async def run_python(
         ctx: pydantic_ai.RunContext,
         script: str,
         environment_name: str = None,
@@ -358,7 +360,7 @@ def create_sandbox_toolset(
             state.thread_id or "",
         )
 
-        return await skill_execute_script(
+        return await skill_run_python(
             bwrap_sandbox=bwrap_sandbox,
             script=script,
             environment_name=environment_name,

--- a/src/soliplex/skills/bwrap_sandbox/__init__.py
+++ b/src/soliplex/skills/bwrap_sandbox/__init__.py
@@ -1,4 +1,5 @@
 import pathlib
+import typing
 
 import pydantic
 import pydantic_ai
@@ -9,6 +10,8 @@ from haiku.skills import models as hs_models
 from haiku.skills import parser as hs_parser
 from haiku.skills import state as hs_state
 from pydantic_ai import toolsets as ai_toolests
+
+VolumeName = typing.Literal["thread"] | typing.Literal["room"]
 
 SKILL_NAME = "bubble-sandbox"
 SKILL_DESCRIPTION = """\
@@ -84,6 +87,32 @@ completely different strategy.
 - Be careful with destructive commands (`rm -rf`, `drop table`, etc.) — \
 verify the target path/object before executing.
 """
+
+
+LIST_VOLUME_FILES_DESCRIPTION = """
+Return a list of absolute filenames of files in a sandbox volume
+"""
+
+
+async def skill_list_volume_files(
+    volume: VolumeName,
+    room_upload_path: pathlib.Path,
+    thread_upload_path: pathlib.Path,
+) -> list[str]:
+
+    def _list_volume_files(volume_path: pathlib.Path) -> list[str]:
+        return [
+            sub.absolute().name
+            for sub in volume_path.glob("*")
+            if sub.is_file()
+        ]
+
+    if volume == "thread":
+        return _list_volume_files(thread_upload_path)
+    elif volume == "room":
+        return _list_volume_files(room_upload_path)
+    else:
+        return []
 
 
 async def skill_run(
@@ -272,7 +301,8 @@ def create_sandbox_toolset(
             up to this many times. Defaults to 1.
 
     Returns:
-        FunctionToolset with 'list_environments, 'run' and 'run_python' tools.
+        FunctionToolset with thses tools:
+        'list_environments, 'list_volume_files', 'run' and 'run_python'.
     """
     if sandbox_config is None:
         sandbox_config = bs_config.Config()
@@ -306,6 +336,25 @@ def create_sandbox_toolset(
         ctx: pydantic_ai.RunContext,
     ) -> list[EnvironmentInfo]:
         return await skill_list_environments(bwrap_sandbox=bwrap_sandbox)
+
+    @toolset.tool(description=LIST_VOLUME_FILES_DESCRIPTION)
+    async def list_volume_files(
+        ctx: pydantic_ai.RunContext,
+        volume: VolumeName,
+    ) -> list[str]:
+        if installation_config is None:
+            return []
+
+        else:
+            state = ctx.deps.state
+            room_id = state.room_id or ""
+            thread_id = state.thread_id or ""
+
+            return await skill_list_volume_files(
+                volume=volume,
+                room_upload_path=rooms_upload_path / room_id,
+                thread_upload_path=threads_upload_path / thread_id,
+            )
 
     @toolset.tool(description=RUN_DESCRIPTION)
     async def run(

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -118,7 +118,7 @@ async def test_skill_list_environments(
         (["/bin/true"], ["/bin/true"]),
     ],
 )
-async def test_skill_execute_w_errors_truncation(
+async def test_skill_run_w_errors_truncation(
     ctx_w_deps,
     bwrap_sandbox,
     w_command,
@@ -145,7 +145,7 @@ async def test_skill_execute_w_errors_truncation(
         if w_exit_code not in [None, 0]:
             expected = f"Command failed (exit code {w_exit_code}):\n{expected}"
 
-    found = await skills_bwrap_sandbox.skill_execute(
+    found = await skills_bwrap_sandbox.skill_run(
         bwrap_sandbox=bwrap_sandbox,
         command=w_command,
     )
@@ -185,7 +185,7 @@ async def test_skill_execute_w_errors_truncation(
         (["/bin/true"], ["/bin/true"]),
     ],
 )
-async def test_skill_execute_w_extra_args(
+async def test_skill_run_w_extra_args(
     ctx_w_deps,
     bwrap_sandbox,
     w_command,
@@ -200,7 +200,7 @@ async def test_skill_execute_w_extra_args(
     )
     expected = "test output"
 
-    found = await skills_bwrap_sandbox.skill_execute(
+    found = await skills_bwrap_sandbox.skill_run(
         bwrap_sandbox=bwrap_sandbox,
         command=w_command,
         **w_kw,
@@ -225,7 +225,7 @@ async def test_skill_execute_w_extra_args(
 @pytest.mark.parametrize("w_att_rte", [False, True])
 @pytest.mark.parametrize("w_exit_code", [0, None, 42])
 @pytest.mark.parametrize("w_truncated", [False, True])
-async def test_skill_execute_script_w_errors_truncation(
+async def test_skill_run_python_w_errors_truncation(
     ctx_w_deps,
     bwrap_sandbox,
     w_truncated,
@@ -233,10 +233,10 @@ async def test_skill_execute_script_w_errors_truncation(
     w_att_rte,
 ):
     if w_att_rte:
-        bwrap_sandbox.execute_script.side_effect = RuntimeError("test")
+        bwrap_sandbox.execute_python.side_effect = RuntimeError("test")
         expected = "Error: test"
     else:
-        bwrap_sandbox.execute_script.return_value = mock.create_autospec(
+        bwrap_sandbox.execute_python.return_value = mock.create_autospec(
             bs_models.ExecuteResult,
             output="test output",
             exit_code=w_exit_code,
@@ -250,14 +250,14 @@ async def test_skill_execute_script_w_errors_truncation(
         if w_exit_code not in [None, 0]:
             expected = f"Command failed (exit code {w_exit_code}):\n{expected}"
 
-    found = await skills_bwrap_sandbox.skill_execute_script(
+    found = await skills_bwrap_sandbox.skill_run_python(
         bwrap_sandbox=bwrap_sandbox,
         script="print('hello')",
     )
 
     assert found == expected
 
-    bwrap_sandbox.execute_script.assert_awaited_once_with(
+    bwrap_sandbox.execute_python.assert_awaited_once_with(
         script="print('hello')",
         environment_name=None,
         workdir=None,
@@ -283,12 +283,12 @@ async def test_skill_execute_script_w_errors_truncation(
         },
     ],
 )
-async def test_skill_execute_script_w_extra_args(
+async def test_skill_run_python_w_extra_args(
     ctx_w_deps,
     bwrap_sandbox,
     w_kw,
 ):
-    bwrap_sandbox.execute_script.return_value = mock.create_autospec(
+    bwrap_sandbox.execute_python.return_value = mock.create_autospec(
         bs_models.ExecuteResult,
         output="test output",
         exit_code=None,
@@ -296,7 +296,7 @@ async def test_skill_execute_script_w_extra_args(
     )
     expected = "test output"
 
-    found = await skills_bwrap_sandbox.skill_execute_script(
+    found = await skills_bwrap_sandbox.skill_run_python(
         bwrap_sandbox=bwrap_sandbox,
         script="print('hello')",
         **w_kw,
@@ -311,7 +311,7 @@ async def test_skill_execute_script_w_extra_args(
         "extra_volumes": None,
     } | w_kw
 
-    bwrap_sandbox.execute_script.assert_awaited_once_with(
+    bwrap_sandbox.execute_python.assert_awaited_once_with(
         script="print('hello')",
         **exp_kw,
     )
@@ -484,11 +484,11 @@ async def test_create_sandbox_toolset_list_environments(
 )
 @mock.patch("soliplex.skills.bwrap_sandbox.get_extra_volumes")
 @mock.patch("soliplex.skills.bwrap_sandbox.get_workdir")
-@mock.patch("soliplex.skills.bwrap_sandbox.skill_execute")
+@mock.patch("soliplex.skills.bwrap_sandbox.skill_run")
 @mock.patch("bubble_sandbox.sandbox.BwrapSandbox")
-async def test_create_sandbox_toolset_execute(
+async def test_create_sandbox_toolset_run(
     bs_klass,
-    skill_execute,
+    skill_run,
     gw,
     gev,
     ctx_w_deps,
@@ -507,7 +507,7 @@ async def test_create_sandbox_toolset_execute(
         toolset = skills_bwrap_sandbox.create_sandbox_toolset()
 
     sandbox = bs_klass.return_value
-    tool = toolset.tools["execute"]
+    tool = toolset.tools["run"]
 
     found = await tool.function(
         ctx=ctx_w_deps,
@@ -515,7 +515,7 @@ async def test_create_sandbox_toolset_execute(
         **w_kw,
     )
 
-    assert found is skill_execute.return_value
+    assert found is skill_run.return_value
 
     exp_kw = {
         "environment_name": None,
@@ -524,7 +524,7 @@ async def test_create_sandbox_toolset_execute(
         "extra_volumes": gev.return_value,
     } | w_kw
 
-    skill_execute.assert_called_once_with(
+    skill_run.assert_called_once_with(
         bwrap_sandbox=sandbox,
         command=["/bin/true"],
         **exp_kw,
@@ -570,11 +570,11 @@ async def test_create_sandbox_toolset_execute(
 )
 @mock.patch("soliplex.skills.bwrap_sandbox.get_extra_volumes")
 @mock.patch("soliplex.skills.bwrap_sandbox.get_workdir")
-@mock.patch("soliplex.skills.bwrap_sandbox.skill_execute_script")
+@mock.patch("soliplex.skills.bwrap_sandbox.skill_run_python")
 @mock.patch("bubble_sandbox.sandbox.BwrapSandbox")
-async def test_create_sandbox_toolset_execute_script(
+async def test_create_sandbox_toolset_run_python(
     bs_klass,
-    skill_execute_script,
+    skill_run_python,
     gw,
     gev,
     ctx_w_deps,
@@ -593,7 +593,7 @@ async def test_create_sandbox_toolset_execute_script(
         toolset = skills_bwrap_sandbox.create_sandbox_toolset()
 
     sandbox = bs_klass.return_value
-    tool = toolset.tools["execute_script"]
+    tool = toolset.tools["run_python"]
 
     found = await tool.function(
         ctx=ctx_w_deps,
@@ -601,7 +601,7 @@ async def test_create_sandbox_toolset_execute_script(
         **w_kw,
     )
 
-    assert found is skill_execute_script.return_value
+    assert found is skill_run_python.return_value
 
     exp_kw = {
         "environment_name": None,
@@ -610,7 +610,7 @@ async def test_create_sandbox_toolset_execute_script(
         "extra_volumes": gev.return_value,
     } | w_kw
 
-    skill_execute_script.assert_called_once_with(
+    skill_run_python.assert_called_once_with(
         bwrap_sandbox=sandbox,
         script="print('hello')",
         **exp_kw,

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -107,6 +107,42 @@ async def test_skill_list_environments(
     assert found is bwrap_sandbox.config.list_environments.return_value
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "volume, expected",
+    [
+        ("thread", ["thread_file.txt"]),
+        ("room", ["room_file.txt"]),
+        ("nonesuch", []),
+    ],
+)
+async def test_skill_list_volume_files(
+    temp_dir,
+    rooms_upload_path,
+    threads_upload_path,
+    bwrap_sandbox,
+    volume,
+    expected,
+):
+    room_upload_path = rooms_upload_path / str(ROOM_ID)
+    room_upload_path.mkdir(parents=True)
+    room_file = room_upload_path / "room_file.txt"
+    room_file.write_text("ROOM FILE")
+
+    thread_upload_path = threads_upload_path / str(THREAD_ID)
+    thread_upload_path.mkdir(parents=True)
+    thread_file = thread_upload_path / "thread_file.txt"
+    thread_file.write_text("THREAD FILE")
+
+    found = await skills_bwrap_sandbox.skill_list_volume_files(
+        volume,
+        room_upload_path=room_upload_path,
+        thread_upload_path=thread_upload_path,
+    )
+
+    assert found == expected
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("w_att_rte", [False, True])
 @pytest.mark.parametrize("w_exit_code", [0, None, 42])
@@ -460,9 +496,9 @@ async def test_create_sandbox_toolset_list_environments(
     skill_list_environments,
     ctx_w_deps,
 ):
-    found = skills_bwrap_sandbox.create_sandbox_toolset()
+    toolset = skills_bwrap_sandbox.create_sandbox_toolset()
     sandbox = bs_klass.return_value
-    tool = found.tools["list_environments"]
+    tool = toolset.tools["list_environments"]
 
     found = await tool.function(ctx=ctx_w_deps)
 
@@ -470,6 +506,39 @@ async def test_create_sandbox_toolset_list_environments(
     skill_list_environments.assert_called_once_with(
         bwrap_sandbox=sandbox,
     )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("w_iconfig", [False, True])
+@mock.patch("soliplex.skills.bwrap_sandbox.skill_list_volume_files")
+async def test_create_sandbox_toolset_list_volume_files(
+    skill_list_volume_files,
+    i_config,
+    ctx_w_deps,
+    rooms_upload_path,
+    threads_upload_path,
+    w_iconfig,
+):
+    if w_iconfig:
+        toolset = skills_bwrap_sandbox.create_sandbox_toolset(
+            installation_config=i_config,
+        )
+    else:
+        toolset = skills_bwrap_sandbox.create_sandbox_toolset()
+
+    tool = toolset.tools["list_volume_files"]
+
+    found = await tool.function(ctx=ctx_w_deps, volume="foo")
+
+    if w_iconfig:
+        assert found is skill_list_volume_files.return_value
+        skill_list_volume_files.assert_called_once_with(
+            volume="foo",
+            room_upload_path=rooms_upload_path / str(ROOM_ID),
+            thread_upload_path=threads_upload_path / str(THREAD_ID),
+        )
+    else:
+        assert found == []
 
 
 @pytest.mark.anyio

--- a/uv.lock
+++ b/uv.lock
@@ -304,7 +304,7 @@ wheels = [
 
 [[package]]
 name = "bubble-sandbox"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-backend" },
@@ -312,9 +312,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/ec/6c28d4b9a6e0e38b4a318aea486be8a1390af75fa8f4f42ce0864bbda0f1/bubble_sandbox-0.8.0.tar.gz", hash = "sha256:6b1a2d86222037c8bb14bcbd5bd68bae2f49d60208d23d0c840f70b9b56c0595", size = 8528, upload-time = "2026-04-23T05:07:54.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/55/d56cb0df2394be705d55df4dc2069a24487ccbb80111ed321582d460a86c/bubble_sandbox-0.9.0.tar.gz", hash = "sha256:01d215cc92481c535aae3ae34072b238456b70e8d8b2160aa8e7973610022561", size = 8640, upload-time = "2026-04-23T19:15:14.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/da/a00394cee5bfcc4160ac425366fd37d5a816023ecffa1000eba5575b6271/bubble_sandbox-0.8.0-py3-none-any.whl", hash = "sha256:c2612ffcbb95e2c97dc7124ce759608af77825709d8c158abbe29338e2c76c8c", size = 10496, upload-time = "2026-04-23T05:07:53.555Z" },
+    { url = "https://files.pythonhosted.org/packages/69/e9/c6bbea33aa4300165c65e242afce811a24ffadb28c1c7bc154540149b4d4/bubble_sandbox-0.9.0-py3-none-any.whl", hash = "sha256:757363a6e85c43d31b9652a3a7f8bd7561a882e3d7b701fe014d59b213791055", size = 10620, upload-time = "2026-04-23T19:15:12.881Z" },
 ]
 
 [[package]]
@@ -3500,7 +3500,7 @@ requires-dist = [
     { name = "ag-ui-protocol", specifier = ">=0.1.16,<0.1.18" },
     { name = "aiosqlite" },
     { name = "authlib" },
-    { name = "bubble-sandbox", specifier = ">=0.8.0,<0.9" },
+    { name = "bubble-sandbox", specifier = ">=0.9.0,<0.10" },
     { name = "certifi", specifier = ">=2025.11.12" },
     { name = "fakeredis", specifier = "!=2.35.0" },
     { name = "fastapi" },


### PR DESCRIPTION
- Make the skill prompt more prescriptive, giving the skill agent clear patterns to follow and a template for any Python script.
- Explicitly call out the new 'list_volume_files' tool as *the* way to detect file inputs.
- Include an 'Example' section showing the entire expected flow.

Claude gave very good advice about making the tweaks for its less gifted siblings.