### PR TITLE
fix: 'PRAGMA foreign_keys=ON' for sqlite connections

### DIFF
--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -78,9 +78,14 @@ def _create_async_engine(url, **kwargs):
         def _set_sqlite_pragma(  # pragma: no cover
             dbapi_connection, connection_record
         ):
-            cursor = dbapi_connection.cursor()
-            cursor.execute("PRAGMA synchronous=NORMAL")
-            cursor.close()
+            cursor_sync = dbapi_connection.cursor()
+            cursor_sync.execute("PRAGMA synchronous=NORMAL")
+            cursor_sync.close()
+
+            # Fix https://github.com/soliplex/soliplex/issues/950
+            cursor_fk = dbapi_connection.cursor()
+            cursor_fk.execute("PRAGMA foreign_keys=ON")
+            cursor_fk.close()
 
     return engine
 

--- a/tests/functional/test_agui_thread.py
+++ b/tests/functional/test_agui_thread.py
@@ -87,3 +87,12 @@ def test_post_rooms_roomid_agui_etc(client_no_llm):
     response = client_no_llm.delete(
         f"/api/v1/rooms/{room_id}/agui/{thread_id}",
     )
+
+    # Exercise https://github.com/soliplex/soliplex/issues/950
+    # New thread after thread deletion triggers bogus sqlite3
+    # behaviour without a 'PRAGMA foreign_keys=ON' on each connection.
+    response = client_no_llm.post(
+        f"/api/v1/rooms/{room_id}/agui",
+        json=new_thread_request,
+    )
+    assert response.status_code == 200

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -1528,15 +1528,21 @@ async def test_create_async_engine_sqlite_file(tmp_path):
             with db as conn:
                 (mode,) = conn.execute("PRAGMA journal_mode").fetchone()
             assert mode == "wal"
+
         finally:
             db.close()
 
         # Engine works and the event listener fires
         async with engine.begin() as conn:
             rows = await conn.exec_driver_sql("PRAGMA synchronous")
-            (value,) = rows.fetchone()
+            (sync,) = rows.fetchone()
             # NORMAL = 1
-            assert value == 1
+            assert sync == 1
+
+            # Test https://github.com/soliplex/soliplex/issues/950
+            rows = await conn.exec_driver_sql("PRAGMA foreign_keys")
+            (fkeys,) = rows.fetchone()
+            assert fkeys == 1
 
     finally:
         await engine.dispose()
@@ -1563,5 +1569,12 @@ async def test_create_async_engine_memory():
     try:
         # In-memory databases should not use NullPool
         assert not isinstance(engine.pool, sqla_pool.NullPool)
+
+        # Engine works and the event listener fires
+        async with engine.begin() as conn:
+            # Test https://github.com/soliplex/soliplex/issues/950
+            rows = await conn.exec_driver_sql("PRAGMA foreign_keys")
+            (fkeys,) = rows.fetchone()
+            assert fkeys == 1
     finally:
         await engine.dispose()


### PR DESCRIPTION
Closes #950.

@bd-mkt I moved the fix you applied in the last commit of PR #887 out to address @91jaeminjo's bug, adding both unit tests and a functest which exercise the bug at the REST API level.