### PR TITLE
feat(tic-tac-toe): backend skill + agent factory

### DIFF
--- a/example/rooms/tic_tac_toe/room_config.yaml
+++ b/example/rooms/tic_tac_toe/room_config.yaml
@@ -1,0 +1,8 @@
+id: "tic_tac_toe"
+name: "Tic-Tac-Toe"
+description: "Play tic-tac-toe against the agent"
+agent:
+  kind: "factory"
+  factory_name: "soliplex.skills.tic_tac_toe.skill.tic_tac_toe_agent_factory"
+  with_agent_config: true
+allow_mcp: false

--- a/src/soliplex/config/agents.py
+++ b/src/soliplex/config/agents.py
@@ -241,8 +241,9 @@ class AgentConfig:
             and self.provider_base_url is None
         ):
             return ic.get_environment("OLLAMA_BASE_URL")
-        else:
-            return ic.interpolate_environment(self.provider_base_url)
+        if self.provider_base_url is None:
+            return None
+        return ic.interpolate_environment(self.provider_base_url)
 
     @property
     def llm_provider_kw(self) -> dict:

--- a/src/soliplex/skills/tic_tac_toe/__init__.py
+++ b/src/soliplex/skills/tic_tac_toe/__init__.py
@@ -1,0 +1,2 @@
+"""Tic-tac-toe skill — provides a deterministic game engine and the
+tools that emit AG-UI StateDeltaEvents in response to user moves."""

--- a/src/soliplex/skills/tic_tac_toe/engine.py
+++ b/src/soliplex/skills/tic_tac_toe/engine.py
@@ -1,0 +1,111 @@
+"""Pure game logic — board representation, win detection, agent AI.
+
+No AG-UI / framework dependencies. Unit-testable in isolation."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Iterable
+
+Mark = str  # "X" or "O"
+Board = tuple[tuple[Mark | None, ...], ...]
+
+
+class InvalidMove(ValueError):
+    """Raised when a move targets an occupied cell or is out of range."""
+
+
+def apply_move(board: Board, row: int, col: int, mark: Mark) -> Board:
+    if not (0 <= row < 3 and 0 <= col < 3):
+        raise InvalidMove(f"out-of-range cell ({row},{col})")  # noqa: TRY003
+    if board[row][col] is not None:
+        raise InvalidMove(f"cell ({row},{col}) already occupied")  # noqa: TRY003
+    return tuple(
+        tuple(mark if (r, c) == (row, col) else board[r][c] for c in range(3))
+        for r in range(3)
+    )
+
+
+Cell = tuple[int, int]
+Outcome = str  # "X" | "O" | "draw"
+
+# All eight winning lines on a 3x3 board.
+_LINES: tuple[tuple[Cell, ...], ...] = (
+    ((0, 0), (0, 1), (0, 2)),  # row 0
+    ((1, 0), (1, 1), (1, 2)),  # row 1
+    ((2, 0), (2, 1), (2, 2)),  # row 2
+    ((0, 0), (1, 0), (2, 0)),  # col 0
+    ((0, 1), (1, 1), (2, 1)),  # col 1
+    ((0, 2), (1, 2), (2, 2)),  # col 2
+    ((0, 0), (1, 1), (2, 2)),  # main diagonal
+    ((0, 2), (1, 1), (2, 0)),  # anti-diagonal
+)
+
+
+def detect_winner(board: Board) -> Outcome | None:
+    for line in _LINES:
+        marks = {board[r][c] for r, c in line}
+        if len(marks) == 1 and None not in marks:
+            return next(iter(marks))
+    if all(board[r][c] is not None for r in range(3) for c in range(3)):
+        return "draw"
+    return None
+
+
+def find_winning_line(board: Board) -> list[Cell] | None:
+    for line in _LINES:
+        marks = {board[r][c] for r, c in line}
+        if len(marks) == 1 and None not in marks:
+            return list(line)
+    return None
+
+
+class NoMoveAvailable(RuntimeError):
+    """Raised when pick_agent_move is called on a full board."""
+
+
+def pick_agent_move(board: Board, rng: random.Random) -> Cell:
+    empty = [(r, c) for r in range(3) for c in range(3) if board[r][c] is None]
+    if not empty:
+        raise NoMoveAvailable("board is full")  # noqa: TRY003
+    return rng.choice(empty)
+
+
+_USER_MARK = "X"
+_AGENT_MARK = "O"
+
+
+def _player_to_mark(player: str) -> Mark:
+    if player == "user":
+        return _USER_MARK
+    if player == "agent":
+        return _AGENT_MARK
+    raise ValueError(f"unknown player {player!r}")  # noqa: TRY003
+
+
+def _next_turn(last_player: str) -> str:
+    return "agent" if last_player == "user" else "user"
+
+
+def replay(
+    moves: Iterable[dict],
+) -> tuple[Board, str, Outcome | None, list[Cell] | None]:
+    """Reconstruct (board, turn, winner, winning_line) from a moves history."""
+    board: Board = tuple(tuple(None for _ in range(3)) for _ in range(3))
+    last_player = None
+    for move in moves:
+        mark = _player_to_mark(move["player"])
+        board = apply_move(board, move["row"], move["col"], mark)
+        last_player = move["player"]
+    winner_mark = detect_winner(board)
+    if winner_mark == _USER_MARK:
+        winner = "user"
+    elif winner_mark == _AGENT_MARK:
+        winner = "agent"
+    elif winner_mark == "draw":
+        winner = "draw"
+    else:
+        winner = None
+    line = find_winning_line(board) if winner in ("user", "agent") else None
+    turn = "user" if last_player is None else _next_turn(last_player)
+    return board, turn, winner, line

--- a/src/soliplex/skills/tic_tac_toe/prompts.py
+++ b/src/soliplex/skills/tic_tac_toe/prompts.py
@@ -1,0 +1,8 @@
+"""Agent system prompt for tic-tac-toe."""
+
+SYSTEM_PROMPT = """\
+You are a tic-tac-toe game agent. The frontend client sends moves and \
+intents through the `_inbox` slice of run-agent state. You handle \
+conversational chat normally; the framework dispatches game actions to \
+deterministic tools before you respond.\
+"""

--- a/src/soliplex/skills/tic_tac_toe/skill.py
+++ b/src/soliplex/skills/tic_tac_toe/skill.py
@@ -1,0 +1,445 @@
+"""AG-UI tool adapters for tic-tac-toe.
+
+Each function returns a `pydantic_ai.ToolReturn` whose metadata
+contains one or more `agui_core.StateDeltaEvent`s. The pattern
+mirrors `src/soliplex/examples.py` and
+`src/soliplex/tools/agui_run_feedback.py`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+import random
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import jsonpatch
+import pydantic_ai
+from ag_ui import core as agui_core
+from pydantic_ai import messages as ai_messages
+from pydantic_ai import output as ai_output
+from pydantic_ai import run as ai_run
+from pydantic_ai import tools as ai_tools
+from pydantic_ai.models import openai as openai_models
+from pydantic_ai.providers import ollama as ollama_providers
+
+from soliplex import agents
+from soliplex.config import agents as config_agents
+from soliplex.config import tools as config_tools
+from soliplex.skills.tic_tac_toe import engine
+from soliplex.skills.tic_tac_toe import prompts
+
+INBOX_KEY = "_inbox"
+SURFACE_KEY = "tic_tac_toe"
+
+_USER_MARK = "X"
+_AGENT_MARK = "O"
+
+
+class InvalidIntent(ValueError):
+    """Raised when an inbox intent cannot be applied to the state."""
+
+
+def _empty_game(*, rng: random.Random) -> dict[str, Any]:
+    first_turn = rng.choice(["user", "agent"])
+    return {
+        "id": str(uuid.uuid4()),
+        "board": [[None, None, None], [None, None, None], [None, None, None]],
+        "moves": [],
+        "turn": first_turn,
+        "winner": None,
+        "winning_line": None,
+        "started_at": datetime.datetime.now(datetime.UTC).isoformat(
+            timespec="seconds",
+        ),
+    }
+
+
+def _board_to_lists(board: engine.Board) -> list[list[str | None]]:
+    return [list(row) for row in board]
+
+
+def _list_board_to_tuple(board: list[list[str | None]]) -> engine.Board:
+    return tuple(tuple(row) for row in board)
+
+
+def _line_to_dicts(line: list[engine.Cell] | None) -> list[dict] | None:
+    if line is None:
+        return None
+    return [{"row": r, "col": c} for r, c in line]
+
+
+def _state_with(state: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    return {**state, **overrides}
+
+
+def _strip_inbox(state: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of state with INBOX_KEY removed.
+
+    `_inbox` is wire-only — the client's bus never holds it. If we
+    let a `remove /_inbox` op leak into a StateDeltaEvent, applying
+    that delta on the client side will throw `PathNotFound` because
+    the client's `agentState` does not contain that key. So we diff
+    inbox-stripped states.
+    """
+    new_state = dict(state)
+    new_state.pop(INBOX_KEY, None)
+    return new_state
+
+
+def _patch(before: dict[str, Any], after: dict[str, Any]) -> list[dict]:
+    # Diff inbox-stripped states so emitted deltas never touch _inbox.
+    return list(
+        jsonpatch.make_patch(_strip_inbox(before), _strip_inbox(after)),
+    )
+
+
+def _clear_inbox_slice(state: dict[str, Any]) -> dict[str, Any]:
+    """Server-side bookkeeping — clear the consumed inbox slice from
+    the *server's working copy* of state. Callers pass this state
+    through `_patch`, which itself strips `_inbox` from both sides,
+    so the cleared slice doesn't appear in the wire delta. This
+    function still exists so the server's own subsequent state
+    reads (e.g., chained tool calls in the same run) don't see
+    stale inbox data.
+    """
+    inbox = dict(state.get(INBOX_KEY, {}))
+    if SURFACE_KEY in inbox:
+        del inbox[SURFACE_KEY]
+    if inbox:
+        return _state_with(state, **{INBOX_KEY: inbox})
+    new_state = dict(state)
+    new_state.pop(INBOX_KEY, None)
+    return new_state
+
+
+def _wrap(
+    before: dict[str, Any],
+    after: dict[str, Any],
+) -> pydantic_ai.ToolReturn:
+    delta = _patch(before, after)
+    return pydantic_ai.ToolReturn(
+        return_value="ok",
+        metadata=[agui_core.StateDeltaEvent(delta=delta)],
+    )
+
+
+def _outcome_from_mark(mark: str) -> str:
+    if mark == _USER_MARK:
+        return "user"
+    if mark == _AGENT_MARK:
+        return "agent"
+    if mark == "draw":
+        return "draw"
+    raise ValueError(f"unknown mark {mark!r}")  # noqa: TRY003
+
+
+def start_game(
+    *,
+    state: dict[str, Any],
+    rng: random.Random | None = None,
+) -> pydantic_ai.ToolReturn:
+    rng = rng or random.Random()
+    after = _state_with(state, game=_empty_game(rng=rng))
+    after = _clear_inbox_slice(after)
+    return _wrap(state, after)
+
+
+def play_move(
+    *,
+    state: dict[str, Any],
+    row: int,
+    col: int,
+    rng: random.Random | None = None,
+) -> pydantic_ai.ToolReturn:
+    rng = rng or random.Random()
+    game = state.get("game")
+    if game is None:
+        raise InvalidIntent("no active game")  # noqa: TRY003
+    if game["winner"] is not None:
+        raise InvalidIntent("game already finished")  # noqa: TRY003
+    if game["turn"] != "user":
+        raise InvalidIntent(  # noqa: TRY003
+            f"not user's turn (turn={game['turn']!r})",
+        )
+
+    board = _list_board_to_tuple(game["board"])
+    try:
+        board_after_user = engine.apply_move(board, row, col, _USER_MARK)
+    except engine.InvalidMove as exc:
+        raise InvalidIntent(str(exc)) from exc
+
+    moves: list[dict] = list(game["moves"])
+    moves.append(
+        {"player": "user", "row": row, "col": col, "mark": _USER_MARK},
+    )
+
+    user_winner = engine.detect_winner(board_after_user)
+    if user_winner is not None:
+        # User's move ended the game; no agent response.
+        line = engine.find_winning_line(board_after_user)
+        new_game = {
+            **game,
+            "board": _board_to_lists(board_after_user),
+            "moves": moves,
+            "turn": "user",  # frozen
+            "winner": _outcome_from_mark(user_winner),
+            "winning_line": _line_to_dicts(line),
+        }
+    else:
+        agent_row, agent_col = engine.pick_agent_move(board_after_user, rng)
+        board_after_agent = engine.apply_move(
+            board_after_user, agent_row, agent_col, _AGENT_MARK,
+        )
+        moves.append(
+            {
+                "player": "agent",
+                "row": agent_row,
+                "col": agent_col,
+                "mark": _AGENT_MARK,
+            },
+        )
+        agent_winner = engine.detect_winner(board_after_agent)
+        line = (
+            engine.find_winning_line(board_after_agent)
+            if agent_winner in (_USER_MARK, _AGENT_MARK)
+            else None
+        )
+        new_game = {
+            **game,
+            "board": _board_to_lists(board_after_agent),
+            "moves": moves,
+            "turn": "user",
+            "winner": (
+                _outcome_from_mark(agent_winner) if agent_winner else None
+            ),
+            "winning_line": _line_to_dicts(line),
+        }
+
+    after = _state_with(state, game=new_game)
+    after = _clear_inbox_slice(after)
+    return _wrap(state, after)
+
+
+def undo_to(
+    *,
+    state: dict[str, Any],
+    target_index: int,
+) -> pydantic_ai.ToolReturn:
+    game = state.get("game")
+    if game is None:
+        raise InvalidIntent("no active game")  # noqa: TRY003
+    if not (0 <= target_index <= len(game["moves"])):
+        raise InvalidIntent(  # noqa: TRY003
+            f"target_index {target_index} out of range",
+        )
+
+    truncated = list(game["moves"])[:target_index]
+    board, turn, winner, line = engine.replay(truncated)
+    new_game = {
+        **game,
+        "board": _board_to_lists(board),
+        "moves": truncated,
+        "turn": turn,
+        "winner": winner,
+        "winning_line": _line_to_dicts(line),
+    }
+    after = _state_with(state, game=new_game)
+    after = _clear_inbox_slice(after)
+    return _wrap(state, after)
+
+
+def redo_replay(
+    *,
+    state: dict[str, Any],
+    moves: list[dict],
+) -> pydantic_ai.ToolReturn:
+    game = state.get("game")
+    if game is None:
+        raise InvalidIntent("no active game")  # noqa: TRY003
+    full_moves = list(game["moves"]) + list(moves)
+    board, turn, winner, line = engine.replay(full_moves)
+    new_game = {
+        **game,
+        "board": _board_to_lists(board),
+        "moves": full_moves,
+        "turn": turn,
+        "winner": winner,
+        "winning_line": _line_to_dicts(line),
+    }
+    after = _state_with(state, game=new_game)
+    after = _clear_inbox_slice(after)
+    return _wrap(state, after)
+
+
+def dispatch_inbox(
+    *,
+    state: dict[str, Any],
+    rng: random.Random | None = None,
+) -> list[agui_core.Event] | None:
+    """Inspect state['_inbox']['tic_tac_toe'] and dispatch to the
+    corresponding tool. Returns the metadata events (StateDeltaEvent)
+    or None if there is no game intent (LLM should handle).
+
+    Raises InvalidIntent on malformed/unknown intents.
+    """
+    inbox = state.get(INBOX_KEY) or {}
+    intent_payload = inbox.get(SURFACE_KEY)
+    if intent_payload is None:
+        return None
+    intent = intent_payload.get("intent")
+    if intent == "new_game":
+        return list(start_game(state=state, rng=rng).metadata or [])
+    if intent == "play":
+        move = intent_payload.get("move") or {}
+        return list(
+            play_move(
+                state=state,
+                row=int(move["row"]),
+                col=int(move["col"]),
+                rng=rng,
+            ).metadata or [],
+        )
+    if intent == "undo":
+        target_index = int(intent_payload["target_index"])
+        return list(
+            undo_to(state=state, target_index=target_index).metadata or [],
+        )
+    if intent == "redo":
+        moves = list(intent_payload.get("moves") or [])
+        return list(
+            redo_replay(state=state, moves=moves).metadata or [],
+        )
+    raise InvalidIntent(f"unknown intent {intent!r}")  # noqa: TRY003
+
+
+def tic_tac_toe_agent_factory(
+    agent_config: config_agents.FactoryAgentConfig,
+    tool_configs: config_tools.ToolConfigMap = None,
+    mcp_client_toolset_configs: (
+        config_tools.MCP_ClientToolsetConfigMap | None
+    ) = None,
+    skill_toolset_config: agents.SkillToolsetConfig | None = None,
+) -> _TicTacToeAgent:
+    """Hybrid agent: dispatches game intents deterministically (no
+    LLM), falls through to a normal LLM agent for chat (no inbox).
+
+    The dispatcher runs *before* the LLM in `run_stream_events` —
+    when `_inbox.tic_tac_toe` is present, we yield only the
+    `StateDeltaEvent`(s) returned by the corresponding tool plus a
+    small templated assistant message ("Played (1,2)") and finish,
+    skipping the LLM call entirely.
+
+    When no inbox is present the agent behaves like a regular
+    pydantic-ai agent with `prompts.SYSTEM_PROMPT`.
+    """
+    installation_config = agent_config._installation_config
+    base_url = installation_config.get_environment("OLLAMA_BASE_URL")
+    provider = openai_models.OpenAIChatModel(
+        model_name="gpt-oss:latest",
+        provider=ollama_providers.OllamaProvider(base_url=f"{base_url}/v1"),
+    )
+    inner = pydantic_ai.Agent(
+        model=provider,
+        system_prompt=prompts.SYSTEM_PROMPT,
+    )
+    return _TicTacToeAgent(inner=inner)
+
+
+class _TicTacToeAgent:
+    """Wraps a pydantic-ai Agent with a pre-LLM inbox dispatcher.
+
+    Mirrors the FauxAgent shape (`run`, `run_stream`,
+    `run_stream_events`) used in `soliplex.examples` so the runtime
+    can drive it the same way.
+    """
+
+    def __init__(self, *, inner: pydantic_ai.Agent) -> None:
+        self._inner = inner
+
+    async def run(
+        self,
+        prompt,
+        *,
+        message_history=None,
+        deps=None,
+    ):
+        return await self._inner.run(
+            prompt,
+            message_history=message_history,
+            deps=deps,
+        )
+
+    @contextlib.asynccontextmanager
+    async def run_stream(
+        self,
+        prompt,
+        *,
+        message_history=None,
+        deps=None,
+    ):
+        async with self._inner.run_stream(
+            prompt,
+            message_history=message_history,
+            deps=deps,
+        ) as r:
+            yield r
+
+    async def run_stream_events(
+        self,
+        output_type: ai_output.OutputSpec | None = None,
+        message_history=None,
+        deferred_tool_results: pydantic_ai.DeferredToolResults | None = None,
+        deps: ai_tools.AgentDepsT = None,
+        **kwargs,
+    ) -> AsyncIterator:
+        state = getattr(deps, "state", None) or {}
+        events = dispatch_inbox(state=state)
+        if events is not None:
+            tc_part = ai_messages.ToolCallPart("tic_tac_toe_dispatch")
+            yield ai_messages.PartStartEvent(index=0, part=tc_part)
+            yield ai_messages.PartEndEvent(index=0, part=tc_part)
+            yield ai_messages.FunctionToolResultEvent(
+                result=ai_messages.ToolReturnPart(
+                    tool_name="tic_tac_toe_dispatch",
+                    tool_call_id=tc_part.tool_call_id,
+                    content="ok",
+                    metadata=events,
+                ),
+            )
+            text = _summarize_intent(state)
+            if text:
+                text_part = ai_messages.TextPart(content=text)
+                yield ai_messages.PartStartEvent(index=1, part=text_part)
+                yield ai_messages.PartEndEvent(index=1, part=text_part)
+            yield ai_run.AgentRunResultEvent(
+                result=text if text else "ok",
+            )
+            return
+        async for ev in self._inner.run_stream_events(
+            output_type=output_type,
+            message_history=message_history,
+            deferred_tool_results=deferred_tool_results,
+            deps=deps,
+            **kwargs,
+        ):
+            yield ev
+
+
+def _summarize_intent(state: dict[str, Any]) -> str | None:
+    payload = (state.get(INBOX_KEY) or {}).get(SURFACE_KEY)
+    if not payload:
+        return None
+    intent = payload.get("intent")
+    if intent == "play":
+        m = payload.get("move") or {}
+        return f"You played ({m.get('row')}, {m.get('col')})."
+    if intent == "new_game":
+        return "Starting a new game."
+    if intent == "undo":
+        return "Undone."
+    if intent == "redo":
+        return "Redone."
+    return None

--- a/src/soliplex/skills/tic_tac_toe/skill.py
+++ b/src/soliplex/skills/tic_tac_toe/skill.py
@@ -142,7 +142,27 @@ def start_game(
     rng: random.Random | None = None,
 ) -> pydantic_ai.ToolReturn:
     rng = rng or random.Random()
-    after = _state_with(state, game=_empty_game(rng=rng))
+    new_game = _empty_game(rng=rng)
+    # If the random first-turn pick lands on the agent, play the
+    # agent's opening move now so the user always meets a board on
+    # which it is their turn.
+    if new_game["turn"] == "agent":
+        board = _list_board_to_tuple(new_game["board"])
+        agent_row, agent_col = engine.pick_agent_move(board, rng)
+        board_after = engine.apply_move(
+            board, agent_row, agent_col, _AGENT_MARK,
+        )
+        new_game["board"] = _board_to_lists(board_after)
+        new_game["moves"] = [
+            {
+                "player": "agent",
+                "row": agent_row,
+                "col": agent_col,
+                "mark": _AGENT_MARK,
+            },
+        ]
+        new_game["turn"] = "user"
+    after = _state_with(state, game=new_game)
     after = _clear_inbox_slice(after)
     return _wrap(state, after)
 

--- a/tests/skills/tic_tac_toe/test_engine.py
+++ b/tests/skills/tic_tac_toe/test_engine.py
@@ -1,0 +1,179 @@
+import random
+
+from soliplex.skills.tic_tac_toe import engine
+
+
+def empty_board():
+    return tuple(tuple(None for _ in range(3)) for _ in range(3))
+
+
+class TestApplyMove:
+    def test_places_mark_at_empty_cell(self):
+        board = empty_board()
+        new_board = engine.apply_move(board, 1, 1, "X")
+        assert new_board[1][1] == "X"
+
+    def test_other_cells_unchanged(self):
+        board = empty_board()
+        new_board = engine.apply_move(board, 1, 1, "X")
+        for r in range(3):
+            for c in range(3):
+                if (r, c) != (1, 1):
+                    assert new_board[r][c] is None
+
+    def test_returns_immutable_board(self):
+        board = empty_board()
+        new_board = engine.apply_move(board, 0, 0, "X")
+        assert isinstance(new_board, tuple)
+        assert isinstance(new_board[0], tuple)
+        # Original board untouched
+        assert board[0][0] is None
+
+    def test_raises_when_cell_occupied(self):
+        board = empty_board()
+        b1 = engine.apply_move(board, 0, 0, "X")
+        try:
+            engine.apply_move(b1, 0, 0, "O")
+        except engine.InvalidMove:
+            pass
+        else:
+            raise AssertionError("expected InvalidMove")  # noqa: TRY003
+
+
+class TestDetectWinner:
+    def test_empty_board_no_winner(self):
+        board = empty_board()
+        assert engine.detect_winner(board) is None
+
+    def test_partial_board_no_winner(self):
+        board = empty_board()
+        board = engine.apply_move(board, 0, 0, "X")
+        board = engine.apply_move(board, 1, 1, "O")
+        assert engine.detect_winner(board) is None
+
+    def test_row_win(self):
+        board = empty_board()
+        for c in range(3):
+            board = engine.apply_move(board, 1, c, "X")
+        assert engine.detect_winner(board) == "X"
+
+    def test_column_win(self):
+        board = empty_board()
+        for r in range(3):
+            board = engine.apply_move(board, r, 2, "O")
+        assert engine.detect_winner(board) == "O"
+
+    def test_diagonal_win(self):
+        board = empty_board()
+        for i in range(3):
+            board = engine.apply_move(board, i, i, "X")
+        assert engine.detect_winner(board) == "X"
+
+    def test_anti_diagonal_win(self):
+        board = empty_board()
+        for i in range(3):
+            board = engine.apply_move(board, i, 2 - i, "O")
+        assert engine.detect_winner(board) == "O"
+
+    def test_full_board_no_winner_is_draw(self):
+        board = (
+            ("X", "O", "X"),
+            ("X", "O", "O"),
+            ("O", "X", "X"),
+        )
+        assert engine.detect_winner(board) == "draw"
+
+
+class TestFindWinningLine:
+    def test_no_winner_returns_none(self):
+        board = empty_board()
+        assert engine.find_winning_line(board) is None
+
+    def test_row_winning_line(self):
+        board = (
+            ("X", "X", "X"),
+            (None, None, None),
+            (None, None, None),
+        )
+        assert engine.find_winning_line(board) == [(0, 0), (0, 1), (0, 2)]
+
+    def test_diagonal_winning_line(self):
+        board = (
+            ("X", None, None),
+            (None, "X", None),
+            (None, None, "X"),
+        )
+        assert engine.find_winning_line(board) == [(0, 0), (1, 1), (2, 2)]
+
+    def test_draw_returns_none(self):
+        board = (
+            ("X", "O", "X"),
+            ("X", "O", "O"),
+            ("O", "X", "X"),
+        )
+        assert engine.find_winning_line(board) is None
+
+
+class TestPickAgentMove:
+    def test_picks_only_empty_cell_when_one_remains(self):
+        board = (
+            ("X", "O", "X"),
+            ("X", "O", "O"),
+            ("O", "X", None),
+        )
+        rng = random.Random(0)
+        assert engine.pick_agent_move(board, rng) == (2, 2)
+
+    def test_picks_from_empty_cells_only(self):
+        board = (
+            ("X", None, None),
+            (None, "O", None),
+            (None, None, "X"),
+        )
+        rng = random.Random(42)
+        for _ in range(20):
+            r, c = engine.pick_agent_move(board, rng)
+            assert board[r][c] is None
+
+    def test_full_board_raises(self):
+        board = (
+            ("X", "O", "X"),
+            ("X", "O", "O"),
+            ("O", "X", "X"),
+        )
+        rng = random.Random(0)
+        try:
+            engine.pick_agent_move(board, rng)
+        except engine.NoMoveAvailable:
+            pass
+        else:
+            raise AssertionError("expected NoMoveAvailable")  # noqa: TRY003
+
+
+class TestReplay:
+    def test_empty_history(self):
+        board, turn, winner, line = engine.replay([])
+        assert board == empty_board()
+        assert turn == "user"
+        assert winner is None
+        assert line is None
+
+    def test_one_user_move(self):
+        moves = [{"player": "user", "row": 1, "col": 1, "mark": "X"}]
+        board, turn, winner, line = engine.replay(moves)
+        assert board[1][1] == "X"
+        assert turn == "agent"
+        assert winner is None
+        assert line is None
+
+    def test_user_winning_history(self):
+        moves = [
+            {"player": "user",  "row": 0, "col": 0, "mark": "X"},
+            {"player": "agent", "row": 1, "col": 0, "mark": "O"},
+            {"player": "user",  "row": 0, "col": 1, "mark": "X"},
+            {"player": "agent", "row": 1, "col": 1, "mark": "O"},
+            {"player": "user",  "row": 0, "col": 2, "mark": "X"},
+        ]
+        board, turn, winner, line = engine.replay(moves)
+        assert winner == "user"
+        assert line == [(0, 0), (0, 1), (0, 2)]

--- a/tests/skills/tic_tac_toe/test_skill.py
+++ b/tests/skills/tic_tac_toe/test_skill.py
@@ -22,15 +22,49 @@ class TestStartGame:
         result = skill.start_game(state={}, rng=rng)
         new_state = _apply_metadata({}, result.metadata)
         game = new_state["game"]
-        assert game["board"] == [
-            [None, None, None],
-            [None, None, None],
-            [None, None, None],
-        ]
-        assert game["moves"] == []
+        # Turn is always "user" after start_game: if the random pick
+        # lands on agent, start_game pre-plays the agent's opening
+        # move and flips turn back to user.
+        assert game["turn"] == "user"
         assert game["winner"] is None
         assert game["winning_line"] is None
-        assert game["turn"] in ("user", "agent")
+        # moves is empty when the user goes first; one agent move
+        # otherwise.
+        assert len(game["moves"]) in (0, 1)
+
+    def test_user_first_starts_with_empty_board(self):
+        # Find a seed that picks "user" first.
+        for seed in range(10):
+            if random.Random(seed).choice(["user", "agent"]) == "user":
+                result = skill.start_game(state={}, rng=random.Random(seed))
+                new_state = _apply_metadata({}, result.metadata)
+                game = new_state["game"]
+                assert game["moves"] == []
+                assert game["board"] == [[None] * 3 for _ in range(3)]
+                return
+        raise AssertionError(  # noqa: TRY003
+            "no seed picked user in 10 tries",
+        )
+
+    def test_agent_first_pre_plays_opening_move(self):
+        # Find a seed that picks "agent" first.
+        for seed in range(10):
+            if random.Random(seed).choice(["user", "agent"]) == "agent":
+                result = skill.start_game(state={}, rng=random.Random(seed))
+                new_state = _apply_metadata({}, result.metadata)
+                game = new_state["game"]
+                assert len(game["moves"]) == 1
+                assert game["moves"][0]["player"] == "agent"
+                assert game["moves"][0]["mark"] == "O"
+                # Board reflects the agent's opening move.
+                ar, ac = game["moves"][0]["row"], game["moves"][0]["col"]
+                assert game["board"][ar][ac] == "O"
+                # Turn handed to the user.
+                assert game["turn"] == "user"
+                return
+        raise AssertionError(  # noqa: TRY003
+            "no seed picked agent in 10 tries",
+        )
 
     def test_clears_inbox(self):
         # The wire delta must not re-introduce inbox keys; the

--- a/tests/skills/tic_tac_toe/test_skill.py
+++ b/tests/skills/tic_tac_toe/test_skill.py
@@ -1,0 +1,265 @@
+import random
+
+import jsonpatch
+import pytest
+from ag_ui import core as agui_core
+
+from soliplex.skills.tic_tac_toe import skill
+
+
+def _apply_metadata(state: dict, metadata: list) -> dict:
+    """Apply each StateDeltaEvent in metadata, returning the result."""
+    s = dict(state)
+    for ev in metadata:
+        assert isinstance(ev, agui_core.StateDeltaEvent)
+        s = jsonpatch.apply_patch(s, list(ev.delta))
+    return s
+
+
+class TestStartGame:
+    def test_initializes_game_state(self):
+        rng = random.Random(0)
+        result = skill.start_game(state={}, rng=rng)
+        new_state = _apply_metadata({}, result.metadata)
+        game = new_state["game"]
+        assert game["board"] == [
+            [None, None, None],
+            [None, None, None],
+            [None, None, None],
+        ]
+        assert game["moves"] == []
+        assert game["winner"] is None
+        assert game["winning_line"] is None
+        assert game["turn"] in ("user", "agent")
+
+    def test_clears_inbox(self):
+        # The wire delta must not re-introduce inbox keys; the
+        # `test_emitted_delta_does_not_touch_inbox` test asserts the
+        # patch never touches `/_inbox`. Here we just verify the
+        # delta does not add a `game` slot under `_inbox` or otherwise
+        # surface inbox via the patch.
+        rng = random.Random(0)
+        state = {"_inbox": {"tic_tac_toe": {"intent": "new_game"}}}
+        result = skill.start_game(state=state, rng=rng)
+        for ev in result.metadata or []:
+            for op in list(ev.delta):
+                assert not op.get("path", "").startswith("/_inbox")
+
+    def test_emitted_delta_does_not_touch_inbox(self):
+        """Regression: the JSON patch must not include any op on the
+        `_inbox` path. The client's bus never contains _inbox, so a
+        `remove /_inbox` op would crash `bus.update(applyJsonPatch)`.
+        """
+        rng = random.Random(0)
+        state = {"_inbox": {"tic_tac_toe": {"intent": "new_game"}}}
+        result = skill.start_game(state=state, rng=rng)
+        for ev in result.metadata or []:
+            for op in list(ev.delta):
+                assert not op.get("path", "").startswith(
+                    "/_inbox",
+                ), f"delta op leaks _inbox: {op}"
+
+
+class TestPlayMove:
+    def test_applies_user_move_and_agent_response(self):
+        rng = random.Random(0)
+        state = {
+            "game": {
+                "id": "g1",
+                "board": [[None] * 3 for _ in range(3)],
+                "moves": [],
+                "turn": "user",
+                "winner": None,
+                "winning_line": None,
+                "started_at": "2026-04-29T00:00:00",
+            },
+            "_inbox": {
+                "tic_tac_toe": {
+                    "intent": "play",
+                    "move": {"row": 1, "col": 1},
+                },
+            },
+        }
+        result = skill.play_move(state=state, row=1, col=1, rng=rng)
+        new_state = _apply_metadata(state, result.metadata)
+        moves = new_state["game"]["moves"]
+        assert moves[0] == {"player": "user", "row": 1, "col": 1, "mark": "X"}
+        assert len(moves) == 2  # user + agent
+        assert moves[1]["player"] == "agent"
+        # Wire delta must never touch `_inbox` (see regression test).
+        for ev in result.metadata or []:
+            for op in list(ev.delta):
+                assert not op.get("path", "").startswith("/_inbox")
+
+    def test_user_winning_move_skips_agent_response(self):
+        # Pre-fill so user's next move wins immediately.
+        rng = random.Random(0)
+        state = {
+            "game": {
+                "id": "g1",
+                "board": [
+                    ["X", "X", None],
+                    ["O", "O", None],
+                    [None, None, None],
+                ],
+                "moves": [
+                    {"player": "user",  "row": 0, "col": 0, "mark": "X"},
+                    {"player": "agent", "row": 1, "col": 0, "mark": "O"},
+                    {"player": "user",  "row": 0, "col": 1, "mark": "X"},
+                    {"player": "agent", "row": 1, "col": 1, "mark": "O"},
+                ],
+                "turn": "user",
+                "winner": None,
+                "winning_line": None,
+                "started_at": "2026-04-29T00:00:00",
+            },
+            "_inbox": {
+                "tic_tac_toe": {
+                    "intent": "play",
+                    "move": {"row": 0, "col": 2},
+                },
+            },
+        }
+        result = skill.play_move(state=state, row=0, col=2, rng=rng)
+        new_state = _apply_metadata(state, result.metadata)
+        moves = new_state["game"]["moves"]
+        # User's winning move appended; no agent move appended after.
+        assert moves[-1] == {"player": "user", "row": 0, "col": 2, "mark": "X"}
+        assert new_state["game"]["winner"] == "user"
+        assert new_state["game"]["winning_line"] is not None
+
+    def test_invalid_move_raises(self):
+        rng = random.Random(0)
+        state = {
+            "game": {
+                "id": "g1",
+                "board": [
+                    ["X", None, None],
+                    [None, None, None],
+                    [None, None, None],
+                ],
+                "moves": [
+                    {"player": "user", "row": 0, "col": 0, "mark": "X"},
+                ],
+                "turn": "agent",
+                "winner": None,
+                "winning_line": None,
+                "started_at": "2026-04-29T00:00:00",
+            },
+            "_inbox": {
+                "tic_tac_toe": {
+                    "intent": "play",
+                    "move": {"row": 0, "col": 0},
+                },
+            },
+        }
+        with pytest.raises(skill.InvalidIntent):
+            skill.play_move(state=state, row=0, col=0, rng=rng)
+
+
+class TestUndoTo:
+    def test_truncates_moves(self):
+        state = {
+            "game": {
+                "id": "g1",
+                "board": [
+                    ["X", None, None],
+                    ["O", None, None],
+                    [None, None, None],
+                ],
+                "moves": [
+                    {"player": "user",  "row": 0, "col": 0, "mark": "X"},
+                    {"player": "agent", "row": 1, "col": 0, "mark": "O"},
+                ],
+                "turn": "user",
+                "winner": None,
+                "winning_line": None,
+                "started_at": "2026-04-29T00:00:00",
+            },
+            "_inbox": {"tic_tac_toe": {"intent": "undo", "target_index": 0}},
+        }
+        result = skill.undo_to(state=state, target_index=0)
+        new_state = _apply_metadata(state, result.metadata)
+        assert new_state["game"]["moves"] == []
+        assert new_state["game"]["board"] == [[None] * 3 for _ in range(3)]
+        assert new_state["game"]["turn"] == "user"
+        assert new_state["game"]["winner"] is None
+
+
+class TestRedoReplay:
+    def test_appends_supplied_moves(self):
+        state = {
+            "game": {
+                "id": "g1",
+                "board": [[None] * 3 for _ in range(3)],
+                "moves": [],
+                "turn": "user",
+                "winner": None,
+                "winning_line": None,
+                "started_at": "2026-04-29T00:00:00",
+            },
+            "_inbox": {
+                "tic_tac_toe": {
+                    "intent": "redo",
+                    "moves": [
+                        {"player": "user",  "row": 0, "col": 0, "mark": "X"},
+                        {"player": "agent", "row": 1, "col": 0, "mark": "O"},
+                    ],
+                },
+            },
+        }
+        result = skill.redo_replay(
+            state=state,
+            moves=[
+                {"player": "user",  "row": 0, "col": 0, "mark": "X"},
+                {"player": "agent", "row": 1, "col": 0, "mark": "O"},
+            ],
+        )
+        new_state = _apply_metadata(state, result.metadata)
+        assert len(new_state["game"]["moves"]) == 2
+
+
+class TestDispatchInbox:
+    """The factory's pre-LLM dispatcher reads `_inbox.tic_tac_toe`
+    and returns the matching tool's events synchronously, without
+    invoking the LLM. Conversational inputs (no inbox) fall through
+    and return None so the regular LLM path runs."""
+
+    def test_play_intent_dispatches_to_play_move(self):
+        rng = random.Random(0)
+        state = {
+            "game": {
+                "id": "g1",
+                "board": [[None] * 3 for _ in range(3)],
+                "moves": [],
+                "turn": "user",
+                "winner": None,
+                "winning_line": None,
+                "started_at": "2026-04-29T00:00:00",
+            },
+            "_inbox": {
+                "tic_tac_toe": {
+                    "intent": "play",
+                    "move": {"row": 0, "col": 0},
+                },
+            },
+        }
+        events = skill.dispatch_inbox(state=state, rng=rng)
+        assert events is not None
+        assert any(
+            isinstance(e, agui_core.StateDeltaEvent) for e in events
+        )
+
+    def test_no_inbox_returns_none(self):
+        state = {"game": None}
+        assert skill.dispatch_inbox(
+            state=state, rng=random.Random(0),
+        ) is None
+
+    def test_unknown_intent_raises(self):
+        state = {
+            "game": None,
+            "_inbox": {"tic_tac_toe": {"intent": "frobnicate"}},
+        }
+        with pytest.raises(skill.InvalidIntent):
+            skill.dispatch_inbox(state=state, rng=random.Random(0))


### PR DESCRIPTION
## Summary

Adds a tic-tac-toe skill under \`src/soliplex/skills/tic_tac_toe/\` and registers it as a factory-kind room. The skill is the first concrete consumer of AG-UI's \`StateDeltaEvent\` channel for surface-driven UIs.

This is the backend half of the tic-tac-toe feature; the frontend lives in [soliplex/soliplex_frontend_main#TBD].

## What's in the box

- **Pure game engine** (\`engine.py\`): \`apply_move\`, \`detect_winner\`, \`find_winning_line\`, \`pick_agent_move\`, \`replay\` + \`InvalidMove\` / \`NoMoveAvailable\`. No AG-UI deps; unit-testable in isolation.
- **AG-UI tool adapters** (\`skill.py\`): \`start_game\`, \`play_move\`, \`undo_to\`, \`redo_replay\`. Each returns a \`pydantic_ai.ToolReturn\` whose \`metadata\` carries one or more \`StateDeltaEvent\`s. JSON patches are diffed over inbox-stripped state so wire deltas never touch \`_inbox\` (regression-tested).
- **Hybrid agent factory** (\`tic_tac_toe_agent_factory\`): wraps a pydantic-ai LLM agent with a pre-LLM dispatcher. When \`RunAgentInput.state['_inbox']['tic_tac_toe']\` is present, \`dispatch_inbox\` short-circuits and yields a synthetic ToolCall + FunctionToolResultEvent (carrying the StateDeltas as metadata) + AgentRunResultEvent — no LLM call. When absent, falls through to normal LLM streaming.
- **Room registration**: \`example/rooms/tic_tac_toe/room_config.yaml\` mirrors the existing \`joker\` factory room.
- **Random-first turn fix**: when \`start_game\`'s random pick lands on agent, the agent's opening move is pre-played so the user always meets a board on which it's their turn.
- **Drive-by config fix**: \`agents.py\`'s \`llm_provider_base_url\` no longer crashes when \`provider_base_url\` is None for non-Ollama providers (was breaking \`GET /api/v1/rooms\` for the \`gemini_flash\` example room).

## Test plan

- [x] \`pytest tests/skills/tic_tac_toe -v\` → 34 passed
- [x] \`ruff check src/soliplex/skills/tic_tac_toe tests/skills/tic_tac_toe\` → clean
- [x] Manual: \`soliplex-cli serve\` against the example installation, \`GET /api/v1/rooms\` returns 200 with all 15 rooms including \`tic_tac_toe\`
- [x] Manual: full play / undo / redo / new-game round-trip from the frontend (separate PR)

## Known issue (filed separately)

\`DELETE\` then immediately \`POST\` an AG-UI thread within one backend process triggers \`IntegrityError\` on \`thread_metadata.thread_id_\` against SQLite. Root cause: \`passive_deletes=True\` + missing \`PRAGMA foreign_keys=ON\`. Filed as #950, separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)