### PR TITLE
chore: agui feature clarification

### DIFF
--- a/docs/config/agents.md
+++ b/docs/config/agents.md
@@ -107,18 +107,13 @@ agent:
 - `retries` (an integer, default `3`):  number of retries for LLM calls
   on recoverable errors.
 
-  **NOTE**: this value is stored on the agent configuration and is
-            returned via the public API, but is not currently applied
-            at agent construction time.  See
-            <https://github.com/soliplex/soliplex/issues/926>.
-
 - `agui_feature_names` (a list of strings, default empty):  AG-UI feature
   names this agent contributes to the room's aggregate feature set.  Each
-  name must be registered in the AG-UI feature registry (typically via a
-  skill or via an entry under `meta.agui_features`; see
-  [meta.md](meta.md#registering-ag-ui-feature-classes)).  The room's
-  effective feature set is the union of features declared on the agent,
-  the room, its tools, and its skills.
+  name must be registered in the AG-UI feature registry; see
+  [AG-UI Features](agui.md) for the registration paths and the
+  [`meta.agui_features`](meta.md#registering-ag-ui-feature-classes) stanza
+  for the YAML form.  The room's effective feature set is the union of
+  features declared on the agent, the room, its tools, and its skills.
 
 ### Example Ollama Configuration
 
@@ -207,11 +202,11 @@ agent:
 
 - `agui_feature_names` (a list of strings, default empty):  AG-UI feature
   names this agent contributes to the room's aggregate feature set.  Each
-  name must be registered in the AG-UI feature registry (typically via a
-  skill or via an entry under `meta.agui_features`; see
-  [meta.md](meta.md#registering-ag-ui-feature-classes)).  The room's
-  effective feature set is the union of features declared on the agent,
-  the room, its tools, and its skills.
+  name must be registered in the AG-UI feature registry; see
+  [AG-UI Features](agui.md) for the registration paths and the
+  [`meta.agui_features`](meta.md#registering-ag-ui-feature-classes) stanza
+  for the YAML form.  The room's effective feature set is the union of
+  features declared on the agent, the room, its tools, and its skills.
 
 ### Example
 
@@ -224,4 +219,6 @@ agent:
     # Additional arguments passed to the factory function
     temperature: 0.8
     max_retries: 5
+  agui_feature_names:
+    - "myfeature"
 ```

--- a/docs/config/agui.md
+++ b/docs/config/agui.md
@@ -1,0 +1,142 @@
+# AG-UI Features
+
+Soliplex uses the [AG-UI protocol](https://docs.ag-ui.com/) to communicate
+with web and TUI clients. AG-UI carries a free-form `state` mapping
+between client and server; **AG-UI features** are the contracts that
+define the schema and write semantics for individual top-level keys
+within that mapping.
+
+Each feature is described by an `AGUI_Feature` dataclass
+(`soliplex.config.agui.AGUI_Feature`) carrying:
+
+- `name` -- the key under which the feature's data appears in the
+  AG-UI `state` mapping.
+- `model_klass` -- a Pydantic model class defining the schema for
+  the feature's data.
+- `source` -- one of `client`, `server`, or `either`, describing
+  which party is allowed to write the feature's portion of the
+  AG-UI state.
+
+## The `AGUI_FEATURES_BY_NAME` Registry
+
+`soliplex.config.agui.AGUI_FEATURES_BY_NAME` is a module-level
+`dict[str, AGUI_Feature]` that maps each feature's `name` to its
+registration. The registry starts empty and is populated by mutation
+during application startup.
+
+The registry is the single source of truth for "which AG-UI features
+does this installation know about?" Code elsewhere in Soliplex (and
+in the TUI client) looks features up here whenever it needs the
+schema, default value, or write-direction for a particular state key.
+
+## How the Registry Gets Populated
+
+The registry is filled from three sources, applied in this order
+during installation load:
+
+### 1. Soliplex-Builtin Registrations
+
+Importing `soliplex.config.skills` (which happens transitively
+whenever `soliplex.config` is imported) registers Soliplex's own
+built-in features. As of this writing, that includes the
+`bwrap-sandbox` skill's state namespace, registered with
+`source=server`.
+
+These registrations happen at module-import time and are present
+before any installation YAML is parsed.
+
+### 2. Entrypoint Skill Discovery
+
+When an `InstallationConfig` is loaded,
+`_load_entrypoint_skill_configs` walks every Haiku skill discovered
+via Python entry points. For each skill whose `state_namespace` is
+set, it adds an entry to the registry using `skill.state_type` as
+`model_klass` and `server` as `source` -- but only if the
+`state_namespace` is **not already present** in the registry. This
+makes entrypoint discovery a no-op for features that have already
+been registered by other means.
+
+### 3. The `meta.agui_features` YAML Stanza
+
+Finally, the
+[`meta.agui_features`](meta.md#registering-ag-ui-feature-classes)
+stanza of the installation YAML is processed by
+`InstallationConfigMeta.__post_init__`. Each entry produces an
+`AGUI_Feature` which is **unconditionally** written into the
+registry, overwriting any earlier entry with the same `name`.
+
+This ordering means installation YAML wins over both built-in
+registrations and entrypoint discovery, so site operators can
+override the default `model_klass` or `source` for any feature
+shipped by Soliplex or by an installed skill package.
+
+## How the Application Uses the Registry After Startup
+
+Once the installation is loaded, the registry is read (never
+written) by the runtime. The main consumers are:
+
+### `InstallationConfig.agui_features`
+
+The `InstallationConfig.agui_features` property simply returns
+`list(AGUI_FEATURES_BY_NAME.values())`. This is the canonical
+"what features does this installation expose?" accessor.
+
+### The `Installation` Runtime Model
+
+`soliplex.models.Installation.from_config` converts each entry
+from `InstallationConfig.agui_features` into a serializable
+`models.AGUI_Feature` carrying `name`, `description`, `source`,
+and `json_schema`. The result is exposed to clients through the
+installation views, so a Soliplex client can introspect the full
+set of features (and their JSON schemas) without reading the
+server's YAML.
+
+### Initial AG-UI State Synthesis
+
+When a new AG-UI thread is started without a client-supplied
+state, `soliplex.views.agui` builds a default state by iterating
+over the room's `agui_feature_names` and, for each name,
+instantiating `AGUI_FEATURES_BY_NAME[name].model_klass()` with no
+arguments and dumping it to a dict. The TUI client
+(`soliplex.tui.main`) does the same thing on its side when
+opening a new room.
+
+This means every model class registered in the registry must be
+constructible with no arguments -- typically by giving every
+field a default value.
+
+### Schema Export
+
+The `soliplex-cli agui-feature-schemas` command iterates the
+registry (via `installation._config.agui_features`) and emits a
+JSON document mapping each feature name to `{source, json_schema}`.
+The `scripts/generate_feature_schemas.sh` helper uses this output
+to regenerate `schemas/schema.json`, which downstream client
+projects consume to generate type-safe client code.
+
+### YAML Round-Trip
+
+`InstallationConfigMeta.as_yaml` walks the registry to emit a
+`meta.agui_features` block recording every registered feature
+(including those that arrived via paths #1 and #2 above). This is
+used by `soliplex-cli` export commands so that a fully expanded
+configuration can be written back to disk.
+
+## Notes for Test and Plugin Authors
+
+- Because the registry is a module-level mutable global, unit tests
+  must isolate themselves from each other. The standard fixture
+  is `patched_agui_features` in `tests/unit/conftest.py`, which uses
+  `mock.patch.dict` to give each test a fresh empty registry.
+
+- A name listed in a room's `agui_feature_names` that is not present
+  in the registry will raise `KeyError` when the server tries to
+  synthesize an initial AG-UI state for a new thread. Run
+  `soliplex-cli audit rooms <installation.yaml>` to detect this before
+  deploying; each room's aggregate feature names are listed with
+  `OK` or `UNREGISTERED`.
+
+- Plugin authors who want to register a feature have two options:
+  ship it as an entrypoint skill (path #2 above), or document a
+  `meta.agui_features` entry that operators can paste into their
+  installation YAML (path #3).

--- a/docs/config/meta.md
+++ b/docs/config/meta.md
@@ -11,6 +11,9 @@ room.
 
 ## Registering AG-UI Feature Classes
 
+See [AG-UI Features](agui.md) for the full registry lifecycle; this
+section covers only the YAML stanza.
+
 The `meta.agui_features` section registers AG-UI feature types so that
 they can be referenced by their `name`.  Each feature is a contract
 between the client application and the server, defining the schema for

--- a/docs/config/rooms.md
+++ b/docs/config/rooms.md
@@ -84,7 +84,8 @@ A minimal room configuration must include the above elements, e.g.:
 
 - `agui_feature_names` (list of strings); if set these values are added
   to the feature names defined on the room's agent, tools, and skills
-  to create an aggregate set for the room.
+  to create an aggregate set for the room.  Each name must resolve to a
+  registered AG-UI feature; see [AG-UI Features](agui.md).
 
 - `logo_image` (a string, default unset) is a path to an image file that
   the UI can display as the room's logo.  Relative paths are resolved

--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -562,9 +562,11 @@ soliplex-cli audit oidc example/
 ### `audit rooms`
 
 List the rooms declared in the installation configuration, along with
-their names, descriptions, and any RAG databases they reference
-(including a live document count for each). (Replaces the deprecated
-`soliplex-cli list-rooms`.)
+their names, descriptions, the AG-UI feature names each room aggregates
+(checked against the
+[AG-UI feature registry](../config/agui.md)), and any RAG databases
+they reference (including a live document count for each). (Replaces
+the deprecated `soliplex-cli list-rooms`.)
 
 ```bash
 soliplex-cli audit [OPTIONS] rooms [INSTALLATION_CONFIG_PATH]
@@ -588,6 +590,9 @@ form:
 - [ <room_id> ] <name>:
   <description>
 
+   AG-UI features
+   - <feature_name>                : OK
+
    Haiku Rag DBs
    - <source>              : <db_path>                     <N> documents
 ```
@@ -598,11 +603,20 @@ shown relative to the current working directory.
 
 If `Room.from_config(...)` fails for a room (i.e. the room cannot be
 converted to its runtime model), an extra line is printed beneath the
-room header before the "Haiku Rag DBs" block:
+room header before the "AG-UI features" block:
 
 ```text
   ERROR: <message>
 ```
+
+Rooms with no AG-UI features in their aggregate set
+([agent](../config/agents.md) ∪ room ∪ tools ∪ skills) omit the
+"AG-UI features" block. Within the block, each feature name is checked
+against the [AG-UI feature registry](../config/agui.md) and flagged
+either `OK` or `UNREGISTERED`. An `UNREGISTERED` flag means a name in
+the room's aggregate set has no corresponding registration; the server
+will raise `KeyError` when synthesizing initial AG-UI state for a new
+thread in that room.
 
 Rooms with no RAG configuration omit the "Haiku Rag DBs" block.
 Within the block, each RAG-bearing sub-config (the agent, a named
@@ -629,12 +643,14 @@ shown as `error` rather than a number.
 
 #### Exit Status
 
-- `0` — every room's runtime model converted, every RAG configuration
+- `0` — every room's runtime model converted, every aggregated AG-UI
+  feature name resolved against the registry, every RAG configuration
   resolved, and every document count completed.
-- `1` — at least one room failed runtime-model validation, had a
-  missing RAG file, or had a failing `count_documents` query. In
-  `--quiet` mode, the per-room errors are printed as JSON on stdout
-  before exit.
+- `1` — at least one room failed runtime-model validation, referenced
+  an unregistered AG-UI feature name, had a missing RAG file, or had
+  a failing `count_documents` query. In `--quiet` mode, the per-room
+  errors are printed as JSON on stdout before exit; unregistered
+  feature names appear under the `agui_features` key.
 
 #### Examples
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - Console logging: config/logging.md
       - SQLAlchemy DBURIs: config/dburis.md
       - AI Skills: config/skills.md
+      - AGUI Features: config/agui.md
   - Usage: usage.md
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ tui = [
 ]
 
 [tool.pytest.ini_options]
-pythonpath = "."
+pythonpath = [".", "tests/unit"]
 python_files = "test_*.py"
 # skip 'tests/functional' by default
 testpaths = ["tests/unit"]

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -4,7 +4,7 @@ This directory contains JSON schemas for AG-UI features defined in the backend.
 
 ## About
 
-These schemas are automatically generated from Pydantic models in `src/soliplex/agui/features.py` and define the contract between the Soliplex backend and frontend applications.
+These schemas are automatically generated from the Pydantic feature models registered under `meta.agui_features` in an installation's YAML config, and define the contract between the Soliplex backend and frontend applications.
 
 ## Generating Schemas
 

--- a/src/soliplex/cli/audit.py
+++ b/src/soliplex/cli/audit.py
@@ -16,6 +16,7 @@ from soliplex import models
 from soliplex import secrets
 from soliplex.cli import cli_util
 from soliplex.cli import types
+from soliplex.config import agui as config_agui
 from soliplex.config import installation as config_installation
 from soliplex.config import quizzes as config_quizzes
 from soliplex.config import rag as config_rag
@@ -394,6 +395,26 @@ def _iter_room_rag_candidates(room_config):
             yield f"tool:{tool_config.tool_name}", tool_config
 
 
+def _invalid_room_agui_features(
+    the_installation: installation.Installation,
+) -> dict:
+    feature_errors: dict[str, list[str]] = {}
+    registry = config_agui.AGUI_FEATURES_BY_NAME
+
+    for room_config in the_installation._config.room_configs.values():
+        missing = [
+            name
+            for name in room_config.agui_feature_names
+            if name not in registry
+        ]
+        if missing:
+            feature_errors[room_config.id] = missing
+
+    if feature_errors:
+        return {"agui_features": feature_errors}
+    return {}
+
+
 def _invalid_room_rag_dbs(
     the_installation: installation.Installation,
 ) -> dict:
@@ -439,6 +460,10 @@ def _audit_rooms_section(
     errors |= rag_invalid
     rag_invalid_rooms = rag_invalid.get("rag", {})
 
+    feature_invalid = _invalid_room_agui_features(the_installation)
+    errors |= feature_invalid
+    feature_invalid_rooms = feature_invalid.get("agui_features", {})
+
     # Deliberately bypass auth check done by 'get_room_configs' here.
     available_rooms = the_installation._config.room_configs
     cwd = pathlib.Path.cwd()
@@ -450,6 +475,16 @@ def _audit_rooms_section(
         room_exc = invalid_rooms.get(room_config.id)
         if room_exc is not None:
             tc_print(f"  ERROR: {room_exc}")
+
+        room_features = room_config.agui_feature_names
+        if room_features:
+            unregistered = set(feature_invalid_rooms.get(room_config.id, ()))
+            tc_print()
+            tc_print("   AG-UI features")
+            for feature_name in room_features:
+                flag = "UNREGISTERED" if feature_name in unregistered else "OK"
+                tc_print(f"   - {feature_name:30}: {flag}")
+            tc_print()
 
         per_room_rag = rag_invalid_rooms.get(room_config.id, {})
         candidates = list(_iter_room_rag_candidates(room_config))

--- a/src/soliplex/config/agents.py
+++ b/src/soliplex/config/agents.py
@@ -17,8 +17,6 @@ from pydantic_ai.providers import google as google_providers
 from pydantic_ai.providers import ollama as ollama_providers
 from pydantic_ai.providers import openai as openai_providers
 
-from soliplex.agui import features as agui_features_module  # noqa F401
-
 from . import _utils
 from . import exceptions
 

--- a/src/soliplex/config/completions.py
+++ b/src/soliplex/config/completions.py
@@ -3,8 +3,6 @@ from __future__ import annotations  # forward refs in typing decls
 import dataclasses
 import pathlib
 
-from soliplex.agui import features as agui_features_module  # noqa F401
-
 from . import _utils
 from . import agents as config_agents
 from . import tools as config_tools

--- a/src/soliplex/config/installation.py
+++ b/src/soliplex/config/installation.py
@@ -16,8 +16,6 @@ from haiku.rag import config as hr_config
 from haiku.skills import discovery as hs_discovery
 from haiku.skills import models as hs_models
 
-from soliplex.agui import features as agui_features_module  # noqa F401
-
 from . import _utils
 from . import agents as config_agents
 from . import agui as config_agui

--- a/src/soliplex/config/logfire.py
+++ b/src/soliplex/config/logfire.py
@@ -6,8 +6,6 @@ import typing
 
 import logfire
 
-from soliplex.agui import features as agui_features_module  # noqa F401
-
 from . import _utils
 from . import exceptions as config_exc
 

--- a/src/soliplex/config/meta.py
+++ b/src/soliplex/config/meta.py
@@ -4,8 +4,6 @@ import dataclasses
 import pathlib
 import typing
 
-from soliplex.agui import features as agui_features_module  # noqa F401
-
 from . import _utils
 from . import agents as config_agents
 from . import agui as config_agui

--- a/src/soliplex/config/quizzes.py
+++ b/src/soliplex/config/quizzes.py
@@ -7,8 +7,6 @@ import os
 import pathlib
 import random
 
-from soliplex.agui import features as agui_features_module  # noqa F401
-
 from . import _utils
 from . import agents
 from . import exceptions

--- a/src/soliplex/config/rooms.py
+++ b/src/soliplex/config/rooms.py
@@ -4,8 +4,6 @@ import dataclasses
 import pathlib
 import typing
 
-from soliplex.agui import features as agui_features_module  # noqa F401
-
 from . import _utils
 from . import agents as config_agents
 from . import exceptions as config_exc

--- a/src/soliplex/config/secrets.py
+++ b/src/soliplex/config/secrets.py
@@ -5,8 +5,6 @@ import pathlib
 import re
 import typing
 
-from soliplex.agui import features as agui_features_module  # noqa F401
-
 from . import _utils
 
 _no_repr_no_compare_none = _utils._no_repr_no_compare_none

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -15,7 +15,6 @@ from haiku.skills import discovery as hs_discovery
 from haiku.skills import models as hs_models
 from pydantic_ai import models as ai_models
 
-from soliplex.agui import features as agui_features_module  # noqa F401
 from soliplex.config import agui as config_agui
 from soliplex.skills import bwrap_sandbox as sk_bwrap_sandbox
 

--- a/tests/unit/_test_features.py
+++ b/tests/unit/_test_features.py
@@ -1,4 +1,4 @@
-"""Features defined by soliplex"""
+"""Test-only feature models for AG-UI tests."""
 
 import pydantic
 

--- a/tests/unit/config/test_config_agui.py
+++ b/tests/unit/config/test_config_agui.py
@@ -1,9 +1,8 @@
 import contextlib
 from unittest import mock
 
+import _test_features as agui_features
 import pytest
-
-from soliplex.agui import features as agui_features
 
 NoRaise = contextlib.nullcontext()
 

--- a/tests/unit/config/test_config_installation.py
+++ b/tests/unit/config/test_config_installation.py
@@ -4,13 +4,13 @@ import dataclasses
 import pathlib
 from unittest import mock
 
+import _test_features as agui_features
 import pytest
 import yaml
 from haiku.rag import config as hr_config_module
 from haiku.skills import models as hs_models
 
 from soliplex import secrets
-from soliplex.agui import features as agui_features
 from soliplex.config import agents as config_agents
 from soliplex.config import authsystem as config_authsystem
 from soliplex.config import exceptions as config_exc
@@ -116,7 +116,7 @@ id: "{INSTALLATION_ID}"
 meta:
   agui_features:
       - name: "{test_meta.AGUI_FEATURE_NAME_FOR_META}"
-        model_klass: "soliplex.agui.features.EmptyFeatureModel"
+        model_klass: "_test_features.EmptyFeatureModel"
         source: "server"
   tool_configs:
     - "test_config_installation.FauxToolConfig"

--- a/tests/unit/config/test_config_meta.py
+++ b/tests/unit/config/test_config_meta.py
@@ -4,11 +4,11 @@ import dataclasses
 import typing
 from unittest import mock
 
+import _test_features as agui_features
 import pytest
 import yaml
 
 from soliplex import secrets
-from soliplex.agui import features as agui_features
 from soliplex.config import agents as config_agents
 from soliplex.config import exceptions as config_exc
 from soliplex.config import meta as config_meta
@@ -59,7 +59,7 @@ W_AGUI_FEATURES_ICMETA_YAML = f"""\
 meta:
   agui_features:
       - name: "{AGUI_FEATURE_NAME_FOR_META}"
-        model_klass: "soliplex.agui.features.EmptyFeatureModel"
+        model_klass: "_test_features.EmptyFeatureModel"
         source: "server"
 """
 
@@ -199,7 +199,7 @@ FULL_ICMETA_YAML = f"""\
 meta:
   agui_features:
       - name: "{AGUI_FEATURE_NAME_FOR_META}"
-        model_klass: "soliplex.agui.features.EmptyFeatureModel"
+        model_klass: "_test_features.EmptyFeatureModel"
         source: "server"
   tool_configs:
     - "test_config_meta.FauxToolConfig"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,9 +2,9 @@ import pathlib
 import tempfile
 from unittest import mock
 
+import _test_features as agui_features
 import pytest
 
-from soliplex.agui import features as agui_features
 from soliplex.config import agents as config_agents
 from soliplex.config import agui as config_agui
 from soliplex.config import authsystem as config_authsystem

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -5,6 +5,7 @@ import functools
 import uuid
 from unittest import mock
 
+import _test_features as agui_features
 import fastapi
 import pytest
 from ag_ui import core as agui_core
@@ -15,7 +16,6 @@ from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
-from soliplex.agui import features as agui_features
 from soliplex.config import agui as config_agui
 from soliplex.config import rooms as config_rooms
 from soliplex.views import agui as agui_views


### PR DESCRIPTION
- cli: check for unregistered features in 'audit rooms'

- docs: add 'docs/config/agui.md'

  Serves as a cross-cutting summary of how AGUI fe

- tests: move src/soliplex/agui/features.py' to 'tests/unit/_test_features.py'

  The module existed purely to allow using a dotted name in testcase YAML.
  Added 'tests/unit' to the Python path during testing to allow the new
  module to be referenced similarly.