### PR TITLE
feat: API endpoints for sandbox workdir files

### DIFF
--- a/src/soliplex/config/installation.py
+++ b/src/soliplex/config/installation.py
@@ -665,6 +665,13 @@ class InstallationConfig:
     #
     sandbox_config: SandboxConfig | None = None
 
+    @property
+    def sandbox_workdirs_path(self) -> pathlib.Path | None:
+        if self.sandbox_config is None:
+            return None
+        else:
+            return self.sandbox_config.workdirs_path
+
     #
     # Path(s) to OIDC Authentication System configs
     #

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -200,6 +200,10 @@ class Installation:
         return self._config.threads_upload_path
 
     @property
+    def sandbox_workdirs_path(self) -> pathlib.Path | None:
+        return self._config.sandbox_workdirs_path
+
+    @property
     def logfire_config(self) -> config_logfire.LogfireConfig | None:
         return self._config.logfire_config
 

--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -28,6 +28,9 @@ UPLOADS_GET_ROOM_THREAD_FILE = "uploads get room thread file"
 UPLOADS_POST_ROOM = "uploads post room"
 UPLOADS_POST_ROOM_THREAD = "uploads post room thread"
 
+WORKDIRS_GET_ROOM_THREAD_RUN = "workdirs get room thread run"
+WORKDIRS_GET_ROOM_THREAD_RUN_FILE = "workdirs get room thread run file"
+
 AUTHN_LOGGER_NAME = "soliplex.authn"
 AUTHN_NO_AUTH_MODE = "soliplex server in no-auth mode"
 AUTHN_JWT_INVALID = "JWT validation failed"

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -586,6 +586,18 @@ class ThreadUploads(pydantic.BaseModel):
     uploads: list[FileUpload]
 
 
+class WorkdirFile(pydantic.BaseModel):
+    filename: str
+    url: pydantic.HttpUrl
+
+
+class RunWorkdirFiles(pydantic.BaseModel):
+    room_id: str
+    thread_id: str
+    run_id: str
+    files: list[WorkdirFile]
+
+
 # ----------------------------------------------------------------------------
 #   AG-UI-related models
 # ----------------------------------------------------------------------------

--- a/src/soliplex/views/file_uploads.py
+++ b/src/soliplex/views/file_uploads.py
@@ -366,3 +366,120 @@ async def post_uploads_room_thread(
     upload_target.write_bytes(await upload_file.read())
 
     return fastapi.Response(status_code=204)
+
+
+@soliplex_views_util.logfire_span(
+    "GET /v1/workdirs/{room_id}/thread/{thread_id}/{run_id}",
+)
+@router.get("/v1/workdirs/{room_id}/thread/{thread_id}/{run_id}")
+async def get_workdirs_room_thread_run(
+    request: fastapi.Request,
+    room_id: str,
+    thread_id: pydantic.UUID4,
+    run_id: pydantic.UUID4,
+    the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
+    the_user_claims: authn_package.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> models.RunWorkdirFiles:
+    """Return a list of files uploaded to the thread"""
+    thread_id = str(thread_id)
+    run_id = str(run_id)
+
+    the_logger.debug(loggers.WORKDIRS_GET_ROOM_THREAD_RUN)
+
+    _room_config = await soliplex_views_agui._check_user_in_room(
+        room_id=room_id,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=the_user_claims,
+        the_logger=the_logger,
+    )
+
+    workdirs_path = the_installation.sandbox_workdirs_path
+
+    if workdirs_path is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="Sandbox workdirs not configured",
+        )
+
+    run_dir = pathlib.Path(workdirs_path) / room_id / thread_id / run_id
+    filename_urls = {}
+
+    if run_dir.is_dir():
+        for file_or_sub in run_dir.glob("*"):
+            if file_or_sub.is_file():
+                filename = file_or_sub.name
+                filename_urls[filename] = request.url_for(
+                    # View function name, not the route path.
+                    "get_workdirs_room_thread_run_filename",
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    filename=filename,
+                )
+
+    return models.RunWorkdirFiles(
+        room_id=room_id,
+        thread_id=thread_id,
+        run_id=run_id,
+        files=[
+            models.WorkdirFile(
+                filename=key,
+                url=str(value),  # The two URL types are not compatible
+            )
+            for key, value in filename_urls.items()
+        ],
+    )
+
+
+@soliplex_views_util.logfire_span(
+    "GET "
+    "/v1/workdirs/{room_id}/thread/{thread_id}/run/{run_id}/file/{filename}"
+)
+@router.get(
+    "/v1/workdirs/{room_id}/thread/{thread_id}/run/{run_id}/file/{filename}"
+)
+async def get_workdirs_room_thread_run_filename(
+    room_id: str,
+    thread_id: pydantic.UUID4,
+    run_id: pydantic.UUID4,
+    filename: str,
+    the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
+    the_user_claims: authn_package.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> models.RunWorkdirFiles:
+    """Return a list of files uploaded to the thread"""
+    thread_id = str(thread_id)
+    run_id = str(run_id)
+
+    the_logger.debug(loggers.WORKDIRS_GET_ROOM_THREAD_RUN_FILE)
+
+    _room_config = await soliplex_views_agui._check_user_in_room(
+        room_id=room_id,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_user_claims=the_user_claims,
+        the_logger=the_logger,
+    )
+
+    workdirs_path = the_installation.sandbox_workdirs_path
+
+    if workdirs_path is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="Sandbox workdirs not configured",
+        )
+
+    run_dir = pathlib.Path(workdirs_path) / room_id / thread_id / run_id
+
+    file_path = run_dir / filename
+    if not file_path.is_file():
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=f"No workdir file: {filename}",
+        )
+
+    return str(file_path)

--- a/tests/unit/config/test_config_installation.py
+++ b/tests/unit/config/test_config_installation.py
@@ -2703,6 +2703,36 @@ def test_installationconfig_threads_upload_path(
     assert found == expected
 
 
+@pytest.mark.parametrize(
+    "w_kwargs, expected",
+    [
+        (BARE_INSTALLATION_CONFIG_KW.copy(), None),
+        (W_SANDBOX_INSTALLATION_CONFIG_KW.copy(), "sandbox/workdirs"),
+    ],
+)
+def test_installationconfig_sandbox_workdirs_path(
+    temp_dir,
+    w_kwargs,
+    expected,
+):
+    config_path = w_kwargs["_config_path"] = temp_dir / "installation.yaml"
+
+    sandbox_config = w_kwargs.get("sandbox_config")
+    if sandbox_config is not None:
+        workdirs_path = sandbox_config._workdirs_path
+        sandbox_config._workdirs_path = pathlib.Path(workdirs_path)
+        sandbox_config._config_path = config_path
+
+    if expected is not None:
+        expected = temp_dir / expected
+
+    i_config = config_installation.InstallationConfig(**w_kwargs)
+
+    found = i_config.sandbox_workdirs_path
+
+    assert found == expected
+
+
 def test_installationconfig_reload_configurations(temp_dir):
     existing = object()
 

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -526,6 +526,16 @@ def test_installation_threads_upload_path():
     assert the_installation.threads_upload_path is i_config.threads_upload_path
 
 
+def test_installation_sandbox_workdirs_path():
+    i_config = mock.create_autospec(config_installation.InstallationConfig)
+    the_installation = installation.Installation(i_config)
+
+    assert (
+        the_installation.sandbox_workdirs_path
+        is i_config.sandbox_workdirs_path
+    )
+
+
 def test_installation_logfire_config():
     i_config = mock.create_autospec(config_installation.InstallationConfig)
     the_installation = installation.Installation(i_config)

--- a/tests/unit/views/test_file_uploads.py
+++ b/tests/unit/views/test_file_uploads.py
@@ -23,6 +23,7 @@ THE_USER_CLAIMS = {"preferred_username": USER_NAME, "email": EMAIL}
 
 TEST_ROOM_ID = "test-room-id"
 TEST_THREAD_ID = uuid.uuid4()
+TEST_RUN_ID = uuid.uuid4()
 TEST_FILENAME = "test_file.txt"
 TEST_CONTENT = b"DEADBEEF"
 
@@ -46,6 +47,13 @@ def the_threads():
 @pytest.fixture
 def uploads_path(temp_dir):
     result = temp_dir / "uploads"
+    result.mkdir()
+    return result
+
+
+@pytest.fixture
+def sandbox_path(temp_dir):
+    result = temp_dir / "sandbox"
     result.mkdir()
     return result
 
@@ -593,4 +601,208 @@ async def test_post_uploads_room_thread(
 
     the_logger.debug.assert_called_once_with(
         loggers.UPLOADS_POST_ROOM_THREAD,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "w_filenames",
+    [
+        [],
+        ["foo.txt"],
+        [f"file_{i_file:03}.txt" for i_file in range(10)],
+    ],
+)
+@pytest.mark.parametrize(
+    "w_sandbox_path, w_workdir_path, expectation",
+    [
+        (True, True, no_error(None)),
+        (True, False, no_error(None)),
+        (
+            False,
+            None,
+            raises_httpexc(code=404, match="Sandbox workdirs not configured"),
+        ),
+    ],
+)
+@mock.patch("soliplex.views.agui._check_user_in_room")
+async def test_get_workdirs_room_thread_run_only(
+    cuir,
+    sandbox_path,
+    w_sandbox_path,
+    w_workdir_path,
+    expectation,
+    w_filenames,
+):
+    sandbox_workdirs_path = sandbox_path / "workdirs"
+    run_path = (
+        sandbox_workdirs_path
+        / TEST_ROOM_ID
+        / str(TEST_THREAD_ID)
+        / str(TEST_RUN_ID)
+    )
+
+    # Note: this is the name of the view function, and not the path
+    #       to which it is bound.
+    ROUTE_NAME = "get_workdirs_room_thread_run_filename"
+
+    def download_url(name, room_id, thread_id, run_id, filename):
+        assert name == ROUTE_NAME
+        return (
+            f"{URL_PREFIX}/v1/workdir/{room_id}"
+            f"/{thread_id}/{run_id}/{filename}"
+        )
+
+    exp_filename_urls = {}
+
+    if w_workdir_path:
+        run_path.mkdir(parents=True)
+        (run_path / "ignore_me").mkdir()
+        for filename in w_filenames:
+            file_path = run_path / filename
+            file_path.write_text(f"filename: {filename}")
+            exp_filename_urls[filename] = download_url(
+                ROUTE_NAME,
+                TEST_ROOM_ID,
+                str(TEST_THREAD_ID),
+                str(TEST_RUN_ID),
+                filename,
+            )
+
+    request = mock.create_autospec(fastapi.Request)
+    request.url_for.side_effect = download_url
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    cuir.return_value = room_config
+
+    the_installation = mock.create_autospec(
+        installation.Installation,
+    )
+
+    if w_sandbox_path:
+        the_installation.sandbox_workdirs_path = str(sandbox_workdirs_path)
+    else:
+        the_installation.sandbox_workdirs_path = None
+
+    the_authz_policy = mock.create_autospec(
+        authz_package.AuthorizationPolicy,
+    )
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    with expectation as expected:
+        found = await file_uploads_views.get_workdirs_room_thread_run(
+            request=request,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            run_id=TEST_RUN_ID,
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_user_claims=THE_USER_CLAIMS,
+            the_logger=the_logger,
+        )
+
+    if expected is None:
+        assert isinstance(found, models.RunWorkdirFiles)
+        assert found.room_id == TEST_ROOM_ID
+        assert found.thread_id == str(TEST_THREAD_ID)
+        assert found.run_id == str(TEST_RUN_ID)
+
+        if w_workdir_path:
+            found_files = {f_up.filename: f_up.url for f_up in found.files}
+            assert set(found_files) == set(w_filenames)
+
+            for filename in w_filenames:
+                exp_url = exp_filename_urls[filename]
+                assert str(found_files[filename]) == exp_url
+        else:
+            assert found.files == []
+
+    the_logger.debug.assert_called_once_with(
+        loggers.WORKDIRS_GET_ROOM_THREAD_RUN,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "w_sandbox_path, w_workdir_path, w_filename, expectation",
+    [
+        (True, True, True, no_error(None)),
+        (
+            True,
+            True,
+            False,
+            raises_httpexc(code=404, match=".*"),
+        ),
+        (
+            True,
+            False,
+            None,
+            raises_httpexc(code=404, match=".*"),
+        ),
+        (
+            False,
+            None,
+            None,
+            raises_httpexc(code=404, match="Sandbox workdirs not configured"),
+        ),
+    ],
+)
+@mock.patch("soliplex.views.agui._check_user_in_room")
+async def test_get_workdirs_room_thread_run_filename(
+    cuir,
+    sandbox_path,
+    w_sandbox_path,
+    w_workdir_path,
+    w_filename,
+    expectation,
+):
+    sandbox_workdirs_path = sandbox_path / "workdirs"
+    workdir_path = (
+        sandbox_workdirs_path
+        / TEST_ROOM_ID
+        / str(TEST_THREAD_ID)
+        / str(TEST_RUN_ID)
+    )
+
+    if w_workdir_path:
+        workdir_path.mkdir(parents=True)
+
+        if w_filename:
+            file_path = workdir_path / TEST_FILENAME
+            file_path.write_text(f"filename: {TEST_FILENAME}")
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    cuir.return_value = room_config
+
+    the_installation = mock.create_autospec(
+        installation.Installation,
+    )
+
+    if w_sandbox_path:
+        the_installation.sandbox_workdirs_path = str(sandbox_workdirs_path)
+    else:
+        the_installation.sandbox_workdirs_path = None
+
+    the_authz_policy = mock.create_autospec(
+        authz_package.AuthorizationPolicy,
+    )
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    with expectation as expected:
+        found = await file_uploads_views.get_workdirs_room_thread_run_filename(
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID,
+            run_id=TEST_RUN_ID,
+            filename=TEST_FILENAME,
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_user_claims=THE_USER_CLAIMS,
+            the_logger=the_logger,
+        )
+
+    if expected is None:
+        assert found == str(file_path)
+
+    the_logger.debug.assert_called_once_with(
+        loggers.WORKDIRS_GET_ROOM_THREAD_RUN_FILE,
     )


### PR DESCRIPTION
- 'GET /api/v1/workdirs/{room_id}/thread/{thread_id}/run/{run_id}' returns a listing of files in the run's workdir

- 'GET /api/v1/workdirs/{room_id}/thread/{thread_id}/run/{run_id}/file/{filename}' returns the given file.

Closes #924.