### PR TITLE
fix: workdir file download returns FileResponse, not validated model

### DIFF
--- a/example/functest_no_llm.yaml
+++ b/example/functest_no_llm.yaml
@@ -103,6 +103,13 @@ agent_configs:
 #==========================================================================
 
 #==========================================================================
+# Sandbox configuration
+#==========================================================================
+sandbox_config:
+    environments_path: ../sandbox/environments
+    workdirs_path: ../sandbox/workdirs
+
+#==========================================================================
 # Rooms configuration
 #
 # We avoid the default here, because the 'mcptest' room uses the SmitheryAI

--- a/src/soliplex/views/file_uploads.py
+++ b/src/soliplex/views/file_uploads.py
@@ -439,7 +439,8 @@ async def get_workdirs_room_thread_run(
     "/v1/workdirs/{room_id}/thread/{thread_id}/run/{run_id}/file/{filename}"
 )
 @router.get(
-    "/v1/workdirs/{room_id}/thread/{thread_id}/run/{run_id}/file/{filename}"
+    "/v1/workdirs/{room_id}/thread/{thread_id}/run/{run_id}/file/{filename}",
+    response_class=responses.FileResponse,
 )
 async def get_workdirs_room_thread_run_filename(
     room_id: str,
@@ -450,7 +451,7 @@ async def get_workdirs_room_thread_run_filename(
     the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
     the_user_claims: authn_package.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
-) -> models.RunWorkdirFiles:
+) -> str:  # file path, converted to file response by FastAPI
     """Return a list of files uploaded to the thread"""
     thread_id = str(thread_id)
     run_id = str(run_id)

--- a/tests/functional/test_file_uploads.py
+++ b/tests/functional/test_file_uploads.py
@@ -1,0 +1,58 @@
+import pathlib
+import shutil
+import uuid
+
+import pytest
+
+from soliplex.config import installation as config_installation
+
+
+@pytest.fixture(scope="module")
+def workdirs_path() -> pathlib.Path:
+    ic = config_installation.load_installation(
+        pathlib.Path("example/functest_no_llm.yaml")
+    )
+    result = ic.sandbox_workdirs_path
+    result.mkdir(parents=True, exist_ok=True)
+    return result
+
+
+@pytest.fixture
+def run_workdir(workdirs_path):
+    room_id = "chat"
+    thread_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    run_dir = workdirs_path / room_id / str(thread_id) / str(run_id)
+    run_dir.mkdir(parents=True)
+
+    yield room_id, thread_id, run_id, run_dir
+
+    shutil.rmtree(workdirs_path / room_id, ignore_errors=True)
+
+
+def test_get_workdir_file_returns_file_bytes(client_no_llm, run_workdir):
+    room_id, thread_id, run_id, run_dir = run_workdir
+    filename = "result.txt"
+    file_bytes = b"hello workdir\n"
+    (run_dir / filename).write_bytes(file_bytes)
+
+    response = client_no_llm.get(
+        f"/api/v1/workdirs/{room_id}"
+        f"/thread/{thread_id}/run/{run_id}/file/{filename}"
+    )
+
+    assert response.status_code == 200
+    assert response.content == file_bytes
+    assert response.headers["content-type"].startswith("text/plain")
+
+
+def test_get_workdir_file_404_when_file_missing(client_no_llm, run_workdir):
+    room_id, thread_id, run_id, _ = run_workdir
+
+    response = client_no_llm.get(
+        f"/api/v1/workdirs/{room_id}"
+        f"/thread/{thread_id}/run/{run_id}/file/nope.txt"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "No workdir file: nope.txt"

--- a/tests/unit/views/test_file_uploads_http.py
+++ b/tests/unit/views/test_file_uploads_http.py
@@ -1,0 +1,128 @@
+import uuid
+from unittest import mock
+
+import fastapi
+import pytest
+from fastapi import testclient
+
+from soliplex import authz as authz_package
+from soliplex import installation
+from soliplex import loggers
+from soliplex import views as views_package
+from soliplex.config import rooms as config_rooms
+from soliplex.views import file_uploads as file_uploads_views
+
+ROOM_ID = "test-room"
+THREAD_ID = uuid.uuid4()
+RUN_ID = uuid.uuid4()
+FILENAME = "result.txt"
+FILE_BYTES = b"hello workdir\n"
+
+
+@pytest.fixture
+def workdirs_path(tmp_path):
+    result = tmp_path / "workdirs"
+    result.mkdir()
+    return result
+
+
+@pytest.fixture
+def the_installation(workdirs_path):
+    inst = mock.create_autospec(installation.Installation)
+    inst.sandbox_workdirs_path = str(workdirs_path)
+    return inst
+
+
+@pytest.fixture
+def app(the_installation):
+    app = fastapi.FastAPI()
+    app.include_router(file_uploads_views.router, prefix="/api")
+
+    async def _user_claims():
+        return {
+            "preferred_username": "phreddy",
+            "email": "phreddy@example.com",
+        }
+
+    async def _authz():
+        return mock.create_autospec(authz_package.AuthorizationPolicy)
+
+    async def _logger():
+        return mock.create_autospec(loggers.LogWrapper)
+
+    async def _inst():
+        return the_installation
+
+    app.dependency_overrides[installation.get_the_installation] = _inst
+    app.dependency_overrides[views_package.get_the_user_claims] = _user_claims
+    app.dependency_overrides[authz_package.get_the_authz_policy] = _authz
+    app.dependency_overrides[views_package.get_the_logger] = _logger
+    return app
+
+
+@pytest.fixture
+def client(app):
+    with testclient.TestClient(
+        app, raise_server_exceptions=False
+    ) as the_client:
+        yield the_client
+
+
+def _route_url(
+    *,
+    room_id=ROOM_ID,
+    thread_id=THREAD_ID,
+    run_id=RUN_ID,
+    filename=FILENAME,
+):
+    return (
+        f"/api/v1/workdirs/{room_id}"
+        f"/thread/{thread_id}/run/{run_id}/file/{filename}"
+    )
+
+
+@mock.patch(
+    "soliplex.views.file_uploads.soliplex_views_agui._check_user_in_room"
+)
+def test_get_workdir_file_returns_file_bytes(cuir, client, workdirs_path):
+    cuir.return_value = mock.create_autospec(config_rooms.RoomConfig)
+
+    target_dir = workdirs_path / ROOM_ID / str(THREAD_ID) / str(RUN_ID)
+    target_dir.mkdir(parents=True)
+    target_path = target_dir / FILENAME
+    target_path.write_bytes(FILE_BYTES)
+
+    response = client.get(_route_url())
+
+    assert response.status_code == 200
+    assert response.content == FILE_BYTES
+    assert response.headers["content-type"].startswith("text/plain")
+
+
+@mock.patch(
+    "soliplex.views.file_uploads.soliplex_views_agui._check_user_in_room"
+)
+def test_get_workdir_file_404_when_sandbox_not_configured(
+    cuir,
+    client,
+    the_installation,
+):
+    cuir.return_value = mock.create_autospec(config_rooms.RoomConfig)
+    the_installation.sandbox_workdirs_path = None
+
+    response = client.get(_route_url())
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Sandbox workdirs not configured"
+
+
+@mock.patch(
+    "soliplex.views.file_uploads.soliplex_views_agui._check_user_in_room"
+)
+def test_get_workdir_file_404_when_file_missing(cuir, client, workdirs_path):
+    cuir.return_value = mock.create_autospec(config_rooms.RoomConfig)
+
+    response = client.get(_route_url(filename="nope.txt"))
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "No workdir file: nope.txt"


### PR DESCRIPTION
Fixes soliplex/soliplex#963.

The route was annotated `-> models.RunWorkdirFiles` with no
`response_class`, so FastAPI ran response validation against a Pydantic
model on a returned path string and 500'd the success path. Match the
pattern used by the two sibling upload-download routes in the same
file.

## Commits
1. `test:` HTTP-level TestClient coverage with mocked deps under `tests/unit/views/` (TDD red — fails on main, captures `assert 500 == 200`).
2. `fix:` two-line change in `views/file_uploads.py` — add `response_class=responses.FileResponse`, change return annotation to `str`.
3. `test:` end-to-end integration coverage under `tests/functional/` (real lifespan, real authz, real `_check_user_in_room`); `functest_no_llm.yaml` gains a `sandbox_config` block to enable the route's prerequisite.

## Test plan
- [x] `uv run pytest` — full unit suite: 3698 passed, 100% coverage.
- [x] `uv run pytest tests/functional/ -m "not needs_llm"` — 7 passed (incl. 2 new integration tests).
- [x] Verified both the new HTTP-level test and the new integration test fail against pre-fix `file_uploads.py` and pass after the fix.
- [x] Existing in-process unit test still passes (function still returns a path string).