### PR TITLE
chore: ignore transitive deprecation from 'fastmpc'/'authlib'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ testpaths = ["tests/unit"]
 addopts = "--cov=soliplex --cov=tests/unit --cov-branch --cov-fail-under=100"
 filterwarnings = [
     # "ignore::DeprecationWarning:<source-package>",
+    "ignore::authlib.deprecate.AuthlibDeprecationWarning:fastmcp",
 ]
 markers = [
     "needs_llm: functest requiring an LLM",


### PR DESCRIPTION
After the version updates in `v0.64`, we have the following warning:
```
.venv/lib/python3.13/site-packages/fastmcp/server/auth/providers/jwt.py:10
  /mnt/work/tseaver/projects/agendaless/Enfold/src/soliplex-v0.64.x/.venv/lib/python3.13/site-packages/fastmcp/server/auth/providers/jwt.py:10: AuthlibDeprecationWarning: authlib.jose module is deprecated, please use joserfc instead.
  It will be compatible before version 2.0.0.
    from authlib.jose import JsonWebKey, JsonWebToken

```
Nothing to be done about it on our side.