### PR TITLE
refactor: address CLI `room-authz` warts

### DIFF
--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -1144,9 +1144,8 @@ described above. The subcommands below read from and modify the per-room
 authorization policy stored in the installation's authorization
 database.
 
-This group replaces the deprecated flat `show-room-authz` /
-`add-room-user` / `clear-room-authz` commands; see
-[Deprecated Command Names](#deprecated-command-names).
+This group replaces the deprecated flat `show-room-authz` command;
+see [Deprecated Command Names](#deprecated-command-names).
 
 ### The Model in One Paragraph
 
@@ -1169,22 +1168,26 @@ and **an empty policy row**:
   through to `default_allow_deny`, which defaults to `DENY` — making
   the room effectively **private**.
 
-The three commands below create, inspect, populate, and delete these
+The six commands below create, inspect, edit, and populate these
 rows.
 
 ### Shared Conventions
 
-All three commands share the following:
+All six commands share the following:
 
 - Positional argument `INSTALLATION_CONFIG_PATH` — as documented in the
   [`admin-users`](#admin-users) section. If omitted, falls back to
   `SOLIPLEX_INSTALLATION_PATH`.
 - Positional argument `ROOM_ID` — the `id` of a configured room (the
-  same identifier surfaced by `audit rooms`). The commands do **not**
-  validate that `ROOM_ID` matches any currently-configured room; you
-  can create or inspect a policy for a room that doesn't exist in the
-  YAML, and that policy will continue to sit in the DB until you clear
-  it.
+  same identifier surfaced by `audit rooms`). The commands validate
+  that `ROOM_ID` matches a room in the installation YAML; an
+  unknown id prints an error (with the list of configured rooms,
+  when any are defined) and exits with status `1` without touching
+  the authorization database. The read-only [`show`](#room-authz-show)
+  command supports an `--allow-stale` escape hatch for inspecting
+  policies left behind by removed or renamed rooms; the other
+  commands do not, so cleanup of stale rows still requires direct
+  database tooling.
 - As with `admin-users`, when the installation's `authorization_dburi`
   is the in-memory default (`sqlite://`), each command detects the
   RAM-based URI, prints a note that the operation would be a no-op,
@@ -1212,8 +1215,27 @@ All three commands share the following:
   }
   ```
 
+- The `-v` / `--verbose` and `-q` / `--quiet` flags at the
+  **group** level (`soliplex-cli room-authz -v <subcommand> …`)
+  toggle between the default JSON dump and a human-focused,
+  Rich-rendered summary. Resolution: `--quiet` always forces JSON;
+  `--verbose` (without `--quiet`) forces the human summary; with
+  neither, the per-deployment default applies (currently JSON, set
+  via `_DEFAULT_VERBOSE` in `cli/room_authz.py`). `--quiet` is
+  intended as the override for scripts in a deployment that has
+  flipped the default to verbose. Example verbose output:
+
+  ```text
+  ─── Room policy: chat ───
+  Default: DENY (private -- denies callers that don't match an ALLOW entry).
+  ACL entries (2):
+    1. ALLOW  email=alice@example.com
+    2. DENY   everyone
+  ```
+
 - Exit status is `0` on success (including when no policy row exists
-  for the room), or `1` when the RAM-DB guard fires.
+  for the room), or `1` when the RAM-DB guard fires or `ROOM_ID`
+  doesn't match a configured room.
 
 ### `room-authz show`
 
@@ -1223,6 +1245,15 @@ Dump the current `RoomPolicy` for a single room without changing it.
 ```bash
 soliplex-cli room-authz show [OPTIONS] INSTALLATION_CONFIG_PATH ROOM_ID
 ```
+
+#### Options
+
+- `--allow-stale` — skip the configured-room check that the rest of
+  the `room-authz` commands enforce. `show` will dump whatever
+  policy row (if any) exists in the authorization database for the
+  given `ROOM_ID`, even when the id isn't present in the
+  installation's current YAML. Useful for inspecting stale policies
+  left behind by a room rename or removal.
 
 #### Examples
 
@@ -1247,112 +1278,410 @@ $ soliplex-cli room-authz show example/installation.yaml search
 null
 ```
 
-### `room-authz add-user`
-
-Grant a single user access to a room by inserting an `ALLOW`-by-`email`
-ACL entry. If no `RoomPolicy` exists for the room yet, one is created
-with the default `default_allow_deny=DENY` — so **the first call to
-`room-authz add-user` against a previously-public room flips the room
-from "public to all authenticated users" to "private except for this
-one user."** Plan accordingly. (Replaces the deprecated
-`soliplex-cli add-room-user`.)
+Inspect a stale policy for a room that has since been removed from
+the YAML — without `--allow-stale` this would exit with status `1`:
 
 ```bash
-soliplex-cli room-authz add-user [OPTIONS] INSTALLATION_CONFIG_PATH ROOM_ID EMAIL
+soliplex-cli room-authz show --allow-stale \
+  example/installation.yaml old-room-id
 ```
 
-#### Positional Arguments
+### `room-authz make-private`
 
-- `INSTALLATION_CONFIG_PATH` — as described above.
-- `ROOM_ID` — as described above.
-- `EMAIL` — the email address to grant access. Matched against the
-  authenticated user's OIDC-asserted email at request time.
+Ensure a room is private by inserting an empty `RoomPolicy` row
+(`default_allow_deny=DENY`, no ACL entries) when none exists for the
+room. Idempotent for rooms that are already private; refuses to
+silently overwrite an existing public-by-policy room unless
+`--update` is passed.
 
-#### Behavior Notes
-
-- **Idempotent per email.** Any existing ACL entries for the same email
-  on this room (including `DENY` entries) are deleted before the new
-  `ALLOW` entry is inserted. Running the command twice with the same
-  email leaves exactly one row.
-- **ALLOW + email only.** The CLI offers no way to create a `DENY`
-  entry, an `everyone` / `authenticated` entry, or an entry keyed by
-  `preferred_username`. For those, use your database tooling or edit
-  the installation's authorization seed YAML.
-- **Policy creation side effect.** As noted above, the first call may
-  silently convert a public room to a private-with-one-exception room.
-  Run `room-authz show` beforehand if you're uncertain of the current
-  state.
-
-#### Examples
-
-Grant Alice access to the `chat` room:
+This is the non-destructive counterpart to `clear --make-room-private`:
+no existing ACL entries are deleted by this command.
 
 ```bash
-soliplex-cli room-authz add-user example/installation.yaml chat alice@example.com
-```
-
-Re-run with the same email to confirm idempotence (exactly one ACL
-entry for `alice@example.com` remains):
-
-```bash
-soliplex-cli room-authz add-user example/installation.yaml chat alice@example.com
-```
-
-### `room-authz clear`
-
-Delete the `RoomPolicy` row for a single room (cascades to all of its
-`ACLEntry` rows). By default this returns the room to the
-**public-to-all-authenticated-users** state; pass `--make-room-private`
-to replace the deleted policy with a fresh empty one, which leaves the
-room **closed to everyone**. (Replaces the deprecated
-`soliplex-cli clear-room-authz`.)
-
-```bash
-soliplex-cli room-authz clear [OPTIONS] INSTALLATION_CONFIG_PATH ROOM_ID
+soliplex-cli room-authz make-private [OPTIONS] INSTALLATION_CONFIG_PATH ROOM_ID
 ```
 
 #### Options
 
-- `--make-room-private` — after deleting the existing policy, create a
-  new empty `RoomPolicy` (no ACL entries, default `DENY`) so that the
-  room remains inaccessible until new ACL entries are added. Without
-  this flag, the command deletes the policy outright and the room
-  reverts to its default **public** state.
+- `--update` — when an existing `RoomPolicy` row is found with
+  `default_allow_deny=ALLOW`, flip it in place to `DENY`. ACL entries
+  are preserved either way. Without this flag, encountering an
+  `ALLOW` policy is treated as an error (see Exit Status below).
 
 #### Behavior Notes
 
-- **Destructive and unconditional.** There is no per-email filter and
-  no confirmation prompt. If you have five users allowed and only want
-  to revoke one, clearing and re-running `room-authz add-user` for the
-  other four is the only route through this CLI.
-- **`--make-room-private` is not a synonym for "deny everyone".** It
-  works by relying on `default_allow_deny=DENY` on the new empty
-  policy, matching the current database default. If a future schema
-  change alters that default, `--make-room-private` will follow the
-  new default rather than hard-coding `DENY`.
+- **Non-destructive.** ACL entries are never deleted. If a
+  `RoomPolicy` already exists and is already private
+  (`default_allow_deny=DENY`), the command is a no-op and the
+  existing policy — including all its ACL entries — is dumped
+  unchanged.
+- **Public-no-row vs. public-by-policy.** A room with no policy row
+  at all is the default public state; this command transitions it
+  directly to private (`DENY`, no entries) without needing
+  `--update`. A room with an explicit policy whose
+  `default_allow_deny=ALLOW` is a deliberately public-by-policy
+  room — the command refuses to flip it without `--update`, so an
+  operator who relied on the explicit ALLOW isn't silently overridden.
+- **Pairs with `add-acl-entry`.** Run `make-private` first to lock
+  the room down, then use
+  [`add-acl-entry`](#room-authz-add-acl-entry) to grant access to
+  specific users.
+
+#### Exit Status
+
+- `0` on success — policy created, already private, or successfully
+  flipped to `DENY` under `--update`.
+- `1` when the existing policy has `default_allow_deny=ALLOW` and
+  `--update` is not passed, or when the RAM-DB guard fires.
 
 #### Examples
 
-Open the `search` room back up to all authenticated users:
+Make the `chat` room private as a fresh setup step:
 
 ```bash
-soliplex-cli room-authz clear example/installation.yaml search
+soliplex-cli room-authz make-private example/installation.yaml chat
 ```
 
-Wipe the ACL on the `chat` room and lock it down completely:
+Re-run safely — the room is already private, so the command is a
+no-op and dumps the existing policy:
 
 ```bash
-soliplex-cli room-authz clear --make-room-private \
+soliplex-cli room-authz make-private example/installation.yaml chat
+```
+
+Flip an explicitly public-by-policy room to private while preserving
+any existing ALLOW ACL entries (so previously-listed users keep
+access and everyone else is now denied):
+
+```bash
+soliplex-cli room-authz make-private --update \
   example/installation.yaml chat
 ```
 
-Clear-and-seed — start from a clean private state, then allow one user
-in:
+Make-private then grant a single user explicit access:
 
 ```bash
-soliplex-cli room-authz clear --make-room-private \
+soliplex-cli room-authz make-private example/installation.yaml chat
+soliplex-cli room-authz add-acl-entry \
+  --allow --email alice@example.com \
   example/installation.yaml chat
-soliplex-cli room-authz add-user example/installation.yaml chat alice@example.com
+```
+
+### `room-authz make-public`
+
+Ensure a room is public. Inverse of `make-private`: a room with no
+`RoomPolicy` row is already public-to-all-authenticated-users, so the
+command is a no-op in that case; a room with an existing policy whose
+`default_allow_deny=ALLOW` is also already public-by-policy, again a
+no-op. The command refuses to silently flip a private room
+(`default_allow_deny=DENY`) to public unless `--update` is passed.
+
+Existing ACL entries are preserved; the command only ever toggles
+`default_allow_deny`.
+
+```bash
+soliplex-cli room-authz make-public [OPTIONS] INSTALLATION_CONFIG_PATH ROOM_ID
+```
+
+#### Options
+
+- `--update` — when an existing `RoomPolicy` row is found with
+  `default_allow_deny=DENY`, flip it in place to `ALLOW`. ACL entries
+  are preserved either way. Without this flag, encountering a `DENY`
+  policy is treated as an error (see Exit Status below).
+
+#### Behavior Notes
+
+- **Non-destructive.** ACL entries are never deleted. After
+  `--update`, any existing `ALLOW` entries become redundant (everyone
+  is now allowed by default) and any existing `DENY` entries continue
+  to block their specific users; if that's not what you want, follow
+  up with [`clear-acl`](#room-authz-clear-acl) and rebuild.
+- **No row needed for "public."** Unlike `make-private`, this command
+  does not create a `RoomPolicy` row in the no-row case — the room
+  is already in the default public state. As a result, the JSON
+  dump may be `null` after a successful run.
+
+#### Exit Status
+
+- `0` on success — already public, or successfully flipped to
+  `ALLOW` under `--update`.
+- `1` when the existing policy has `default_allow_deny=DENY` and
+  `--update` is not passed, or when the RAM-DB guard fires.
+
+#### Examples
+
+Confirm a room is public (no-op when already in the default state):
+
+```bash
+soliplex-cli room-authz make-public example/installation.yaml chat
+```
+
+Flip a previously-private room to public while preserving its ACL
+entries (so any `DENY` entries continue to block their specific
+users):
+
+```bash
+soliplex-cli room-authz make-public --update \
+  example/installation.yaml chat
+```
+
+Open a room back up *and* drop its ACL entries — combine with
+[`clear-acl`](#room-authz-clear-acl):
+
+```bash
+soliplex-cli room-authz make-public --update example/installation.yaml chat
+soliplex-cli room-authz clear-acl example/installation.yaml chat
+```
+
+### `room-authz add-acl-entry`
+
+Add an `ACLEntry` to a room's `RoomPolicy`. The entry's allow/deny
+flag is selected with `--allow` or `--deny`; the entry's
+discriminator (what it matches against the caller's token) is
+selected with one of `--everyone`, `--authenticated`,
+`--preferred-username`, or `--email`.
+
+The room must already have a `RoomPolicy` row — run
+[`make-private`](#room-authz-make-private) or
+[`make-public`](#room-authz-make-public) first to establish the
+policy's `default_allow_deny`. This avoids silently flipping a
+public room to private as a side effect of adding the first entry.
+
+```bash
+soliplex-cli room-authz add-acl-entry [OPTIONS] INSTALLATION_CONFIG_PATH ROOM_ID
+```
+
+#### Options
+
+Exactly one of:
+
+- `--allow` — the entry grants access.
+- `--deny` — the entry denies access.
+
+Exactly one of (the discriminator — what the entry matches on):
+
+- `--everyone` — matches every request, regardless of token. Useful
+  as a catch-all that sets effective behavior independent of the
+  policy's `default_allow_deny`.
+- `--authenticated` — matches any caller with a valid OIDC token,
+  regardless of identity.
+- `--preferred-username TEXT` — matches a caller whose OIDC
+  `preferred_username` claim equals `TEXT`.
+- `--email TEXT` — matches a caller whose OIDC `email` claim equals
+  `TEXT`.
+
+#### Behavior Notes
+
+- **Existing policy required.** If no `RoomPolicy` row exists for the
+  room, the command prints an error and exits with status `1`. Run
+  `make-private` (or `make-public`) first.
+- **Dedup is per-discriminator.** Adding an entry whose discriminator
+  matches an existing entry on the policy deletes the existing entry
+  before inserting the new one. Adding `--allow --email alice@x.y`
+  replaces any prior `email=alice@x.y` entry (whether previously
+  `ALLOW` or `DENY`). Entries keyed by other discriminators
+  (`--preferred-username alice`, `--email bob@x.y`, etc.) are left
+  alone.
+- **First-match-wins, in insertion order.** ACL entries are checked
+  in their creation order at request time; the first one whose
+  discriminator matches the caller wins (see
+  `ACLEntry.check_token`). This means a `--deny --email alice@x.y`
+  added *after* a `--allow --everyone` will still keep Alice out,
+  because the `email` entry matches her token before the catch-all
+  fires — but only if Alice's row was created *before* the
+  `--everyone` row. When ordering matters, build the policy from
+  most-specific to least-specific.
+
+#### Exit Status
+
+- `0` on success.
+- `1` when `--allow`/`--deny` are both passed or both omitted; when
+  no (or more than one) discriminator option is supplied; when no
+  `RoomPolicy` exists for the room; or when the RAM-DB guard fires.
+
+#### Examples
+
+Grant a single user access to a private room:
+
+```bash
+soliplex-cli room-authz add-acl-entry \
+  --allow --email alice@example.com \
+  example/installation.yaml chat
+```
+
+Block a single user on a public-by-policy room:
+
+```bash
+soliplex-cli room-authz add-acl-entry \
+  --deny --email mallory@example.com \
+  example/installation.yaml chat
+```
+
+Open the room to every authenticated user, on top of an existing
+private policy (useful for temporarily widening access without
+flipping `default_allow_deny`):
+
+```bash
+soliplex-cli room-authz add-acl-entry \
+  --allow --authenticated \
+  example/installation.yaml chat
+```
+
+Keyed by `preferred_username` instead of `email`:
+
+```bash
+soliplex-cli room-authz add-acl-entry \
+  --allow --preferred-username alice \
+  example/installation.yaml chat
+```
+
+Catch-all `DENY` for a public-by-policy room, with selective ALLOW
+exceptions added beforehand (because earlier entries win):
+
+```bash
+soliplex-cli room-authz make-public example/installation.yaml chat
+soliplex-cli room-authz add-acl-entry \
+  --allow --email alice@example.com \
+  example/installation.yaml chat
+soliplex-cli room-authz add-acl-entry \
+  --deny --everyone \
+  example/installation.yaml chat
+```
+
+### `room-authz delete-acl-entry`
+
+Delete a single `ACLEntry` from a room's `RoomPolicy`. The entry is
+identified by the same parameter shape as
+[`add-acl-entry`](#room-authz-add-acl-entry): the combination of
+`--allow`/`--deny` and one discriminator option (`--everyone`,
+`--authenticated`, `--preferred-username`, or `--email`).
+
+The room must already have a `RoomPolicy` row with at least one ACL
+entry matching the supplied parameters. If no match is found, the
+command exits with status `1` so the operator can tell that the
+delete was a no-op.
+
+```bash
+soliplex-cli room-authz delete-acl-entry [OPTIONS] INSTALLATION_CONFIG_PATH ROOM_ID
+```
+
+#### Options
+
+Exactly one of:
+
+- `--allow` — match an `ALLOW` entry.
+- `--deny` — match a `DENY` entry.
+
+Exactly one of (the discriminator):
+
+- `--everyone` — match an `everyone` entry.
+- `--authenticated` — match an `authenticated` entry.
+- `--preferred-username TEXT` — match a `preferred_username` entry
+  whose claim value equals `TEXT`.
+- `--email TEXT` — match an `email` entry whose claim value equals
+  `TEXT`.
+
+#### Behavior Notes
+
+- **Exact match on (allow/deny, discriminator).** An entry with the
+  same discriminator but the opposite allow/deny flag is *not* a
+  match. To swap an entry from `DENY` to `ALLOW` for the same
+  discriminator, just call
+  [`add-acl-entry`](#room-authz-add-acl-entry) with the new flag —
+  its per-discriminator dedup will replace the existing row.
+- **Policy preserved.** Only the matching ACL entries are removed;
+  the `RoomPolicy` row remains. The room's `default_allow_deny`
+  is unchanged.
+- **Multiple matches.** If the database somehow contains more than
+  one entry matching the supplied parameters (which the CLI cannot
+  produce on its own, but a seed YAML or direct DB write could),
+  all matches are deleted.
+
+#### Exit Status
+
+- `0` on success — at least one matching entry was deleted.
+- `1` when `--allow`/`--deny` are both passed or both omitted; when
+  no (or more than one) discriminator option is supplied; when no
+  `RoomPolicy` exists for the room; when no entry matches the
+  supplied parameters; or when the RAM-DB guard fires.
+
+#### Examples
+
+Revoke a single user's access:
+
+```bash
+soliplex-cli room-authz delete-acl-entry \
+  --allow --email alice@example.com \
+  example/installation.yaml chat
+```
+
+Remove a `DENY` blocking a specific user, so they fall back to the
+policy's `default_allow_deny`:
+
+```bash
+soliplex-cli room-authz delete-acl-entry \
+  --deny --email mallory@example.com \
+  example/installation.yaml chat
+```
+
+Lift a temporary `--allow --authenticated` catch-all that was added
+to widen access while keeping the policy private:
+
+```bash
+soliplex-cli room-authz delete-acl-entry \
+  --allow --authenticated \
+  example/installation.yaml chat
+```
+
+### `room-authz clear-acl`
+
+Delete every `ACLEntry` attached to a room's `RoomPolicy` while
+leaving the policy itself in place. The room's `default_allow_deny`
+setting is preserved: a private room (`DENY`) stays private and now
+denies *everyone* (no ACL entries left to grant exceptions); a
+public-by-policy room (`ALLOW`) stays public-by-policy.
+
+```bash
+soliplex-cli room-authz clear-acl [OPTIONS] INSTALLATION_CONFIG_PATH ROOM_ID
+```
+
+#### Behavior Notes
+
+- **Policy preserved.** The `RoomPolicy` row is not deleted, only
+  its ACL entries; pair with `make-private` or `make-public` if
+  you also need to change the room's `default_allow_deny`.
+- **No-op on the no-row case.** If no `RoomPolicy` exists for the
+  room, the command makes no changes and dumps `null`. (There are
+  no ACL entries to clear without a parent policy.)
+- **Destructive and unconditional.** There is no per-discriminator
+  filter and no confirmation prompt — every ACL entry on the policy
+  is removed in one call. If you want to revoke a single user, use
+  your database tooling or rebuild the ACL with repeated
+  [`add-acl-entry`](#room-authz-add-acl-entry) calls.
+- **"Lock everyone out, then re-grant" primitive.** Run
+  `clear-acl` on a private room and the policy row stays in place
+  with zero allowed users; follow up with
+  [`add-acl-entry`](#room-authz-add-acl-entry) to re-grant access
+  to a fresh set of users.
+
+#### Examples
+
+Strip every ACL entry from the `chat` room while keeping it
+private (no one can get in until `add-acl-entry` is run again):
+
+```bash
+soliplex-cli room-authz clear-acl example/installation.yaml chat
+```
+
+Reset-and-seed — clear all existing access without changing the
+room's privacy setting, then grant one user:
+
+```bash
+soliplex-cli room-authz clear-acl example/installation.yaml chat
+soliplex-cli room-authz add-acl-entry \
+  --allow --email alice@example.com \
+  example/installation.yaml chat
 ```
 
 ## `ollama`
@@ -1633,8 +1962,6 @@ future major release. New scripts should use the grouped form.
 | `add-admin-user`              | `admin-users add`          |
 | `clear-admin-users`           | `admin-users clear`        |
 | `show-room-authz`             | `room-authz show`          |
-| `add-room-user`               | `room-authz add-user`      |
-| `clear-room-authz`            | `room-authz clear`         |
 | `pull-models`                 | `ollama pull`              |
 
 The `serve --add-admin-user` option on the `serve` subcommand is **not**

--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -1269,10 +1269,10 @@ All six commands share the following:
   ```json
   {
     "room_id": "chat",
-    "default_allow_deny": "AllowDeny.DENY",
+    "default_allow_deny": "DENY",
     "acl_entries": [
       {
-        "allow_deny": "AllowDeny.ALLOW",
+        "allow_deny": "ALLOW",
         "everyone": false,
         "authenticated": false,
         "preferred_username": null,
@@ -1334,7 +1334,7 @@ Extract just the list of allowed emails with `jq`:
 
 ```bash
 soliplex-cli room-authz show example/installation.yaml chat \
-  | jq -r '.acl_entries[] | select(.allow_deny == "AllowDeny.ALLOW") | .email'
+  | jq -r '.acl_entries[] | select(.allow_deny == "ALLOW") | .email'
 ```
 
 A `null` response means no `RoomPolicy` row exists yet — i.e. the room

--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -672,6 +672,73 @@ Just the room IDs and names, skipping the RAG detail:
 soliplex-cli audit rooms example/installation.yaml | grep '^- \['
 ```
 
+### `audit room-authz`
+
+Bucket the configured rooms by their authorization state, and surface
+any stale `RoomPolicy` rows left behind in the authorization database
+by past room renames or removals.
+
+```bash
+soliplex-cli audit [OPTIONS] room-authz [INSTALLATION_CONFIG_PATH]
+```
+
+See [Group Options](#group-options) for the available `[OPTIONS]`.
+
+#### Positional Argument
+
+- `INSTALLATION_CONFIG_PATH` — path to the installation configuration.
+  May be a YAML file, or a directory containing an `installation.yaml`.
+  If omitted, falls back to the `SOLIPLEX_INSTALLATION_PATH` environment
+  variable.
+
+#### Output
+
+Four buckets are printed (each a bulleted list of `room_id`s, or
+`(none)` when empty):
+
+- **Default** — configured rooms with no `RoomPolicy` row in the
+  authorization database; public to all authenticated users by
+  default.
+- **Public** — configured rooms with a `RoomPolicy` row whose
+  `default_allow_deny=ALLOW` (public-by-policy).
+- **Private** — configured rooms with a `RoomPolicy` row whose
+  `default_allow_deny=DENY`.
+- **Stale** — `RoomPolicy` rows whose `room_id` is **not** present
+  in the installation YAML. Each entry is suffixed with the literal
+  marker `STALE`. These rows are typically orphaned leftovers from
+  a room rename or removal, and they cannot be inspected or cleaned
+  up through the (non-deprecated) `room-authz` commands, which
+  require a configured `ROOM_ID`. Use
+  [`room-authz show --allow-stale`](#room-authz-show) to inspect a
+  specific stale policy.
+
+When the installation's `authorization_dburi` is the in-memory
+default (`sqlite://`), every configured room falls into the
+**Default** bucket and the other three buckets are empty.
+
+#### Exit Status
+
+- `0` when the **Stale** bucket is empty.
+- `1` when one or more stale rows are detected, regardless of how
+  the configured rooms are distributed across the other three
+  buckets. In `-q` / `--quiet` mode, the stale list is emitted to
+  stdout as JSON of the form
+  `{"room_authz": {"stale_rooms": ["<room_id>", …]}}`.
+
+#### Examples
+
+Inspect the room/authz state of the example installation:
+
+```bash
+soliplex-cli audit room-authz example/installation.yaml
+```
+
+CI-friendly check that no stale policies remain:
+
+```bash
+soliplex-cli audit -q room-authz example/installation.yaml
+```
+
 ### `audit completions`
 
 List the OpenAI-compatible completion endpoints declared in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ omit = [
     "src/soliplex/cli/__init__.py",
     "src/soliplex/cli/admin_users.py",
     "src/soliplex/cli/ollama.py",
-    "src/soliplex/cli/room_authz.py",
     "src/soliplex/cli/serve.py",
 
     "src/soliplex/examples.py",

--- a/src/soliplex/cli/audit.py
+++ b/src/soliplex/cli/audit.py
@@ -11,9 +11,11 @@ from haiku.rag import client as hr_client
 from skills_ref import validator as skill_validator
 from typer import core as typer_core
 
+from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import models
 from soliplex import secrets
+from soliplex.authz import schema as authz_schema
 from soliplex.cli import cli_util
 from soliplex.cli import types
 from soliplex.config import agui as config_agui
@@ -128,6 +130,7 @@ def audit_all(
     errors |= _audit_environment_section(ctx, installation_path)
     errors |= _audit_oidc_section(ctx, installation_path)
     errors |= _audit_rooms_section(ctx, installation_path)
+    errors |= _audit_room_authz_section(ctx, installation_path)
     errors |= _audit_completions_section(ctx, installation_path)
     errors |= _audit_quizzes_section(ctx, installation_path)
     errors |= _audit_skills_section(ctx, installation_path)
@@ -549,6 +552,109 @@ def _invalid_completions(
             errors.setdefault("completions", {})[compl_config.id] = str(exc)
 
     return errors
+
+
+def _room_authz_groups(the_installation):
+    """Bucket configured rooms by authorization state; collect stale rows."""
+    configured = sorted(the_installation._config.room_configs)
+    dburi = the_installation.authorization_dburi_sync
+
+    if dburi == config_installation.SYNC_MEMORY_ENGINE_URL:
+        return {
+            "default": list(configured),
+            "public": [],
+            "private": [],
+            "stale": [],
+        }
+
+    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
+    with session:
+        policies = {
+            p.room_id: p.default_allow_deny
+            for p in session.query(authz_schema.RoomPolicy)
+        }
+
+    configured_set = set(configured)
+    default, public, private = [], [], []
+    for room_id in configured:
+        if room_id not in policies:
+            default.append(room_id)
+        elif policies[room_id] == authz_package.AllowDeny.ALLOW:
+            public.append(room_id)
+        else:
+            private.append(room_id)
+
+    stale = sorted(rid for rid in policies if rid not in configured_set)
+
+    return {
+        "default": default,
+        "public": public,
+        "private": private,
+        "stale": stale,
+    }
+
+
+def _audit_room_authz_section(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+) -> dict:  # pragma NO COVER UI ONLY
+    """Print the room-authz section (rule header + four buckets)."""
+    quiet = ctx.obj["quiet"]
+    the_installation = _get_installation(ctx, installation_path)
+    tc_line, tc_rule, tc_print, _ = _quiet_console_funcs(quiet)
+
+    tc_line()
+    tc_rule("Configured rooms by authorization state")
+    tc_line()
+
+    groups = _room_authz_groups(the_installation)
+
+    for label, room_ids in (
+        (
+            "Default (no policy row -- public to authenticated users)",
+            groups["default"],
+        ),
+        ("Public (policy row, default ALLOW)", groups["public"]),
+        ("Private (policy row, default DENY)", groups["private"]),
+    ):
+        tc_print(f"{label}:")
+        if room_ids:
+            for room_id in room_ids:
+                tc_print(f"  - {room_id}")
+        else:
+            tc_print("  (none)")
+        tc_line()
+
+    tc_print("Stale (policy row exists for unconfigured room):")
+    if groups["stale"]:
+        for room_id in groups["stale"]:
+            tc_print(f"  - {room_id}  STALE")
+    else:
+        tc_print("  (none)")
+    tc_line()
+
+    errors: dict = {}
+    if groups["stale"]:
+        errors["room_authz"] = {"stale_rooms": groups["stale"]}
+    return errors
+
+
+@app.command("room-authz")
+def audit_room_authz(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+):  # pragma NO COVER command
+    """List rooms by authorization status.
+
+    Buckets: 'default' (no policy row), 'public' (policy with
+    default_allow_deny=ALLOW), 'private' (policy with
+    default_allow_deny=DENY), 'stale' (policy row exists in the
+    authorization database for a room that isn't configured in the
+    YAML). A non-empty 'stale' bucket is reported as an audit error.
+    """
+    quiet = ctx.obj["quiet"]
+    errors = _audit_room_authz_section(ctx, installation_path)
+    _emit_errors(errors, quiet)
 
 
 def _audit_completions_section(

--- a/src/soliplex/cli/main.py
+++ b/src/soliplex/cli/main.py
@@ -2,21 +2,32 @@ from __future__ import annotations
 
 import json
 import pathlib
+import warnings
 from importlib import metadata as importlib_metadata
 
 import typer
 import yaml
+from authlib import deprecate as authlib_deprecate
 
-from soliplex import secrets
-from soliplex import util
-from soliplex.cli import admin_users
-from soliplex.cli import audit
-from soliplex.cli import cli_util
-from soliplex.cli import ollama
-from soliplex.cli import room_authz
-from soliplex.cli import serve
-from soliplex.cli import types
-from soliplex.config import installation as config_installation
+warnings.filterwarnings(
+    action="ignore",
+    category=authlib_deprecate.AuthlibDeprecationWarning,
+    module="fastmcp",
+)
+
+if True:  # noqa E402
+    # These imports are not "top level" because we install the warning
+    # filter for the 'fastmcp'/'authlib' deprecation first.
+    from soliplex import secrets
+    from soliplex import util
+    from soliplex.cli import admin_users
+    from soliplex.cli import audit
+    from soliplex.cli import cli_util
+    from soliplex.cli import ollama
+    from soliplex.cli import room_authz
+    from soliplex.cli import serve
+    from soliplex.cli import types
+    from soliplex.config import installation as config_installation
 
 the_cli = typer.Typer(
     context_settings={

--- a/src/soliplex/cli/room_authz.py
+++ b/src/soliplex/cli/room_authz.py
@@ -19,7 +19,121 @@ app = typer.Typer(
 )
 
 
-def _dump_room_policy(session, room_id):
+# Flip this to True to make human-focused output the default.
+# '--quiet' will still force JSON.
+_DEFAULT_VERBOSE = False
+
+
+@app.callback()
+def _room_authz_callback(
+    ctx: typer.Context,
+    verbose: bool = typer.Option(
+        False,
+        "-v",
+        "--verbose",
+        help=(
+            "Print human-focused output instead of a JSON dump. "
+            "Overridden by '--quiet'."
+        ),
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "-q",
+        "--quiet",
+        help=(
+            "Force JSON output, overriding '--verbose' and any "
+            "verbose-by-default setting."
+        ),
+    ),
+):
+    if quiet:
+        effective = False
+    elif verbose:
+        effective = True
+    else:
+        effective = _DEFAULT_VERBOSE
+    ctx.obj = {"verbose": effective}
+
+
+def _check_room_id(the_installation, room_id):
+    room_configs = the_installation._config.room_configs
+    if room_id in room_configs:
+        return
+
+    the_console.rule(f"No room configured with id '{room_id}'")
+    configured = sorted(room_configs)
+    if configured:
+        the_console.print(
+            f"Configured rooms: {', '.join(configured)}",
+        )
+    else:
+        the_console.print("The installation has no rooms configured.")
+    raise typer.Exit(1)
+
+
+def _describe_discriminator(entry):
+    if entry.everyone:
+        return "everyone"
+    if entry.authenticated:
+        return "authenticated"
+    if entry.preferred_username is not None:
+        return f"preferred_username={entry.preferred_username}"
+    if entry.email is not None:
+        return f"email={entry.email}"
+    return "(invalid: no discriminator set)"
+
+
+def _human_dump_room_policy(session, room_id):  # pragma NO COVER UI ONLY
+    with session:
+        policy = (
+            session.query(
+                authz_schema.RoomPolicy,
+            )
+            .where(
+                authz_schema.RoomPolicy.room_id == room_id,
+            )
+            .first()
+        )
+
+        the_console.rule(f"Room policy: {room_id}")
+
+        if policy is None:
+            the_console.print(
+                "No policy row exists. Room is in default public "
+                "state (all authenticated users allowed).",
+            )
+            return
+
+        if policy.default_allow_deny == authz_package.AllowDeny.DENY:
+            the_console.print(
+                "Default: DENY (private -- denies callers that don't "
+                "match an ALLOW entry).",
+            )
+        else:
+            the_console.print(
+                "Default: ALLOW (public-by-policy -- admits callers "
+                "that don't match a DENY entry).",
+            )
+
+        if not policy.acl_entries:
+            the_console.print("ACL entries: (none)")
+            return
+
+        the_console.print(f"ACL entries ({len(policy.acl_entries)}):")
+        for index, entry in enumerate(policy.acl_entries, 1):
+            flag = entry.allow_deny.name
+            discriminator = _describe_discriminator(entry)
+            the_console.print(f"  {index}. {flag:<5}  {discriminator}")
+
+
+def _dump(ctx, session, room_id):
+    if ctx.obj and ctx.obj.get("verbose"):
+        _human_dump_room_policy(session, room_id)
+    else:
+        _dump_room_policy(session, room_id)
+
+
+def _dump_room_policy(session, room_id):  # pragma NO COVER UI ONLY
     with session:
         policy = (
             session.query(
@@ -48,34 +162,64 @@ def show_room_authz(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
     room_id: str,
-):
+    allow_stale: bool = typer.Option(
+        False,
+        "--allow-stale",
+        help=(
+            "Skip the configured-room check, so a policy left behind "
+            "by a removed or renamed room can still be inspected."
+        ),
+    ),
+):  # pragma NO COVER command
     """Show room ACL entries defined in the installation's authz database."""
     the_installation = cli_util.get_installation(installation_path)
     dburi = the_installation.authorization_dburi_sync
 
     cli_util._check_ram_dburi(dburi, "room-authz show")
+    if not allow_stale:
+        _check_room_id(the_installation, room_id)
 
     session = authz_schema.get_session(engine_url=dburi, init_schema=True)
 
-    _dump_room_policy(session, room_id)
+    _dump(ctx, session, room_id)
 
 
-@app.command("clear")
-def clear_room_authz(
+@app.command("make-private")
+def make_room_private(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
     room_id: str,
-    make_room_private: bool = typer.Option(
+    update: bool = typer.Option(
         False,
-        "--make-room-private",
-        help="Make room private",
+        "--update",
+        help=(
+            "If the room already has a policy with "
+            "default_allow_deny=ALLOW, update it in place to DENY "
+            "(preserving existing ACL entries)."
+        ),
     ),
-):
-    """Clear room ACL entries from the installation's authz database."""
+):  # pragma NO COVER command
+    """Ensure a room is private
+
+    A room with no RoomPolicy row is public-to-all-authenticated-users
+    by default; this command flips it to private by inserting an empty
+    RoomPolicy (default_allow_deny=DENY, no ACL entries).
+
+    If a policy already exists for the room, existing ACL entries are
+    preserved.
+
+    If the existing policy has default_allow_deny set to DENY,
+    the command is a no-op.
+
+    If the existing policy has default_allow_deny set to ALLOW,
+    the command fails, unless '--update' is passed in which case the
+    policy is updated in place to DENY (ACL entries still preserved).
+    """
     the_installation = cli_util.get_installation(installation_path)
     dburi = the_installation.authorization_dburi_sync
 
-    cli_util._check_ram_dburi(dburi, "room-authz clear")
+    cli_util._check_ram_dburi(dburi, "room-authz make-private")
+    _check_room_id(the_installation, room_id)
 
     session = authz_schema.get_session(engine_url=dburi, init_schema=True)
 
@@ -90,35 +234,433 @@ def clear_room_authz(
             .first()
         )
 
-        before_entries = len(session.query(authz_schema.ACLEntry).all())
-
-        should_remove = 0
-        if policy is not None:
-            # for acl_entry in policy.acl_entries:
-            #    session.delete(acl_entry)
-            should_remove = len(policy.acl_entries)
-
-            session.delete(policy)
-            session.commit()
-
-        after_entries = len(session.query(authz_schema.ACLEntry).all())
-        assert after_entries == before_entries - should_remove
-
-        if make_room_private:
+        if policy is None:
             policy = authz_schema.RoomPolicy(room_id=room_id)
             session.add(policy)
             session.commit()
+        elif policy.default_allow_deny == authz_package.AllowDeny.ALLOW:
+            if not update:
+                the_console.rule(
+                    "Room policy already exists with default ALLOW",
+                )
+                the_console.print(
+                    f"Room '{room_id}' has an existing policy with "
+                    "default_allow_deny=ALLOW; pass '--update' to "
+                    "flip it to DENY.",
+                )
+                raise typer.Exit(1)
+            policy.default_allow_deny = authz_package.AllowDeny.DENY
+            session.commit()
 
-    _dump_room_policy(session, room_id)
+    _dump(ctx, session, room_id)
 
 
-@app.command("add-user")
+@app.command("make-public")
+def make_room_public(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+    room_id: str,
+    update: bool = typer.Option(
+        False,
+        "--update",
+        help=(
+            "If the room already has a policy with "
+            "default_allow_deny=DENY, update it in place to ALLOW "
+            "(preserving existing ACL entries)."
+        ),
+    ),
+):  # pragma NO COVER command
+    """Ensure a room is public
+
+    A room with no RoomPolicy row is public-to-all-authenticated-users
+    by default; this command is a no-op in that case.
+
+    If a policy already exists for the room, existing ACL entries are
+    preserved.
+
+    If the existing policy has default_allow_deny set to ALLOW,
+    the command is a no-op.
+
+    If the existing policy has default_allow_deny set to DENY,
+    the command fails, unless '--update' is passed in which case the
+    policy is updated in place to ALLOW (ACL entries still preserved).
+    """
+    the_installation = cli_util.get_installation(installation_path)
+    dburi = the_installation.authorization_dburi_sync
+
+    cli_util._check_ram_dburi(dburi, "room-authz make-public")
+    _check_room_id(the_installation, room_id)
+
+    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
+
+    with session:
+        policy = (
+            session.query(
+                authz_schema.RoomPolicy,
+            )
+            .where(
+                authz_schema.RoomPolicy.room_id == room_id,
+            )
+            .first()
+        )
+
+        if policy is not None and (
+            policy.default_allow_deny == authz_package.AllowDeny.DENY
+        ):
+            if not update:
+                the_console.rule(
+                    "Room policy already exists with default DENY",
+                )
+                the_console.print(
+                    f"Room '{room_id}' has an existing policy with "
+                    "default_allow_deny=DENY; pass '--update' to "
+                    "flip it to ALLOW.",
+                )
+                raise typer.Exit(1)
+            policy.default_allow_deny = authz_package.AllowDeny.ALLOW
+            session.commit()
+
+    _dump(ctx, session, room_id)
+
+
+@app.command("clear-acl")
+def clear_room_acl(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+    room_id: str,
+):  # pragma NO COVER command
+    """Clear ACL entries from a room's policy, preserving the policy
+
+    Unlike 'clear', this command does not delete the room's
+    RoomPolicy row -- only its ACL entries. The policy's
+    'default_allow_deny' setting is preserved: a private room
+    (default DENY) stays private (and now denies everyone),
+    a public-by-policy room (default ALLOW) stays public-by-policy.
+
+    If no RoomPolicy exists for the room, the command is a no-op.
+    """
+    the_installation = cli_util.get_installation(installation_path)
+    dburi = the_installation.authorization_dburi_sync
+
+    cli_util._check_ram_dburi(dburi, "room-authz clear-acl")
+    _check_room_id(the_installation, room_id)
+
+    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
+
+    with session:
+        policy = (
+            session.query(
+                authz_schema.RoomPolicy,
+            )
+            .where(
+                authz_schema.RoomPolicy.room_id == room_id,
+            )
+            .first()
+        )
+
+        if policy is not None:
+            for acl_entry in policy.acl_entries:
+                session.delete(acl_entry)
+            session.commit()
+
+    _dump(ctx, session, room_id)
+
+
+# Deprecated and hidden BBB commands.
+
+
+@app.command("add-acl-entry")
+def add_acl_entry(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+    room_id: str,
+    allow: bool = typer.Option(
+        False,
+        "--allow",
+        help="Entry grants access. Mutually exclusive with '--deny'.",
+    ),
+    deny: bool = typer.Option(
+        False,
+        "--deny",
+        help="Entry denies access. Mutually exclusive with '--allow'.",
+    ),
+    everyone: bool = typer.Option(
+        False,
+        "--everyone",
+        help="Match every request (use as a catch-all).",
+    ),
+    authenticated: bool = typer.Option(
+        False,
+        "--authenticated",
+        help="Match any authenticated user.",
+    ),
+    preferred_username: str | None = typer.Option(
+        None,
+        "--preferred-username",
+        help="Match a user by OIDC preferred_username claim.",
+    ),
+    email: str | None = typer.Option(
+        None,
+        "--email",
+        help="Match a user by OIDC email claim.",
+    ),
+):  # pragma NO COVER command
+    """Add an ACL entry to a room's policy.
+
+    Exactly one of '--allow' or '--deny' must be supplied.
+
+    Exactly one discriminator option ('--everyone', '--authenticated',
+    '--preferred-username', or '--email') must be supplied.
+
+    The room must already have a RoomPolicy row -- run 'make-private'
+    or 'make-public' first to establish the policy's
+    'default_allow_deny'. This avoids silently flipping a public
+    room to private as a side effect of adding the first entry.
+
+    If an existing ACL entry has the same discriminator, it is
+    replaced by the new entry. Entries with different discriminators
+    are left untouched.
+    """
+    if allow == deny:
+        the_console.rule("Exactly one of '--allow' or '--deny' required")
+        flags_given = [
+            name for name, v in (("--allow", allow), ("--deny", deny)) if v
+        ]
+        the_console.print(
+            "Pass exactly one of '--allow' or '--deny'. "
+            f"Got: {flags_given or ['(none)']}.",
+        )
+        raise typer.Exit(1)
+
+    if allow:
+        allow_deny = authz_package.AllowDeny.ALLOW
+    else:
+        allow_deny = authz_package.AllowDeny.DENY
+
+    selected = [
+        name
+        for name, present in (
+            ("--everyone", everyone),
+            ("--authenticated", authenticated),
+            ("--preferred-username", preferred_username is not None),
+            ("--email", email is not None),
+        )
+        if present
+    ]
+    if len(selected) != 1:
+        the_console.rule("Exactly one discriminator required")
+        the_console.print(
+            "Pass exactly one of '--everyone', '--authenticated', "
+            "'--preferred-username', or '--email'. "
+            f"Got: {selected or ['(none)']}.",
+        )
+        raise typer.Exit(1)
+
+    the_installation = cli_util.get_installation(installation_path)
+    dburi = the_installation.authorization_dburi_sync
+
+    cli_util._check_ram_dburi(dburi, "room-authz add-acl-entry")
+    _check_room_id(the_installation, room_id)
+
+    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
+
+    with session:
+        policy = (
+            session.query(
+                authz_schema.RoomPolicy,
+            )
+            .where(
+                authz_schema.RoomPolicy.room_id == room_id,
+            )
+            .first()
+        )
+
+        if policy is None:
+            the_console.rule(f"No policy exists for room '{room_id}'")
+            the_console.print(
+                f"Run 'room-authz make-private' or "
+                "'room-authz make-public' to establish a policy "
+                f"for '{room_id}' before adding ACL entries.",
+            )
+            raise typer.Exit(1)
+
+        for entry in list(policy.acl_entries):
+            if everyone and entry.everyone:
+                session.delete(entry)
+            elif authenticated and entry.authenticated:
+                session.delete(entry)
+            elif (
+                preferred_username is not None
+                and entry.preferred_username == preferred_username
+            ):
+                session.delete(entry)
+            elif email is not None and entry.email == email:
+                session.delete(entry)
+        session.commit()
+
+        new_acl = authz_schema.ACLEntry(
+            room_policy=policy,
+            allow_deny=allow_deny,
+            everyone=everyone,
+            authenticated=authenticated,
+            preferred_username=preferred_username,
+            email=email,
+        )
+        session.add(new_acl)
+        session.commit()
+
+    _dump(ctx, session, room_id)
+
+
+@app.command("delete-acl-entry")
+def delete_acl_entry(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+    room_id: str,
+    allow: bool = typer.Option(
+        False,
+        "--allow",
+        help="Match an ALLOW entry. Mutually exclusive with '--deny'.",
+    ),
+    deny: bool = typer.Option(
+        False,
+        "--deny",
+        help="Match a DENY entry. Mutually exclusive with '--allow'.",
+    ),
+    everyone: bool = typer.Option(
+        False,
+        "--everyone",
+        help="Match an 'everyone' entry.",
+    ),
+    authenticated: bool = typer.Option(
+        False,
+        "--authenticated",
+        help="Match an 'authenticated' entry.",
+    ),
+    preferred_username: str | None = typer.Option(
+        None,
+        "--preferred-username",
+        help="Match a 'preferred_username' entry by claim value.",
+    ),
+    email: str | None = typer.Option(
+        None,
+        "--email",
+        help="Match an 'email' entry by claim value.",
+    ),
+):  # pragma NO COVER command
+    """Delete an ACL entry from a room's policy.
+
+    The entry to delete is identified by the combination of
+    '--allow'/'--deny' and exactly one discriminator option
+    ('--everyone', '--authenticated', '--preferred-username',
+    '--email') -- the same parameter shape as 'add-acl-entry'.
+
+    The room must already have a RoomPolicy row with at least one
+    matching ACL entry. If no matching entry exists, the command
+    fails and exits with a non-zero status.
+
+    The RoomPolicy row is preserved; only matching ACL entries
+    are removed.
+    """
+    if allow == deny:
+        the_console.rule("Exactly one of '--allow' or '--deny' required")
+        flags_given = [
+            name for name, v in (("--allow", allow), ("--deny", deny)) if v
+        ]
+        the_console.print(
+            "Pass exactly one of '--allow' or '--deny'. "
+            f"Got: {flags_given or ['(none)']}.",
+        )
+        raise typer.Exit(1)
+
+    if allow:
+        allow_deny = authz_package.AllowDeny.ALLOW
+    else:
+        allow_deny = authz_package.AllowDeny.DENY
+
+    selected = [
+        name
+        for name, present in (
+            ("--everyone", everyone),
+            ("--authenticated", authenticated),
+            ("--preferred-username", preferred_username is not None),
+            ("--email", email is not None),
+        )
+        if present
+    ]
+    if len(selected) != 1:
+        the_console.rule("Exactly one discriminator required")
+        the_console.print(
+            "Pass exactly one of '--everyone', '--authenticated', "
+            "'--preferred-username', or '--email'. "
+            f"Got: {selected or ['(none)']}.",
+        )
+        raise typer.Exit(1)
+
+    the_installation = cli_util.get_installation(installation_path)
+    dburi = the_installation.authorization_dburi_sync
+
+    cli_util._check_ram_dburi(dburi, "room-authz delete-acl-entry")
+    _check_room_id(the_installation, room_id)
+
+    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
+
+    with session:
+        policy = (
+            session.query(
+                authz_schema.RoomPolicy,
+            )
+            .where(
+                authz_schema.RoomPolicy.room_id == room_id,
+            )
+            .first()
+        )
+
+        if policy is None:
+            the_console.rule(f"No policy exists for room '{room_id}'")
+            the_console.print(
+                f"Room '{room_id}' has no RoomPolicy; nothing to delete.",
+            )
+            raise typer.Exit(1)
+
+        matches = []
+        for entry in policy.acl_entries:
+            if entry.allow_deny != allow_deny:
+                continue
+            if everyone and entry.everyone:
+                matches.append(entry)
+            elif authenticated and entry.authenticated:
+                matches.append(entry)
+            elif (
+                preferred_username is not None
+                and entry.preferred_username == preferred_username
+            ):
+                matches.append(entry)
+            elif email is not None and entry.email == email:
+                matches.append(entry)
+
+        if not matches:
+            the_console.rule("No matching ACL entry found")
+            the_console.print(
+                f"Room '{room_id}' has no ACL entry matching the "
+                "supplied --allow/--deny and discriminator.",
+            )
+            raise typer.Exit(1)
+
+        for entry in matches:
+            session.delete(entry)
+        session.commit()
+
+    _dump(ctx, session, room_id)
+
+
+@app.command("add-user", hidden=True, deprecated=True)
 def add_room_user(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
     room_id: str,
     user_email: str,
-):
+):  # pragma NO COVER command
     """Add a user to the ACL for a room."""
     the_installation = cli_util.get_installation(installation_path)
     dburi = the_installation.authorization_dburi_sync
@@ -159,5 +701,64 @@ def add_room_user(
         )
         session.add(new_acl)
         session.commit()
+
+    _dump_room_policy(session, room_id)
+
+
+@app.command("clear", hidden=True, deprecated=True)
+def clear_room_authz(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+    room_id: str,
+    make_room_private: bool = typer.Option(
+        False,
+        "--make-room-private",
+        help="Make room private",
+    ),
+):  # pragma NO COVER command
+    """Clear room ACL entries from the installation's authz database
+
+    Unless '--make-room-private' is passed, the room will be in its
+    default-public state.
+
+    If '--make-room-private' is passed, the room policy will be set to
+    private (default_allow_deny of DENY), with no users.
+    """
+    the_installation = cli_util.get_installation(installation_path)
+    dburi = the_installation.authorization_dburi_sync
+
+    cli_util._check_ram_dburi(dburi, "room-authz clear")
+
+    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
+
+    with session:
+        policy = (
+            session.query(
+                authz_schema.RoomPolicy,
+            )
+            .where(
+                authz_schema.RoomPolicy.room_id == room_id,
+            )
+            .first()
+        )
+
+        before_entries = len(session.query(authz_schema.ACLEntry).all())
+
+        should_remove = 0
+        if policy is not None:
+            # for acl_entry in policy.acl_entries:
+            #    session.delete(acl_entry)
+            should_remove = len(policy.acl_entries)
+
+            session.delete(policy)
+            session.commit()
+
+        after_entries = len(session.query(authz_schema.ACLEntry).all())
+        assert after_entries == before_entries - should_remove
+
+        if make_room_private:
+            policy = authz_schema.RoomPolicy(room_id=room_id)
+            session.add(policy)
+            session.commit()
 
     _dump_room_policy(session, room_id)

--- a/src/soliplex/cli/room_authz.py
+++ b/src/soliplex/cli/room_authz.py
@@ -133,6 +133,22 @@ def _dump(ctx, session, room_id):
         _dump_room_policy(session, room_id)
 
 
+def _room_policy_as_jsonable(policy):
+    """Render a RoomPolicy (or None) as a JSON-serializable dict.
+
+    AllowDeny values are emitted as their member names ('ALLOW' /
+    'DENY') rather than the default 'AllowDeny.ALLOW' /
+    'AllowDeny.DENY' string form.
+    """
+    if policy is None:
+        return None
+    to_dump = policy.as_model.model_dump()
+    to_dump["default_allow_deny"] = to_dump["default_allow_deny"].name
+    for dump_ae in to_dump["acl_entries"]:
+        dump_ae["allow_deny"] = dump_ae["allow_deny"].name
+    return to_dump
+
+
 def _dump_room_policy(session, room_id):  # pragma NO COVER UI ONLY
     with session:
         policy = (
@@ -144,15 +160,7 @@ def _dump_room_policy(session, room_id):  # pragma NO COVER UI ONLY
             )
             .first()
         )
-
-        if policy is None:
-            to_dump = policy
-        else:
-            to_dump = policy.as_model.model_dump()
-            to_dump["default_allow_deny"] = str(to_dump["default_allow_deny"])
-
-            for dump_ae in to_dump["acl_entries"]:
-                dump_ae["allow_deny"] = str(dump_ae["allow_deny"])
+        to_dump = _room_policy_as_jsonable(policy)
 
     print(json.dumps(to_dump))
 

--- a/tests/unit/cli/test_cli_audit.py
+++ b/tests/unit/cli/test_cli_audit.py
@@ -8,8 +8,10 @@ import pytest
 import typer
 import yaml
 
+from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import secrets
+from soliplex.authz import schema as authz_schema
 from soliplex.cli import audit as cli_audit
 from soliplex.config import installation as config_installation
 from soliplex.config import quizzes as config_quizzes
@@ -183,6 +185,7 @@ def test__audit_callback(ctx, w_quiet):
 @mock.patch("soliplex.cli.audit._audit_skills_section")
 @mock.patch("soliplex.cli.audit._audit_quizzes_section")
 @mock.patch("soliplex.cli.audit._audit_completions_section")
+@mock.patch("soliplex.cli.audit._audit_room_authz_section")
 @mock.patch("soliplex.cli.audit._audit_rooms_section")
 @mock.patch("soliplex.cli.audit._audit_oidc_section")
 @mock.patch("soliplex.cli.audit._audit_environment_section")
@@ -194,6 +197,7 @@ def test_audit_all(
     _audit_environment_section,
     _audit_oidc_section,
     _audit_rooms_section,
+    _audit_room_authz_section,
     _audit_completions_section,
     _audit_quizzes_section,
     _audit_skills_section,
@@ -213,6 +217,7 @@ def test_audit_all(
         _audit_environment_section.return_value = {"environment": None}
         _audit_oidc_section.return_value = {"oidc": None}
         _audit_rooms_section.return_value = {"rooms": None}
+        _audit_room_authz_section.return_value = {"room_authz": None}
         _audit_completions_section.return_value = {"completions": None}
         _audit_quizzes_section.return_value = {"quizzes": None}
         _audit_skills_section.return_value = {"skills": None}
@@ -225,6 +230,7 @@ def test_audit_all(
             "environment": None,
             "oidc": None,
             "rooms": None,
+            "room_authz": None,
             "completions": None,
             "quizzes": None,
             "skills": None,
@@ -237,6 +243,7 @@ def test_audit_all(
         _audit_environment_section.return_value = {}
         _audit_oidc_section.return_value = {}
         _audit_rooms_section.return_value = {}
+        _audit_room_authz_section.return_value = {}
         _audit_completions_section.return_value = {}
         _audit_quizzes_section.return_value = {}
         _audit_skills_section.return_value = {}
@@ -254,6 +261,7 @@ def test_audit_all(
     _audit_environment_section.assert_called_once_with(ctx, installation_path)
     _audit_oidc_section.assert_called_once_with(ctx, installation_path)
     _audit_rooms_section.assert_called_once_with(ctx, installation_path)
+    _audit_room_authz_section.assert_called_once_with(ctx, installation_path)
     _audit_completions_section.assert_called_once_with(ctx, installation_path)
     _audit_quizzes_section.assert_called_once_with(ctx, installation_path)
     _audit_skills_section.assert_called_once_with(ctx, installation_path)
@@ -654,6 +662,130 @@ def test__invalid_room_rag_dbs(
 
 # _audit_rooms_section: ui only
 # audit_rooms: command
+
+
+@pytest.mark.parametrize(
+    "is_ram, configured_rooms, policy_specs, exp_groups",
+    [
+        # RAM DB: all configured rooms land in 'default'; DB
+        # query is not invoked.
+        (
+            True,
+            [],
+            None,
+            {"default": [], "public": [], "private": [], "stale": []},
+        ),
+        (
+            True,
+            ["alpha", "beta"],
+            None,
+            {
+                "default": ["alpha", "beta"],
+                "public": [],
+                "private": [],
+                "stale": [],
+            },
+        ),
+        # Non-RAM, empty configuration + empty DB.
+        (
+            False,
+            [],
+            [],
+            {"default": [], "public": [], "private": [], "stale": []},
+        ),
+        # Non-RAM, configured rooms but no DB rows -> all default.
+        (
+            False,
+            ["alpha", "beta"],
+            [],
+            {
+                "default": ["alpha", "beta"],
+                "public": [],
+                "private": [],
+                "stale": [],
+            },
+        ),
+        # Non-RAM, only DB rows for unconfigured rooms -> all stale.
+        (
+            False,
+            [],
+            [("old", "ALLOW"), ("removed", "DENY")],
+            {
+                "default": [],
+                "public": [],
+                "private": [],
+                "stale": ["old", "removed"],
+            },
+        ),
+        # Non-RAM, mixed: one row in each of the four buckets.
+        (
+            False,
+            ["alpha", "beta", "gamma", "delta"],
+            [
+                ("beta", "ALLOW"),
+                ("gamma", "DENY"),
+                ("ghost", "DENY"),
+            ],
+            {
+                "default": ["alpha", "delta"],
+                "public": ["beta"],
+                "private": ["gamma"],
+                "stale": ["ghost"],
+            },
+        ),
+    ],
+)
+@mock.patch("soliplex.cli.audit.authz_schema.get_session")
+def test__room_authz_groups(
+    get_session,
+    the_installation,
+    is_ram,
+    configured_rooms,
+    policy_specs,
+    exp_groups,
+):
+    the_installation._config.room_configs = {
+        rid: mock.Mock() for rid in configured_rooms
+    }
+
+    if is_ram:
+        the_installation._config.authorization_dburi_sync = (
+            config_installation.SYNC_MEMORY_ENGINE_URL
+        )
+    else:
+        the_installation._config.authorization_dburi_sync = "sqlite:///x.db"
+
+        policy_rows = []
+        for room_id, allow_deny in policy_specs:
+            row = mock.Mock()
+            row.room_id = room_id
+            row.default_allow_deny = (
+                authz_package.AllowDeny.ALLOW
+                if allow_deny == "ALLOW"
+                else authz_package.AllowDeny.DENY
+            )
+            policy_rows.append(row)
+
+        session = mock.MagicMock()
+        session.query.return_value = policy_rows
+        get_session.return_value = session
+
+    found = cli_audit._room_authz_groups(the_installation)
+
+    assert found == exp_groups
+
+    if is_ram:
+        get_session.assert_not_called()
+    else:
+        get_session.assert_called_once_with(
+            engine_url="sqlite:///x.db",
+            init_schema=True,
+        )
+        session.query.assert_called_once_with(authz_schema.RoomPolicy)
+
+
+# _audit_room_authz_section: ui only
+# audit_room_authz: command
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli/test_cli_room_authz.py
+++ b/tests/unit/cli/test_cli_room_authz.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import typer
+
+from soliplex import installation
+from soliplex.cli import room_authz as cli_room_authz
+from soliplex.config import installation as config_installation
+
+
+@pytest.fixture
+def ctx():
+    return mock.create_autospec(typer.Context, obj={})
+
+
+@pytest.fixture
+def the_installation() -> installation.Installation:
+    i_config = mock.create_autospec(config_installation.InstallationConfig)
+    return installation.Installation(_config=i_config)
+
+
+@pytest.mark.parametrize(
+    "w_verbose, w_quiet, w_default_verbose, exp_effective",
+    [
+        # Neither flag: falls back to the module default.
+        (False, False, False, False),
+        (False, False, True, True),
+        # --verbose alone forces human.
+        (True, False, False, True),
+        (True, False, True, True),
+        # --quiet alone forces JSON, regardless of the default.
+        (False, True, False, False),
+        (False, True, True, False),
+        # --quiet wins when both flags are passed.
+        (True, True, False, False),
+        (True, True, True, False),
+    ],
+)
+def test__room_authz_callback(
+    ctx,
+    w_verbose,
+    w_quiet,
+    w_default_verbose,
+    exp_effective,
+):
+    with mock.patch.object(
+        cli_room_authz,
+        "_DEFAULT_VERBOSE",
+        w_default_verbose,
+    ):
+        cli_room_authz._room_authz_callback(
+            ctx,
+            verbose=w_verbose,
+            quiet=w_quiet,
+        )
+
+    assert ctx.obj == {"verbose": exp_effective}
+
+
+@pytest.mark.parametrize(
+    "w_configured, w_room_id, exp_raises",
+    [
+        # No configured rooms; any id is unknown.
+        ([], "anything", True),
+        # Configured rooms; matching id is OK.
+        (["chat"], "chat", False),
+        (["chat", "search"], "search", False),
+        # Configured rooms; non-matching id is rejected.
+        (["chat"], "search", True),
+        (["chat", "search"], "nosuch", True),
+    ],
+)
+@mock.patch("soliplex.cli.room_authz.the_console")
+def test__check_room_id(
+    the_console,
+    the_installation,
+    w_configured,
+    w_room_id,
+    exp_raises,
+):
+    the_installation._config.room_configs = {
+        rid: mock.Mock() for rid in w_configured
+    }
+
+    if not exp_raises:
+        cli_room_authz._check_room_id(the_installation, w_room_id)
+
+        the_console.rule.assert_not_called()
+        the_console.print.assert_not_called()
+        return
+
+    with pytest.raises(typer.Exit) as excinfo:
+        cli_room_authz._check_room_id(the_installation, w_room_id)
+
+    (return_code,) = excinfo.value.args
+    assert return_code == 1
+
+    the_console.rule.assert_called_once_with(
+        f"No room configured with id '{w_room_id}'",
+    )
+    if w_configured:
+        the_console.print.assert_called_once_with(
+            f"Configured rooms: {', '.join(sorted(w_configured))}",
+        )
+    else:
+        the_console.print.assert_called_once_with(
+            "The installation has no rooms configured.",
+        )
+
+
+@pytest.mark.parametrize(
+    "w_attrs, exp_text",
+    [
+        # 'everyone' wins outright.
+        (
+            {
+                "everyone": True,
+                "authenticated": False,
+                "preferred_username": None,
+                "email": None,
+            },
+            "everyone",
+        ),
+        # ... even when other discriminators are also set.
+        (
+            {
+                "everyone": True,
+                "authenticated": True,
+                "preferred_username": "alice",
+                "email": "alice@example.com",
+            },
+            "everyone",
+        ),
+        # 'authenticated' is the second priority.
+        (
+            {
+                "everyone": False,
+                "authenticated": True,
+                "preferred_username": None,
+                "email": None,
+            },
+            "authenticated",
+        ),
+        # 'preferred_username' is the third priority.
+        (
+            {
+                "everyone": False,
+                "authenticated": False,
+                "preferred_username": "alice",
+                "email": None,
+            },
+            "preferred_username=alice",
+        ),
+        # 'email' is the fallback when only it is set.
+        (
+            {
+                "everyone": False,
+                "authenticated": False,
+                "preferred_username": None,
+                "email": "alice@example.com",
+            },
+            "email=alice@example.com",
+        ),
+        # No discriminator set is treated as invalid (defensive).
+        (
+            {
+                "everyone": False,
+                "authenticated": False,
+                "preferred_username": None,
+                "email": None,
+            },
+            "(invalid: no discriminator set)",
+        ),
+    ],
+)
+def test__describe_discriminator(w_attrs, exp_text):
+    entry = mock.Mock(**w_attrs)
+
+    found = cli_room_authz._describe_discriminator(entry)
+
+    assert found == exp_text
+
+
+@pytest.mark.parametrize(
+    "w_obj, exp_human",
+    [
+        # No ctx.obj at all -> JSON dispatch.
+        (None, False),
+        # Empty ctx.obj -> JSON dispatch.
+        ({}, False),
+        # ctx.obj['verbose'] falsy -> JSON dispatch.
+        ({"verbose": False}, False),
+        # ctx.obj['verbose'] truthy -> human dispatch.
+        ({"verbose": True}, True),
+    ],
+)
+@mock.patch("soliplex.cli.room_authz._human_dump_room_policy")
+@mock.patch("soliplex.cli.room_authz._dump_room_policy")
+def test__dump(
+    _dump_room_policy,
+    _human_dump_room_policy,
+    ctx,
+    w_obj,
+    exp_human,
+):
+    ctx.obj = w_obj
+    session = mock.Mock()
+
+    cli_room_authz._dump(ctx, session, "room-1")
+
+    if exp_human:
+        _human_dump_room_policy.assert_called_once_with(session, "room-1")
+        _dump_room_policy.assert_not_called()
+    else:
+        _dump_room_policy.assert_called_once_with(session, "room-1")
+        _human_dump_room_policy.assert_not_called()
+
+
+# _human_dump_room_policy: ui only
+# _dump_room_policy: ui only
+# show_room_authz: command
+# make_room_private: command
+# make_room_public: command
+# clear_room_acl: command
+# add_acl_entry: command
+# delete_acl_entry: command
+# add_room_user: command (deprecated)
+# clear_room_authz: command (deprecated)

--- a/tests/unit/cli/test_cli_room_authz.py
+++ b/tests/unit/cli/test_cli_room_authz.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 import typer
 
+from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex.cli import room_authz as cli_room_authz
 from soliplex.config import installation as config_installation
@@ -216,6 +217,83 @@ def test__dump(
     else:
         _dump_room_policy.assert_called_once_with(session, "room-1")
         _human_dump_room_policy.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "w_dumped, exp_jsonable",
+    [
+        # No policy row -> passes through as None.
+        (None, None),
+        # Empty policy: default-DENY, no ACL entries.
+        (
+            {
+                "room_id": "chat",
+                "default_allow_deny": authz_package.AllowDeny.DENY,
+                "acl_entries": [],
+            },
+            {
+                "room_id": "chat",
+                "default_allow_deny": "DENY",
+                "acl_entries": [],
+            },
+        ),
+        # Populated policy: both 'default_allow_deny' and each entry's
+        # 'allow_deny' must be emitted as their bare member names, not
+        # as the 'AllowDeny.<NAME>' default 'str()' form.
+        (
+            {
+                "room_id": "chat",
+                "default_allow_deny": authz_package.AllowDeny.ALLOW,
+                "acl_entries": [
+                    {
+                        "allow_deny": authz_package.AllowDeny.ALLOW,
+                        "everyone": False,
+                        "authenticated": False,
+                        "preferred_username": None,
+                        "email": "alice@example.com",
+                    },
+                    {
+                        "allow_deny": authz_package.AllowDeny.DENY,
+                        "everyone": True,
+                        "authenticated": False,
+                        "preferred_username": None,
+                        "email": None,
+                    },
+                ],
+            },
+            {
+                "room_id": "chat",
+                "default_allow_deny": "ALLOW",
+                "acl_entries": [
+                    {
+                        "allow_deny": "ALLOW",
+                        "everyone": False,
+                        "authenticated": False,
+                        "preferred_username": None,
+                        "email": "alice@example.com",
+                    },
+                    {
+                        "allow_deny": "DENY",
+                        "everyone": True,
+                        "authenticated": False,
+                        "preferred_username": None,
+                        "email": None,
+                    },
+                ],
+            },
+        ),
+    ],
+)
+def test__room_policy_as_jsonable(w_dumped, exp_jsonable):
+    if w_dumped is None:
+        policy = None
+    else:
+        policy = mock.Mock()
+        policy.as_model.model_dump.return_value = w_dumped
+
+    found = cli_room_authz._room_policy_as_jsonable(policy)
+
+    assert found == exp_jsonable
 
 
 # _human_dump_room_policy: ui only


### PR DESCRIPTION
Described in #935.

## New commands
    
      ┌──────────────────┬───────────────────────────────────────────────────────┐
      │     Command      │                        Purpose                        │
      ├──────────────────┼───────────────────────────────────────────────────────┤
      │                  │ Ensure a room has a RoomPolicy with                   │
      │ make-private     │ default_allow_deny=DENY. Idempotent; --update flips   │
      │                  │ an existing ALLOW policy in place. Errors on          │
      │                  │ ALLOW-policy without --update.                        │
      ├──────────────────┼───────────────────────────────────────────────────────┤
      │ make-public      │ Inverse of make-private. No-op on no-row or ALLOW;    │
      │                  │ --update required to flip a DENY policy.              │
      ├──────────────────┼───────────────────────────────────────────────────────┤
      │ clear-acl        │ Delete all ACL entries on a policy; preserve the      │
      │                  │ policy row and its default_allow_deny.                │
      ├──────────────────┼───────────────────────────────────────────────────────┤
      │                  │ Full-fidelity add: --allow/--deny × one discriminator │
      │ add-acl-entry    │  (--everyone, --authenticated, --preferred-username,  │
      │                  │ --email). Requires an existing policy (no silent      │
      │                  │ public→private flip).                                 │
      ├──────────────────┼───────────────────────────────────────────────────────┤
      │                  │ Parallels add-acl-entry's parameter shape. Exact      │
      │ delete-acl-entry │ match on (allow/deny, discriminator); no-match exits  │
      │                  │ 1.                                                    │
      └──────────────────┴───────────────────────────────────────────────────────┘
    
## Deprecated, kept functional
    
  - add-user and clear — both marked hidden=True, deprecated=True, removed from
    docs, still wired for back-compat. Their flat aliases (add-room-user,
    clear-room-authz) likewise still work.

## Group-level flags
    
  - -v / --verbose — replaces the default JSON dump with a Rich-rendered human
    summary (rule header, default-DENY/ALLOW annotation, numbered ACL entry list
    with discriminator)
  - -q / --quiet — forces JSON, overriding --verbose or any verbose-by-default
    setting.
  - _DEFAULT_VERBOSE = False knob in cli/room_authz.py for flipping the default
    later. Resolution: quiet > verbose > _DEFAULT_VERBOSE.

## Safety guards added
    
  - _check_room_id — six non-deprecated commands now validate ROOM_ID against
    the_installation._config.room_configs and exit 1 with the configured-rooms
    list when no match. Closes issue #935's 'stale policies accumulate' footgun
    
## Stale policiy handling
    
  - show now accepts an '--allow-stale' flag to permit inspecting the
    policy for a room ID not defined in the installation config.

  - 'audit room-authz' now reports rooms grouped by auhtz policy status:
    'default' (empty), 'public', 'private', and 'stale' (DB records for rooms which
    do not exist).

## Cleanups

- Silence transitive 'fastmcp'/'authlib' deprecation