### PR TITLE
feat: 'soliplex-cli shell <installation_path>'

### DIFF
--- a/src/soliplex/cli/main.py
+++ b/src/soliplex/cli/main.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import code
 import json
 import pathlib
+import sys
 from importlib import metadata as importlib_metadata
 
 import typer
@@ -136,6 +138,24 @@ def agui_feature_schemas(
     }
 
     print(json.dumps(feature_schemas))
+
+
+BANNER = f"""\
+Python {sys.version} on {sys.platform}
+(Soliplex CLI shell)
+'the_intstallation' is available for querying.
+"""
+EXITMSG = "Now exiting Soliplex CLI shell"
+
+
+@misc_app.command("shell")
+def shell(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+):
+    """Python REPL w/ installation configuration available"""
+    the_installation = cli_util.get_installation(installation_path)
+    code.interact(local=locals(), banner=BANNER, exitmsg=EXITMSG)
 
 
 the_cli.add_typer(misc_app)


### PR DESCRIPTION
Loads 'the_installation' from the supplied path and drops into a Python REPL prompt for debugging.

Reviewers:  I wrote this to ease querying a configuration as loaded.  It *does* include the ability to see resolved secrets, but given that the user has shell access on the system, I don't think that is a new exposure.  Maybe if we were supporting some kind of third party secret storage, it would be problematic.