### PR TITLE
chore: remove workarounds for 'fastmcp'/'authlib' deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,17 +19,16 @@ dependencies = [
     "authlib",
     "bubble-sandbox >= 0.10.0, < 0.11",
     "fastapi",
-    #"fastmcp >= 2.14.0, < 2.15",
     "fastmcp >= 3.2.4, < 3.3",
     "fakeredis != 2.35.0",  # brownbag
     "greenlet",
     "haiku.rag-slim >= 0.47.0, < 0.48",
     "haiku-skills >= 0.16.0, < 0.17",
+    "idna >= 3.15",
     "itsdangerous",
     "jsonpatch",
     "jwcrypto",
     "logfire[fastapi]",
-    #"pydantic-ai-slim[google] >= 1.81, < 1.82",
     "pydantic-ai-slim[google] >= 1.95, < 2.0",
     "pyjwt",
     "python-keycloak",
@@ -81,7 +80,6 @@ testpaths = ["tests/unit"]
 addopts = "--cov=soliplex --cov=tests/unit --cov-branch --cov-fail-under=100"
 filterwarnings = [
     # "ignore::DeprecationWarning:<source-package>",
-    "ignore::authlib.deprecate.AuthlibDeprecationWarning:fastmcp",
 ]
 markers = [
     "needs_llm: functest requiring an LLM",

--- a/src/soliplex/cli/main.py
+++ b/src/soliplex/cli/main.py
@@ -2,32 +2,21 @@ from __future__ import annotations
 
 import json
 import pathlib
-import warnings
 from importlib import metadata as importlib_metadata
 
 import typer
 import yaml
-from authlib import deprecate as authlib_deprecate
 
-warnings.filterwarnings(
-    action="ignore",
-    category=authlib_deprecate.AuthlibDeprecationWarning,
-    module="fastmcp",
-)
-
-if True:  # noqa E402
-    # These imports are not "top level" because we install the warning
-    # filter for the 'fastmcp'/'authlib' deprecation first.
-    from soliplex import secrets
-    from soliplex import util
-    from soliplex.cli import admin_users
-    from soliplex.cli import audit
-    from soliplex.cli import cli_util
-    from soliplex.cli import ollama
-    from soliplex.cli import room_authz
-    from soliplex.cli import serve
-    from soliplex.cli import types
-    from soliplex.config import installation as config_installation
+from soliplex import secrets
+from soliplex import util
+from soliplex.cli import admin_users
+from soliplex.cli import audit
+from soliplex.cli import cli_util
+from soliplex.cli import ollama
+from soliplex.cli import room_authz
+from soliplex.cli import serve
+from soliplex.cli import types
+from soliplex.config import installation as config_installation
 
 the_cli = typer.Typer(
     context_settings={

--- a/uv.lock
+++ b/uv.lock
@@ -1189,11 +1189,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -3370,6 +3370,7 @@ dependencies = [
     { name = "greenlet" },
     { name = "haiku-rag-slim" },
     { name = "haiku-skills" },
+    { name = "idna" },
     { name = "itsdangerous" },
     { name = "jsonpatch" },
     { name = "jwcrypto" },
@@ -3423,6 +3424,7 @@ requires-dist = [
     { name = "greenlet" },
     { name = "haiku-rag-slim", specifier = ">=0.47.0,<0.48" },
     { name = "haiku-skills", specifier = ">=0.16.0,<0.17" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous" },
     { name = "jsonpatch" },
     { name = "jwcrypto" },


### PR DESCRIPTION
chore: bump 'idna >= 3.15' for CVE-2026-45409 fix