### PR TITLE
fix: 'result.usage' as method is deprecated

### DIFF
--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -526,7 +526,6 @@ async def capture_usage_after_stream(
         async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
             the_threads = agui_persistence.ThreadStorage(session)
 
-            usage = usage()
             await the_threads.save_run_usage(
                 user_name=user_name,
                 room_id=room_id,

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -987,7 +987,7 @@ async def test_capture_usage_after_stream(a_session, t_storage, w_usage):
     )
     if w_usage:
         result = mock.Mock(spec_set=["usage"])
-        result.usage.return_value = usage
+        result.usage = usage
     else:
         result = object()
 


### PR DESCRIPTION
Closes #992.