### PR TITLE
fix: 'retries' argument to 'Agent' deprecated

### DIFF
--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -122,7 +122,7 @@ def get_default_agent_from_configs(
         instructions=instructions,
         capabilities=agent_config.capabilities,
         deps_type=AgentDependencies,
-        retries=agent_config.retries,
+        tool_retries=agent_config.retries,
     )
 
 

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -211,7 +211,7 @@ def test_get_default_agent_from_configs(
 
     assert akc_kw["instructions"] == exp_instructions
     assert akc_kw["capabilities"] == exp_capabilities
-    assert akc_kw["retries"] == exp_retries
+    assert akc_kw["tool_retries"] == exp_retries
 
     if w_room_skills:
         build_system_prompt.assert_called_once_with(


### PR DESCRIPTION
  ... use 'tool_retries' instead.

Closes #994.