### PR TITLE
fix: CLI `ollama pull` quirks / affordances

### DIFF
--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -1782,11 +1782,14 @@ soliplex-cli ollama pull [OPTIONS] [INSTALLATION_CONFIG_PATH]
 
 #### Options
 
-- `-u URL` / `--ollama-url URL` — restrict the scan to a single Ollama
-  base URL. If omitted, the command pulls models on *every* Ollama URL
-  referenced by the installation (installations may point different
-  rooms at different Ollama instances). Defaults to the
-  `OLLAMA_BASE_URL` value in the installation's resolved environment.
+- `-u URL` / `--ollama-url URL` — restrict the scan to one or more
+  Ollama base URLs referenced by the installation. Repeatable: pass the
+  flag once per URL (e.g. `-u http://a.example.com -u
+  http://b.example.com`). If omitted, the command pulls models on
+  *every* Ollama URL referenced by the installation (installations may
+  point different rooms at different Ollama instances). Each supplied
+  URL must already be referenced by the installation — see
+  [Behavior Notes](#behavior-notes).
 - `-n` / `--dry-run` — scan the installation and print the model list
   per URL without actually pulling. Useful for verifying what *would*
   happen before committing to potentially slow downloads.
@@ -1797,12 +1800,13 @@ For each Ollama URL in scope, the command:
 
 1. Reports the URL and the count of distinct models the installation
    references at it.
-2. Lists the model names in sorted order.
-3. Unless `--dry-run` is set, pulls each model via Ollama's REST API
-   (`stream=False` — each pull blocks until complete, so no per-chunk
-   progress is shown) and prints the final status line returned by
-   Ollama for each model.
-4. Prints a summary in the form
+2. Iterates the model names in sorted order, printing
+   `Pulling: <model_name>` for each. Unless `--dry-run` is set, the
+   model is then pulled via Ollama's REST API (`stream=False` — each
+   pull blocks until complete, so no per-chunk progress is shown) and
+   the final status line returned by Ollama is printed below the
+   `Pulling:` line.
+3. Unless `--dry-run` is set, prints a summary in the form
    `Pulled <success_count>/<total> model(s) successfully`.
 
 If a URL has no models referenced by the installation, a
@@ -1817,21 +1821,25 @@ pulled for that URL.
 - **Per-model errors are reported inline.** Network failures
   (`requests.RequestException`) and missing-status responses are shown
   in red alongside the model name and counted against the success
-  total, but do not abort the overall command. Other models on the
-  same URL will still be pulled.
-- **`--ollama-url` filters, it doesn't inject.** If you pass a URL that
-  the installation doesn't reference, the scan finds an empty model
-  set for it and reports "No Ollama models for URL" — the command
-  won't pull arbitrary models to arbitrary servers.
+  total, but do not abort the per-URL loop. Other models on the same
+  URL will still be pulled. The command does exit non-zero at the end
+  if any pull failed — see [Exit Status](#exit-status).
+- **`--ollama-url` is validated against the installation.** Each
+  supplied URL must already appear among the Ollama URLs the
+  installation references. If any supplied URL is unknown, the command
+  prints the list of configured Ollama URLs (or notes that there are
+  none) and exits non-zero without pulling anything. The flag filters
+  the existing set; it does not inject a new destination.
 - **Non-Ollama providers are ignored.** Models bound to OpenAI, Gemini,
   or any other non-Ollama provider are not considered here; this
   command deals strictly with the local-model case.
 
 #### Exit Status
 
-- Always `0`, even when some pulls failed. Check the printed summary
-  (`Pulled X/N …`) to detect partial failure. Use `audit all` if you
-  need a non-zero exit for configuration problems before pulling.
+- `0` — every requested pull succeeded, `--dry-run` was specified, or
+  the in-scope URLs referenced no Ollama models.
+- `1` — at least one individual model pull failed, **or** one or more
+  `--ollama-url` values were not referenced by the installation.
 
 #### Examples
 
@@ -1853,6 +1861,15 @@ installation references multiple Ollama URLs):
 ```bash
 soliplex-cli ollama pull example/installation.yaml \
   --ollama-url http://ollama.internal:11434
+```
+
+Restrict the scan to several specific Ollama instances by repeating
+`--ollama-url`:
+
+```bash
+soliplex-cli ollama pull example/installation.yaml \
+  --ollama-url http://ollama-a.internal:11434 \
+  --ollama-url http://ollama-b.internal:11434
 ```
 
 ## `config`

--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -242,6 +242,11 @@ below for output details and JSON-error shapes.
 9. **Python logging** — if a `logging_config_file` is configured, it
    parses as YAML and the logging headers / claims maps are printed.
 10. **Logfire** — the Logfire config (if any) is printed for review.
+11. **Ollama** — for each Ollama server URL referenced by the
+    installation, the available-models list is fetched and compared
+    against the models the installation requires. Unreachable servers
+    and missing models are flagged. (See [`audit ollama`](#audit-ollama)
+    for the full output and JSON shape.)
 
 #### Exit Status
 
@@ -1063,6 +1068,84 @@ Logfire:
 
 ```bash
 soliplex-cli audit logfire example/minimal.yaml
+```
+
+### `audit ollama`
+
+For each Ollama server URL referenced by the installation, fetch the
+list of models currently available on the server (via the `/api/tags`
+endpoint) and compare it against the set of model names the
+installation requires for that URL. Models named by the installation
+but absent from the server are reported as needing to be pulled.
+
+```bash
+soliplex-cli audit [OPTIONS] ollama [INSTALLATION_CONFIG_PATH]
+```
+
+See [Group Options](#group-options) for the available `[OPTIONS]`.
+
+#### Positional Argument
+
+- `INSTALLATION_CONFIG_PATH` — path to the installation configuration.
+  May be a YAML file, or a directory containing an `installation.yaml`.
+  If omitted, falls back to the `SOLIPLEX_INSTALLATION_PATH` environment
+  variable.
+
+#### Output
+
+A `Configured Ollama URLs` rule is printed, followed by one entry per
+URL referenced by the installation:
+
+```text
+- <url>
+  OK | MISSING: <comma-separated model names> | ERROR: <reason>
+```
+
+When models are missing, the line directly below the `MISSING:` entry
+points to the `ollama pull` command:
+
+```text
+  Run 'soliplex-cli ollama pull' to pull missing models.
+```
+
+If the installation references no Ollama URLs, a single
+`No Ollama URLs referenced by the installation.` line is printed and
+the command exits cleanly.
+
+#### Exit Status
+
+- `0` — every required Ollama model is available on its server (or the
+  installation references no Ollama URLs).
+- `1` — at least one server is unreachable, **or** at least one
+  required model is missing from a reachable server.
+
+When the group's `-q` / `--quiet` flag is in effect, a `1` exit is
+accompanied by a single JSON document on stdout under the `ollama` key:
+
+```json
+{
+  "ollama": {
+    "http://a.example.com": {"missing_models": ["mistral", "phi3"]},
+    "http://b.example.com": {"unreachable": "('Connection refused',)"}
+  }
+}
+```
+
+A URL appears under `ollama` only when something went wrong on it;
+reachable servers with no missing models are omitted from the JSON.
+
+#### Examples
+
+Audit Ollama availability for an installation:
+
+```bash
+soliplex-cli audit ollama example/installation.yaml
+```
+
+Drive the audit from automation, capturing missing-models JSON:
+
+```bash
+soliplex-cli audit -q ollama example/installation.yaml
 ```
 
 ## `admin-users`

--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -1760,6 +1760,16 @@ referenced by the installation. Currently a single subcommand,
 This group replaces the deprecated flat `pull-models` command; see
 [Deprecated Command Names](#deprecated-command-names).
 
+### Group Options
+
+- `-q` / `--quiet` — suppress human-readable console output and emit
+  any errors as a single JSON document on stdout. The command still
+  exits non-zero on failure (see each subcommand's
+  [Exit Status](#exit-status)). Useful for piping into `jq` or for
+  driving the command from automation. Belongs to the group, so it
+  must appear before the subcommand name (e.g.
+  `soliplex-cli ollama -q pull example/installation.yaml`).
+
 ### `ollama pull`
 
 Scan the installation for every Ollama model referenced by its agents,
@@ -1841,6 +1851,19 @@ pulled for that URL.
 - `1` — at least one individual model pull failed, **or** one or more
   `--ollama-url` values were not referenced by the installation.
 
+When the group's `-q` / `--quiet` flag is in effect, a `1` exit is
+accompanied by a single JSON document on stdout. The document is a
+mapping whose keys identify the failure mode:
+
+- `unknown_ollama_urls`: list of URLs supplied via `--ollama-url` that
+  the installation does not reference.
+- `pulls`: mapping of Ollama URL → mapping of model name → error
+  message, populated when individual pulls fail.
+
+The two keys are mutually exclusive in practice: the unknown-URLs
+check fires before any pulls are attempted, so a run that fails on
+unknown URLs reports `unknown_ollama_urls` and skips the pull loop.
+
 #### Examples
 
 Preview which models would be pulled, without pulling anything:
@@ -1870,6 +1893,13 @@ Restrict the scan to several specific Ollama instances by repeating
 soliplex-cli ollama pull example/installation.yaml \
   --ollama-url http://ollama-a.internal:11434 \
   --ollama-url http://ollama-b.internal:11434
+```
+
+Drive the command from automation, suppressing the rule-decorated
+output and capturing any errors as JSON:
+
+```bash
+soliplex-cli ollama -q pull example/installation.yaml
 ```
 
 ## `config`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ markers = [
 omit = [
     "src/soliplex/cli/__init__.py",
     "src/soliplex/cli/admin_users.py",
-    "src/soliplex/cli/ollama.py",
     "src/soliplex/cli/serve.py",
 
     "src/soliplex/examples.py",

--- a/src/soliplex/cli/audit.py
+++ b/src/soliplex/cli/audit.py
@@ -5,6 +5,7 @@ import pathlib
 import sys
 import warnings
 
+import requests
 import typer
 import yaml
 from haiku.rag import client as hr_client
@@ -14,6 +15,7 @@ from typer import core as typer_core
 from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import models
+from soliplex import ollama
 from soliplex import secrets
 from soliplex.authz import schema as authz_schema
 from soliplex.cli import cli_util
@@ -136,6 +138,7 @@ def audit_all(
     errors |= _audit_skills_section(ctx, installation_path)
     errors |= _audit_logging_section(ctx, installation_path)
     errors |= _audit_logfire_section(ctx, installation_path)
+    errors |= _audit_ollama_section(ctx, installation_path)
 
     _emit_errors(errors, quiet)
 
@@ -994,4 +997,91 @@ def audit_logfire(
     """Show the Logfire config defined in the installation"""
     quiet = ctx.obj["quiet"]
     errors = _audit_logfire_section(ctx, installation_path)
+    _emit_errors(errors, quiet)
+
+
+def _missing_ollama_models(
+    the_installation: installation.Installation,
+) -> dict:
+    """Return per-URL info about Ollama models missing from each server.
+
+    Each value is either ``{"unreachable": str}`` (the server refused
+    the connection or returned an HTTP error) or
+    ``{"missing_models": [str, ...]}`` (the server is reachable but is
+    missing one or more models the installation references).
+    """
+    ollama_url_models = the_installation.all_provider_info.get("ollama", {})
+    per_url: dict[str, dict] = {}
+
+    for url, required in ollama_url_models.items():
+        if not required:
+            continue
+
+        rest_api = ollama.REST_API(url)
+
+        try:
+            response = rest_api.get_available_models()
+        except requests.RequestException as exc:
+            per_url[url] = {"unreachable": str(exc.args)}
+            continue
+
+        available = {entry["name"] for entry in response.get("models", ())}
+        missing = sorted(required - available)
+        if missing:
+            per_url[url] = {"missing_models": missing}
+
+    if per_url:
+        return {"ollama": per_url}
+    return {}
+
+
+def _audit_ollama_section(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+) -> dict:  # pragma NO COVER UI ONLY
+    """Print the Ollama section (rule header + per-URL availability check)."""
+    quiet = ctx.obj["quiet"]
+    the_installation = _get_installation(ctx, installation_path)
+    tc_line, tc_rule, tc_print, _ = _quiet_console_funcs(quiet)
+
+    tc_line()
+    tc_rule("Configured Ollama URLs")
+    tc_line()
+
+    ollama_url_models = the_installation.all_provider_info.get("ollama", {})
+    errors = _missing_ollama_models(the_installation)
+    per_url = errors.get("ollama", {})
+
+    if not ollama_url_models:
+        tc_print("No Ollama URLs referenced by the installation.")
+        tc_line()
+        return errors
+
+    for url in sorted(ollama_url_models):
+        tc_print(f"- {url}")
+        url_errors = per_url.get(url, {})
+        unreachable = url_errors.get("unreachable")
+        missing = url_errors.get("missing_models")
+        if unreachable is not None:
+            tc_print(f"  ERROR: {unreachable}")
+        elif missing:
+            tc_print(f"  MISSING: {', '.join(missing)}")
+            tc_print(
+                "  Run 'soliplex-cli ollama pull' to pull missing models.",
+            )
+        else:
+            tc_print("  OK")
+        tc_line()
+
+    return errors
+
+
+@app.command("ollama")
+def audit_ollama(
+    ctx: typer.Context,
+    installation_path: types.installation_path_type,
+):  # pragma NO COVER command
+    """Compare configured Ollama models against each server's available set"""
+    quiet = ctx.obj["quiet"]
+    errors = _audit_ollama_section(ctx, installation_path)
     _emit_errors(errors, quiet)

--- a/src/soliplex/cli/ollama.py
+++ b/src/soliplex/cli/ollama.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import requests
 import typer
 
@@ -7,11 +9,59 @@ from soliplex import ollama
 from soliplex.cli import cli_util
 from soliplex.cli import types
 
+OLLAMA_HELP = "List / manage Ollama models for the installation"
+
+the_console = cli_util.the_console
+
+
+_QUIET_OPTION = typer.Option(
+    False,
+    "-q",
+    "--quiet",
+    help="Show only errors (as JSON)",
+)
+
+
+def _noop(*args, **kwargs):  # pragma: NO COVER
+    return None
+
+
+def _quiet_console_funcs(quiet):
+    """Return ``(line, rule, print, print_exception)`` callables.
+
+    When ``quiet`` is true the returned callables are no-ops, suppressing
+    human-focused output.
+    """
+    if quiet:
+        return _noop, _noop, _noop, _noop
+    return (
+        the_console.line,
+        the_console.rule,
+        the_console.print,
+        the_console.print_exception,
+    )
+
+
+def _emit_errors(errors, quiet):
+    """Emit a JSON error report (in quiet mode) and exit ``1`` if any."""
+    if errors:
+        if quiet:
+            the_console.print_json(data=errors)
+        sys.exit(1)
+
+
 app = typer.Typer(
     name="ollama",
-    help="List / manage Ollama models for the installation",
+    help=OLLAMA_HELP,
 )
-the_console = cli_util.the_console
+
+
+@app.callback()
+def _ollama_callback(
+    ctx: typer.Context,
+    quiet: bool = _QUIET_OPTION,
+):
+    ctx.obj = {"quiet": quiet}
 
 
 ollama_url_option: list[str] = typer.Option(
@@ -93,19 +143,25 @@ def pull_models(
     ),
 ):  # pragma NO COVER command
     """Pull Ollama models referenced in the installation configuration"""
+    quiet = ctx.obj["quiet"]
+    tc_line, tc_rule, tc_print, _ = _quiet_console_funcs(quiet)
 
     def on_status(msg, is_error=False):
         style = "red" if is_error else None
-        the_console.print(f"  {msg}", style=style)
+        tc_print(f"  {msg}", style=style)
 
-    the_console.line()
-    the_console.rule("Scanning for Ollama models")
-    the_console.line()
+    errors: dict = {}
+
+    tc_line()
+    tc_rule("Scanning for Ollama models")
+    tc_line()
 
     the_installation = cli_util.get_installation(installation_path)
     the_installation.resolve_environment()
     all_provider_info = the_installation.all_provider_info
     all_ollama_url_models = all_provider_info["ollama"]
+
+    ollama_url_models = None
 
     try:
         ollama_url_models = _filter_ollama_url_models(
@@ -113,60 +169,58 @@ def pull_models(
             ollama_urls,
         )
     except UnknownOllamaURLs as exc:
-        the_console.rule(str(exc))
+        errors["unknown_ollama_urls"] = exc.unknown_urls
+        tc_rule(str(exc))
         configured = sorted(all_ollama_url_models)
         if configured:
-            the_console.print(
-                f"Configured Ollama URLs: {', '.join(configured)}",
-            )
+            tc_print(f"Configured Ollama URLs: {', '.join(configured)}")
         else:
-            the_console.print(
-                "The installation references no Ollama URLs.",
-            )
-        raise typer.Exit(1) from exc
+            tc_print("The installation references no Ollama URLs.")
 
-    any_failures = False
+    if ollama_url_models is not None:
+        for url, model_names in ollama_url_models.items():
+            if not model_names:
+                tc_rule(f"No Ollama models for URL: {url}")
+                tc_line()
+                continue
 
-    for url, model_names in ollama_url_models.items():
-        if not model_names:
-            the_console.rule(f"No Ollama models for URL: {url}")
-            the_console.line()
-
-        else:
             rest_api = ollama.REST_API(url)
 
-            the_console.rule(f"Pulling Ollama models for URL: {url}")
-            the_console.line()
-            the_console.print(
-                f"Found {len(model_names)} unique Ollama model(s)"
-            )
-            the_console.line()
+            tc_rule(f"Pulling Ollama models for URL: {url}")
+            tc_line()
+            tc_print(f"Found {len(model_names)} unique Ollama model(s)")
+            tc_line()
 
             success_count = 0
 
             for model_name in sorted(model_names):
-                the_console.print(f"\nPulling: {model_name}")
+                tc_print(f"\nPulling: {model_name}")
 
                 if not dry_run:
                     try:
                         status_text = _pull_one_model(rest_api, model_name)
                     except requests.RequestException as exc:
-                        on_status(str(exc.args), True)
-                        any_failures = True
+                        msg = str(exc.args)
+                        on_status(msg, True)
+                        errors.setdefault("pulls", {}).setdefault(url, {})[
+                            model_name
+                        ] = msg
                     except NoStatusReturned as exc:
-                        on_status(str(exc), True)
-                        any_failures = True
+                        msg = str(exc)
+                        on_status(msg, True)
+                        errors.setdefault("pulls", {}).setdefault(url, {})[
+                            model_name
+                        ] = msg
                     else:
                         on_status(status_text, False)
                         success_count += 1
 
-            the_console.line()
+            tc_line()
             if not dry_run:
-                the_console.rule(
+                tc_rule(
                     f"Pulled {success_count}/{len(model_names)} model(s) "
                     "successfully"
                 )
-            the_console.line()
+            tc_line()
 
-    if any_failures:
-        raise typer.Exit(1)
+    _emit_errors(errors, quiet)

--- a/src/soliplex/cli/ollama.py
+++ b/src/soliplex/cli/ollama.py
@@ -91,7 +91,7 @@ def pull_models(
         "--dry-run",
         help="Show which models would be pulled without actually pulling them",
     ),
-):
+):  # pragma NO COVER command
     """Pull Ollama models referenced in the installation configuration"""
 
     def on_status(msg, is_error=False):

--- a/src/soliplex/cli/ollama.py
+++ b/src/soliplex/cli/ollama.py
@@ -39,6 +39,30 @@ class UnknownOllamaURLs(Exception):
         )
 
 
+class NoStatusReturned(KeyError):
+    """Raised when an Ollama 'pull' response is missing the 'status' field."""
+
+    def __init__(self, result):
+        self.result = result
+        super().__init__(
+            f"No status returned in result: keys were {', '.join(result)}"
+        )
+
+
+def _pull_one_model(rest_api, model_name):
+    """Pull a single model via the Ollama REST API.
+
+    Returns the status text on success. Raises 'requests.RequestException'
+    on network errors and 'NoStatusReturned' when the response has no
+    'status' field.
+    """
+    result = rest_api.pull_model(model_name, stream=False)
+    try:
+        return result["status"]
+    except KeyError:
+        raise NoStatusReturned(result) from None
+
+
 def _filter_ollama_url_models(ollama_url_models, ollama_urls):
     """Restrict 'ollama_url_models' to 'ollama_urls' if any are supplied.
 
@@ -101,6 +125,8 @@ def pull_models(
             )
         raise typer.Exit(1) from exc
 
+    any_failures = False
+
     for url, model_names in ollama_url_models.items():
         if not model_names:
             the_console.rule(f"No Ollama models for URL: {url}")
@@ -116,29 +142,31 @@ def pull_models(
             )
             the_console.line()
 
+            success_count = 0
+
             for model_name in sorted(model_names):
-                the_console.print(f"  - {model_name}")
+                the_console.print(f"\nPulling: {model_name}")
 
-            if not dry_run:
-                success_count = 0
-
-                for model_name in sorted(model_names):
-                    the_console.print(f"\nPulling: {model_name}")
-
+                if not dry_run:
                     try:
-                        result = rest_api.pull_model(model_name, stream=False)
-                        status_text = result["status"]
+                        status_text = _pull_one_model(rest_api, model_name)
                     except requests.RequestException as exc:
                         on_status(str(exc.args), True)
-                    except KeyError:
-                        on_status("No status returned", True)
+                        any_failures = True
+                    except NoStatusReturned as exc:
+                        on_status(str(exc), True)
+                        any_failures = True
                     else:
                         on_status(status_text, False)
                         success_count += 1
 
-                the_console.line()
+            the_console.line()
+            if not dry_run:
                 the_console.rule(
                     f"Pulled {success_count}/{len(model_names)} model(s) "
                     "successfully"
                 )
-                the_console.line()
+            the_console.line()
+
+    if any_failures:
+        raise typer.Exit(1)

--- a/src/soliplex/cli/ollama.py
+++ b/src/soliplex/cli/ollama.py
@@ -14,19 +14,53 @@ app = typer.Typer(
 the_console = cli_util.the_console
 
 
+ollama_url_option: list[str] = typer.Option(
+    [],
+    "-u",
+    "--ollama-url",
+    help=(
+        "Restrict the pull to one or more Ollama API base URLs "
+        "referenced by the installation (repeatable; defaults to "
+        "scanning every Ollama URL the installation references)"
+    ),
+)
+
+
+class UnknownOllamaURLs(Exception):
+    """Raised when '--ollama-url' names URLs the installation does not
+    reference.
+    """
+
+    def __init__(self, unknown_urls):
+        self.unknown_urls = list(unknown_urls)
+        super().__init__(
+            "URL(s) not referenced by installation: "
+            f"{', '.join(self.unknown_urls)}"
+        )
+
+
+def _filter_ollama_url_models(ollama_url_models, ollama_urls):
+    """Restrict 'ollama_url_models' to 'ollama_urls' if any are supplied.
+
+    Raises 'UnknownOllamaURLs' if any of 'ollama_urls' is not referenced
+    by the installation.
+    """
+    if not ollama_urls:
+        return ollama_url_models
+
+    unknown = [url for url in ollama_urls if url not in ollama_url_models]
+
+    if unknown:
+        raise UnknownOllamaURLs(unknown)
+
+    return {url: ollama_url_models[url] for url in ollama_urls}
+
+
 @app.command("pull")
 def pull_models(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
-    ollama_url: str = typer.Option(
-        None,
-        "-u",
-        "--ollama-url",
-        help=(
-            "Ollama API base URL (defaults to 'OLLAMA_BASE_URL' from "
-            "installation enviroment)"
-        ),
-    ),
+    ollama_urls: list[str] = ollama_url_option,
     dry_run: bool = typer.Option(
         False,
         "-n",
@@ -47,12 +81,25 @@ def pull_models(
     the_installation = cli_util.get_installation(installation_path)
     the_installation.resolve_environment()
     all_provider_info = the_installation.all_provider_info
-    ollama_url_models = all_provider_info["ollama"]
+    all_ollama_url_models = all_provider_info["ollama"]
 
-    if ollama_url is not None:
-        ollama_url_models = {
-            ollama_url: ollama_url_models.get(ollama_url, set())
-        }
+    try:
+        ollama_url_models = _filter_ollama_url_models(
+            all_ollama_url_models,
+            ollama_urls,
+        )
+    except UnknownOllamaURLs as exc:
+        the_console.rule(str(exc))
+        configured = sorted(all_ollama_url_models)
+        if configured:
+            the_console.print(
+                f"Configured Ollama URLs: {', '.join(configured)}",
+            )
+        else:
+            the_console.print(
+                "The installation references no Ollama URLs.",
+            )
+        raise typer.Exit(1) from exc
 
     for url, model_names in ollama_url_models.items():
         if not model_names:

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -170,26 +170,31 @@ class Installation:
 
         return found
 
+    _all_provider_info: ProviderInfoMap | None = None
+
     @property
     def all_provider_info(self) -> ProviderInfoMap:
-        found = self.agent_provider_info
+        if self._all_provider_info is None:
+            found = self.agent_provider_info
 
-        for provider_type, hr_info in self.haiku_rag_provider_info.items():
-            ac_info = found.setdefault(provider_type, {})
+            for provider_type, hr_info in self.haiku_rag_provider_info.items():
+                ac_info = found.setdefault(provider_type, {})
 
-            for hr_url, hr_models in hr_info.items():
-                ac_models = ac_info.get(hr_url, set())
-                ac_info[hr_url] = ac_models | hr_models
+                for hr_url, hr_models in hr_info.items():
+                    ac_models = ac_info.get(hr_url, set())
+                    ac_info[hr_url] = ac_models | hr_models
 
-        ollama_url_info = found.get(config_agents.LLMProviderType.OLLAMA)
+            ollama_url_info = found.get(config_agents.LLMProviderType.OLLAMA)
 
-        if ollama_url_info is not None:
-            no_url_models = ollama_url_info.pop(None, set())
-            base_url = self.get_environment("OLLAMA_BASE_URL")
-            base_url_models = ollama_url_info.get(base_url, set())
-            ollama_url_info[base_url] = base_url_models | no_url_models
+            if ollama_url_info is not None:
+                no_url_models = ollama_url_info.pop(None, set())
+                base_url = self.get_environment("OLLAMA_BASE_URL")
+                base_url_models = ollama_url_info.get(base_url, set())
+                ollama_url_info[base_url] = base_url_models | no_url_models
 
-        return found
+            self._all_provider_info = found
+
+        return self._all_provider_info
 
     @property
     def rooms_upload_path(self) -> pathlib.Path | None:

--- a/tests/unit/cli/test_cli_audit.py
+++ b/tests/unit/cli/test_cli_audit.py
@@ -5,6 +5,7 @@ import pathlib
 from unittest import mock
 
 import pytest
+import requests
 import typer
 import yaml
 
@@ -180,6 +181,7 @@ def test__audit_callback(ctx, w_quiet):
 @pytest.mark.parametrize("w_errors", [False, True])
 @pytest.mark.parametrize("w_quiet", [False, True])
 @mock.patch("soliplex.cli.audit._emit_errors")
+@mock.patch("soliplex.cli.audit._audit_ollama_section")
 @mock.patch("soliplex.cli.audit._audit_logfire_section")
 @mock.patch("soliplex.cli.audit._audit_logging_section")
 @mock.patch("soliplex.cli.audit._audit_skills_section")
@@ -203,6 +205,7 @@ def test_audit_all(
     _audit_skills_section,
     _audit_logging_section,
     _audit_logfire_section,
+    _audit_ollama_section,
     _emit_errors,
     ctx,
     installation_path,
@@ -223,6 +226,7 @@ def test_audit_all(
         _audit_skills_section.return_value = {"skills": None}
         _audit_logging_section.return_value = {"logging": None}
         _audit_logfire_section.return_value = {"logfire": None}
+        _audit_ollama_section.return_value = {"ollama": None}
 
         expected = {
             "installation": None,
@@ -236,6 +240,7 @@ def test_audit_all(
             "skills": None,
             "logging": None,
             "logfire": None,
+            "ollama": None,
         }
     else:
         _audit_installation_section.return_value = {}
@@ -249,6 +254,7 @@ def test_audit_all(
         _audit_skills_section.return_value = {}
         _audit_logging_section.return_value = {}
         _audit_logfire_section.return_value = {}
+        _audit_ollama_section.return_value = {}
 
         expected = {}
 
@@ -267,6 +273,7 @@ def test_audit_all(
     _audit_skills_section.assert_called_once_with(ctx, installation_path)
     _audit_logging_section.assert_called_once_with(ctx, installation_path)
     _audit_logfire_section.assert_called_once_with(ctx, installation_path)
+    _audit_ollama_section.assert_called_once_with(ctx, installation_path)
 
 
 @pytest.mark.parametrize("w_error", [False, True])
@@ -1185,3 +1192,136 @@ def test__invalid_logging(
 
 # _audit_logfire_section: ui only
 # audit_logfire: command
+
+
+@pytest.mark.parametrize(
+    "w_provider_info, w_responses, exp_errors",
+    [
+        # No Ollama URLs configured -> no errors.
+        ({}, {}, {}),
+        # URL present but no models referenced -> skipped, no errors.
+        (
+            {"ollama": {"http://a.example.com": set()}},
+            {},
+            {},
+        ),
+        # All required models are available -> no errors.
+        (
+            {"ollama": {"http://a.example.com": {"llama3", "mistral"}}},
+            {
+                "http://a.example.com": {
+                    "models": [{"name": "llama3"}, {"name": "mistral"}],
+                },
+            },
+            {},
+        ),
+        # Some required models are missing -> sorted list reported.
+        (
+            {
+                "ollama": {
+                    "http://a.example.com": {"llama3", "mistral", "phi3"},
+                },
+            },
+            {
+                "http://a.example.com": {"models": [{"name": "llama3"}]},
+            },
+            {
+                "ollama": {
+                    "http://a.example.com": {
+                        "missing_models": ["mistral", "phi3"],
+                    },
+                },
+            },
+        ),
+        # Server returns an empty 'models' list -> everything is missing.
+        (
+            {"ollama": {"http://a.example.com": {"llama3"}}},
+            {"http://a.example.com": {"models": []}},
+            {
+                "ollama": {
+                    "http://a.example.com": {"missing_models": ["llama3"]},
+                },
+            },
+        ),
+        # Multiple URLs: a mix of OK and missing.
+        (
+            {
+                "ollama": {
+                    "http://a.example.com": {"llama3"},
+                    "http://b.example.com": {"mistral"},
+                },
+            },
+            {
+                "http://a.example.com": {
+                    "models": [{"name": "llama3"}],
+                },
+                "http://b.example.com": {"models": []},
+            },
+            {
+                "ollama": {
+                    "http://b.example.com": {"missing_models": ["mistral"]},
+                },
+            },
+        ),
+    ],
+)
+@mock.patch("soliplex.cli.audit.ollama.REST_API")
+def test__missing_ollama_models_compares_available_to_required(
+    rest_api_cls,
+    the_installation,
+    w_provider_info,
+    w_responses,
+    exp_errors,
+):
+    type(the_installation).all_provider_info = mock.PropertyMock(
+        return_value=w_provider_info,
+    )
+
+    instances = {}
+    for url, response in w_responses.items():
+        instance = mock.Mock()
+        instance.get_available_models.return_value = response
+        instances[url] = instance
+
+    rest_api_cls.side_effect = lambda url: instances[url]
+
+    found = cli_audit._missing_ollama_models(the_installation)
+
+    assert found == exp_errors
+
+    # Only URLs with a required-model set should have triggered an
+    # 'all_models' call.
+    expected_calls = [
+        mock.call(url)
+        for url, models in w_provider_info.get("ollama", {}).items()
+        if models
+    ]
+    assert rest_api_cls.call_args_list == expected_calls
+
+
+@mock.patch("soliplex.cli.audit.ollama.REST_API")
+def test__missing_ollama_models_reports_unreachable_server(
+    rest_api_cls,
+    the_installation,
+):
+    type(the_installation).all_provider_info = mock.PropertyMock(
+        return_value={"ollama": {"http://a.example.com": {"llama3"}}},
+    )
+
+    instance = mock.Mock()
+    instance.get_available_models.side_effect = requests.ConnectionError(
+        "refused",
+    )
+    rest_api_cls.return_value = instance
+
+    found = cli_audit._missing_ollama_models(the_installation)
+
+    assert found == {
+        "ollama": {
+            "http://a.example.com": {"unreachable": "('refused',)"},
+        },
+    }
+
+
+# _audit_ollama_section: ui only
+# audit_ollama: command

--- a/tests/unit/cli/test_cli_audit.py
+++ b/tests/unit/cli/test_cli_audit.py
@@ -1273,9 +1273,7 @@ def test__missing_ollama_models_compares_available_to_required(
     w_responses,
     exp_errors,
 ):
-    type(the_installation).all_provider_info = mock.PropertyMock(
-        return_value=w_provider_info,
-    )
+    the_installation._all_provider_info = w_provider_info
 
     instances = {}
     for url, response in w_responses.items():
@@ -1304,9 +1302,9 @@ def test__missing_ollama_models_reports_unreachable_server(
     rest_api_cls,
     the_installation,
 ):
-    type(the_installation).all_provider_info = mock.PropertyMock(
-        return_value={"ollama": {"http://a.example.com": {"llama3"}}},
-    )
+    the_installation._all_provider_info = {
+        "ollama": {"http://a.example.com": {"llama3"}}
+    }
 
     instance = mock.Mock()
     instance.get_available_models.side_effect = requests.ConnectionError(

--- a/tests/unit/cli/test_cli_ollama.py
+++ b/tests/unit/cli/test_cli_ollama.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import requests
+import typer
+
+from soliplex.cli import ollama as cli_ollama
+
+
+@pytest.fixture
+def ctx():
+    return mock.create_autospec(typer.Context, obj={})
+
+
+@pytest.mark.parametrize(
+    "w_unknown_urls, exp_message",
+    [
+        # Single unknown URL.
+        (
+            ["http://nope.example.com"],
+            "URL(s) not referenced by installation: http://nope.example.com",
+        ),
+        # Multiple unknown URLs are joined with ", ".
+        (
+            ["http://a.example.com", "http://b.example.com"],
+            (
+                "URL(s) not referenced by installation: "
+                "http://a.example.com, http://b.example.com"
+            ),
+        ),
+    ],
+)
+def test_UnknownOllamaURLs(w_unknown_urls, exp_message):
+    exc = cli_ollama.UnknownOllamaURLs(w_unknown_urls)
+
+    # 'unknown_urls' is normalized to a list (defensive copy).
+    assert exc.unknown_urls == list(w_unknown_urls)
+    assert exc.unknown_urls is not w_unknown_urls
+    assert str(exc) == exp_message
+
+
+def test_UnknownOllamaURLs_accepts_non_list_iterable():
+    # Generator inputs are coerced to a list so the message can be built.
+    exc = cli_ollama.UnknownOllamaURLs(
+        iter(["http://a.example.com", "http://b.example.com"]),
+    )
+
+    assert exc.unknown_urls == [
+        "http://a.example.com",
+        "http://b.example.com",
+    ]
+
+
+@pytest.mark.parametrize(
+    "w_result, exp_message",
+    [
+        # Empty result: the keys list is empty in the message tail.
+        ({}, "No status returned in result: keys were "),
+        # Single key.
+        (
+            {"error": "boom"},
+            "No status returned in result: keys were error",
+        ),
+        # Multiple keys are joined in their dict order.
+        (
+            {"error": "boom", "code": 42},
+            "No status returned in result: keys were error, code",
+        ),
+    ],
+)
+def test_NoStatusReturned(w_result, exp_message):
+    exc = cli_ollama.NoStatusReturned(w_result)
+
+    assert exc.result is w_result
+    # The exception subclasses KeyError so callers can catch either type.
+    assert isinstance(exc, KeyError)
+    # The 'KeyError.__str__' wraps the message in single quotes; use 'args'
+    # to read the raw text.
+    (message,) = exc.args
+    assert message == exp_message
+
+
+def test__pull_one_model_returns_status_on_success():
+    rest_api = mock.Mock()
+    rest_api.pull_model.return_value = {"status": "success"}
+
+    found = cli_ollama._pull_one_model(rest_api, "llama3")
+
+    assert found == "success"
+    rest_api.pull_model.assert_called_once_with("llama3", stream=False)
+
+
+def test__pull_one_model_lets_RequestException_propagate():
+    rest_api = mock.Mock()
+    rest_api.pull_model.side_effect = requests.RequestException("boom")
+
+    with pytest.raises(requests.RequestException):
+        cli_ollama._pull_one_model(rest_api, "llama3")
+
+
+def test__pull_one_model_raises_NoStatusReturned_on_missing_status():
+    rest_api = mock.Mock()
+    result = {"error": "boom"}
+    rest_api.pull_model.return_value = result
+
+    with pytest.raises(cli_ollama.NoStatusReturned) as excinfo:
+        cli_ollama._pull_one_model(rest_api, "llama3")
+
+    # The raw response is attached for diagnostics, and the chain is
+    # suppressed ('raise ... from None').
+    assert excinfo.value.result is result
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__suppress_context__ is True
+
+
+@pytest.mark.parametrize(
+    "w_ollama_urls",
+    [
+        # Empty list short-circuits.
+        [],
+        # 'None' is a valid sentinel for "no filter".
+        None,
+    ],
+)
+def test__filter_ollama_url_models_returns_input_when_no_urls_supplied(
+    w_ollama_urls,
+):
+    ollama_url_models = {
+        "http://a.example.com": {"llama3"},
+        "http://b.example.com": {"mistral"},
+    }
+
+    found = cli_ollama._filter_ollama_url_models(
+        ollama_url_models,
+        w_ollama_urls,
+    )
+
+    # No new dict is allocated when no filtering is needed.
+    assert found is ollama_url_models
+
+
+@pytest.mark.parametrize(
+    "w_configured, w_filter, exp_filtered",
+    [
+        # Single URL match.
+        (
+            {
+                "http://a.example.com": {"llama3"},
+                "http://b.example.com": {"mistral"},
+            },
+            ["http://a.example.com"],
+            {"http://a.example.com": {"llama3"}},
+        ),
+        # Multiple URL matches preserve caller-supplied order.
+        (
+            {
+                "http://a.example.com": {"llama3"},
+                "http://b.example.com": {"mistral"},
+                "http://c.example.com": {"phi3"},
+            },
+            ["http://c.example.com", "http://a.example.com"],
+            {
+                "http://c.example.com": {"phi3"},
+                "http://a.example.com": {"llama3"},
+            },
+        ),
+    ],
+)
+def test__filter_ollama_url_models_restricts_to_known_urls(
+    w_configured,
+    w_filter,
+    exp_filtered,
+):
+    found = cli_ollama._filter_ollama_url_models(w_configured, w_filter)
+
+    assert found == exp_filtered
+    # Iteration order is preserved (matters for downstream per-URL output).
+    assert list(found) == list(exp_filtered)
+
+
+@pytest.mark.parametrize(
+    "w_configured, w_filter, exp_unknown",
+    [
+        # No configured URLs; anything is unknown.
+        ({}, ["http://nope.example.com"], ["http://nope.example.com"]),
+        # All requested URLs are unknown.
+        (
+            {"http://a.example.com": {"llama3"}},
+            ["http://x.example.com", "http://y.example.com"],
+            ["http://x.example.com", "http://y.example.com"],
+        ),
+        # Mixed: only the unknown URL is reported.
+        (
+            {"http://a.example.com": {"llama3"}},
+            ["http://a.example.com", "http://x.example.com"],
+            ["http://x.example.com"],
+        ),
+    ],
+)
+def test__filter_ollama_url_models_raises_UnknownOllamaURLs(
+    w_configured,
+    w_filter,
+    exp_unknown,
+):
+    with pytest.raises(cli_ollama.UnknownOllamaURLs) as excinfo:
+        cli_ollama._filter_ollama_url_models(w_configured, w_filter)
+
+    assert excinfo.value.unknown_urls == exp_unknown
+
+
+# pull_models: command, ui only

--- a/tests/unit/cli/test_cli_ollama.py
+++ b/tests/unit/cli/test_cli_ollama.py
@@ -14,6 +14,57 @@ def ctx():
     return mock.create_autospec(typer.Context, obj={})
 
 
+@pytest.mark.parametrize("w_quiet", [False, True])
+@mock.patch("soliplex.cli.ollama.the_console")
+def test__quiet_console_funcs(the_console, w_quiet):
+    found = cli_ollama._quiet_console_funcs(w_quiet)
+
+    (f_line, f_rule, f_print, f_print_exception) = found
+
+    if w_quiet:
+        assert f_line is cli_ollama._noop
+        assert f_rule is cli_ollama._noop
+        assert f_print is cli_ollama._noop
+        assert f_print_exception is cli_ollama._noop
+    else:
+        assert f_line is the_console.line
+        assert f_rule is the_console.rule
+        assert f_print is the_console.print
+        assert f_print_exception is the_console.print_exception
+
+
+@pytest.mark.parametrize("w_quiet", [False, True])
+@pytest.mark.parametrize("w_errors", [{}, {"foo": "bar"}])
+@mock.patch("soliplex.cli.ollama.the_console")
+@mock.patch("sys.exit")
+def test__emit_errors(
+    sys_exit,
+    the_console,
+    w_errors,
+    w_quiet,
+):
+    cli_ollama._emit_errors(w_errors, w_quiet)
+
+    if w_errors and w_quiet:
+        the_console.print_json.assert_called_once_with(data=w_errors)
+    else:
+        the_console.print_json.assert_not_called()
+
+    if w_errors:
+        sys_exit.assert_called_once_with(1)
+    else:
+        sys_exit.assert_not_called()
+
+
+@pytest.mark.parametrize("w_quiet", [False, True])
+def test__ollama_callback(ctx, w_quiet):
+    w_quiet_kw = {"quiet": w_quiet}
+
+    cli_ollama._ollama_callback(ctx, **w_quiet_kw)
+
+    assert ctx.obj == {"quiet": w_quiet}
+
+
 @pytest.mark.parametrize(
     "w_unknown_urls, exp_message",
     [

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -454,7 +454,20 @@ def test_installation_haiku_rag_provider_info(hr_config_w_providers):
     assert found == expected
 
 
-def test_installation_all_provider_info(
+def test_installation_all_provider_info_w_already():
+    i_config = mock.create_autospec(
+        config_installation.InstallationConfig,
+    )
+    already = object()
+    the_installation = installation.Installation(i_config)
+    the_installation._all_provider_info = already
+
+    found = the_installation.all_provider_info
+
+    assert found is already
+
+
+def test_installation_all_provider_info_wo_already(
     standalone_agents,
     rooms_with_agents,
     completions_with_agents,


### PR DESCRIPTION
Highlighted in #935.

Additionally:

- Test coverage for the`cli.ollama` module.
- Quiet-mode option (`-q` / `--quiet`) for `ollama pull`.
- New `audit ollama` subcommnd.