### PR TITLE
fix: (CLI) `admin-users` quirks

### DIFF
--- a/alembic/versions/63edaa5987f6_soliplex_v0_67.py
+++ b/alembic/versions/63edaa5987f6_soliplex_v0_67.py
@@ -54,6 +54,38 @@ def _admin_users_table() -> sa.Table:
     )
 
 
+def _dialect() -> str:
+    """Backend dialect name, available in both online and offline mode."""
+    return op.get_context().dialect.name
+
+
+def _json_encode_sql(col: str) -> str:
+    """SQL expression that JSON-encodes a text column to a quoted string.
+
+    Mirrors 'json.dumps' for a string value ('alice' -> '"alice"'), so a
+    set-based '--sql' rewrite produces the same json_path the online,
+    Python row-by-row branch builds via '_token_field_json_path'. SQLite
+    uses 'json_quote'; PostgreSQL uses 'to_jsonb(...)::text'. Non-ASCII
+    renders as literal UTF-8 rather than '\\uXXXX' on both, which the
+    JSONPath evaluator treats identically.
+    """
+    if _dialect() == "sqlite":
+        return f"json_quote({col})"
+    return f"to_jsonb({col})::text"
+
+
+def _json_decode_sql(expr: str) -> str:
+    """SQL expression that decodes a JSON-encoded string back to text.
+
+    Inverse of '_json_encode_sql' ('"alice"' -> 'alice'). SQLite uses
+    'json_extract(..., '$')'; PostgreSQL casts to 'jsonb' and extracts
+    the root scalar with '#>> '{}''.
+    """
+    if _dialect() == "sqlite":
+        return f"json_extract({expr}, '$')"
+    return f"({expr})::jsonb #>> '{{}}'"
+
+
 def upgrade(engine_name: str) -> None:
     """Upgrade schema."""
     globals()[f"upgrade_{engine_name}"]()
@@ -160,19 +192,18 @@ def _convert_legacy_discriminators_online() -> None:
 def _convert_legacy_discriminators_offline() -> None:
     """Set-based conversion emitted as SQL for '--sql' mode.
 
-    SQLite's 'json_quote' mirrors 'json.dumps' for ASCII discriminators
-    (non-ASCII renders as literal UTF-8 rather than '\\uXXXX', which the
-    JSONPath evaluator treats identically). The preferred_username pass
-    runs first and sets json_path, so the email pass -- still gated on
-    'json_path IS NULL' -- skips those rows, matching the online branch
-    that prefers preferred_username.
+    Uses '_json_encode_sql' so the rendered json_path matches the
+    online, Python row-by-row branch on both SQLite and PostgreSQL. The
+    preferred_username pass runs first and sets json_path, so the email
+    pass -- still gated on 'json_path IS NULL' -- skips those rows,
+    matching the online branch that prefers preferred_username.
     """
     for field in ("preferred_username", "email"):
         # Mirrors _token_field_json_path; the prefix has no single quote.
         prefix = f"$[?$.{field} == "
         op.execute(
             f"UPDATE room_acl_entries "
-            f"SET json_path = '{prefix}' || json_quote({field}) || ']', "
+            f"SET json_path = '{prefix}' || {_json_encode_sql(field)} || ']', "
             f"preferred_username = NULL, email = NULL "
             f"WHERE json_path IS NULL AND {field} IS NOT NULL"
         )
@@ -220,23 +251,27 @@ def _restore_legacy_discriminators_offline() -> None:
 
     Mirrors _LEGACY_FIELD_RES: a json_path carrying the frozen
     converted-discriminator shape ('<prefix>' ... ']') is decoded back
-    into its legacy column. SQLite's 'json_extract(..., '$')' inverts
-    'json_quote'/'json.dumps'. The two prefixes are mutually exclusive,
-    so the passes are order-independent; genuine '--json-path' entries
-    fail the prefix test and are left for the column drop to discard.
+    into its legacy column via '_json_decode_sql' (the inverse of
+    '_json_encode_sql' on both SQLite and PostgreSQL). The 'ends with
+    "]"' test uses 'LIKE ''%]''' rather than a negative-index 'substr'
+    (whose semantics differ between SQLite and PostgreSQL). The two
+    prefixes are mutually exclusive, so the passes are order-
+    independent; genuine '--json-path' entries fail the prefix test and
+    are left for the column drop to discard.
     """
     for field in ("preferred_username", "email"):
         # Mirrors _token_field_json_path; the prefix has no single quote.
         prefix = f"$[?$.{field} == "
         plen = len(prefix)
+        encoded = (
+            f"substr(json_path, {plen + 1}, length(json_path) - {plen + 1})"
+        )
         op.execute(
             f"UPDATE room_acl_entries "
-            f"SET {field} = json_extract("
-            f"substr(json_path, {plen + 1}, length(json_path) - {plen + 1})"
-            f", '$') "
+            f"SET {field} = {_json_decode_sql(encoded)} "
             f"WHERE json_path IS NOT NULL "
             f"AND substr(json_path, 1, {plen}) = '{prefix}' "
-            f"AND substr(json_path, -1, 1) = ']'"
+            f"AND json_path LIKE '%]'"
         )
 
 
@@ -248,28 +283,39 @@ def _upgrade_admin_users() -> None:
     'check_admin_access' now matches the user token.
 
     SQLite cannot 'DROP' a column that carries a UNIQUE constraint, so
-    the table is rebuilt -- the same move-and-copy alembic batch mode
-    performs, written explicitly here so it also runs under '--sql'
-    offline mode. The rebuilt table mirrors 'create_all' for a fresh DB.
+    on SQLite the table is rebuilt (the move-and-copy alembic batch mode
+    would perform, written explicitly here so it also runs under '--sql'
+    offline mode); the rebuilt table mirrors 'create_all' for a fresh
+    DB. PostgreSQL drops the column natively, which is both simpler and
+    safer -- a rebuild would discard 'id_'s identity sequence.
     """
     op.add_column(
         "admin_users", sa.Column("json_path", sa.String(), nullable=True)
     )
     _convert_admin_emails()
-    op.execute(
-        "CREATE TABLE _new_admin_users ("
-        "id_ INTEGER NOT NULL, "
-        "json_path VARCHAR NOT NULL, "
-        "created TIMESTAMP NOT NULL, "
-        "CONSTRAINT pk_admin_users PRIMARY KEY (id_), "
-        "CONSTRAINT uq_admin_users_json_path UNIQUE (json_path))"
-    )
-    op.execute(
-        "INSERT INTO _new_admin_users (id_, json_path, created) "
-        "SELECT id_, json_path, created FROM admin_users"
-    )
-    op.execute("DROP TABLE admin_users")
-    op.execute("ALTER TABLE _new_admin_users RENAME TO admin_users")
+
+    if _dialect() == "sqlite":
+        op.execute(
+            "CREATE TABLE _new_admin_users ("
+            "id_ INTEGER NOT NULL, "
+            "json_path VARCHAR NOT NULL, "
+            "created TIMESTAMP NOT NULL, "
+            "CONSTRAINT pk_admin_users PRIMARY KEY (id_), "
+            "CONSTRAINT uq_admin_users_json_path UNIQUE (json_path))"
+        )
+        op.execute(
+            "INSERT INTO _new_admin_users (id_, json_path, created) "
+            "SELECT id_, json_path, created FROM admin_users"
+        )
+        op.execute("DROP TABLE admin_users")
+        op.execute("ALTER TABLE _new_admin_users RENAME TO admin_users")
+    else:
+        # Dropping 'email' discards 'uq_admin_users_email' with it.
+        op.alter_column("admin_users", "json_path", nullable=False)
+        op.drop_column("admin_users", "email")
+        op.create_unique_constraint(
+            "uq_admin_users_json_path", "admin_users", ["json_path"]
+        )
 
 
 def _downgrade_admin_users() -> None:
@@ -278,27 +324,36 @@ def _downgrade_admin_users() -> None:
     Only email-shaped json_paths can be represented by the legacy
     column; admins created with a non-email '--json-path' query have no
     email and are dropped (as the 'room_acl_entries' downgrade drops
-    genuine json_path entries).
+    genuine json_path entries). SQLite rebuilds the table; PostgreSQL
+    drops 'json_path' natively (see '_upgrade_admin_users').
     """
     op.add_column(
         "admin_users", sa.Column("email", sa.String(), nullable=True)
     )
     _restore_admin_emails()
     op.execute("DELETE FROM admin_users WHERE email IS NULL")
-    op.execute(
-        "CREATE TABLE _new_admin_users ("
-        "id_ INTEGER NOT NULL, "
-        "email VARCHAR NOT NULL, "
-        "created TIMESTAMP NOT NULL, "
-        "CONSTRAINT pk_admin_users PRIMARY KEY (id_), "
-        "CONSTRAINT uq_admin_users_email UNIQUE (email))"
-    )
-    op.execute(
-        "INSERT INTO _new_admin_users (id_, email, created) "
-        "SELECT id_, email, created FROM admin_users"
-    )
-    op.execute("DROP TABLE admin_users")
-    op.execute("ALTER TABLE _new_admin_users RENAME TO admin_users")
+
+    if _dialect() == "sqlite":
+        op.execute(
+            "CREATE TABLE _new_admin_users ("
+            "id_ INTEGER NOT NULL, "
+            "email VARCHAR NOT NULL, "
+            "created TIMESTAMP NOT NULL, "
+            "CONSTRAINT pk_admin_users PRIMARY KEY (id_), "
+            "CONSTRAINT uq_admin_users_email UNIQUE (email))"
+        )
+        op.execute(
+            "INSERT INTO _new_admin_users (id_, email, created) "
+            "SELECT id_, email, created FROM admin_users"
+        )
+        op.execute("DROP TABLE admin_users")
+        op.execute("ALTER TABLE _new_admin_users RENAME TO admin_users")
+    else:
+        op.alter_column("admin_users", "email", nullable=False)
+        op.drop_column("admin_users", "json_path")
+        op.create_unique_constraint(
+            "uq_admin_users_email", "admin_users", ["email"]
+        )
 
 
 def _convert_admin_emails() -> None:
@@ -334,15 +389,14 @@ def _convert_admin_emails_online() -> None:
 def _convert_admin_emails_offline() -> None:
     """Set-based conversion emitted as SQL for '--sql' mode.
 
-    SQLite's 'json_quote' mirrors 'json.dumps' for ASCII emails (see
-    the room_acl_entries note), so the rendered query matches the online
-    branch and the JSONPath evaluator.
+    Uses '_json_encode_sql' so the rendered query matches the online
+    branch and the JSONPath evaluator on both SQLite and PostgreSQL.
     """
     # Mirrors _token_field_json_path; the prefix has no single quote.
     prefix = "$[?$.email == "
     op.execute(
         f"UPDATE admin_users "
-        f"SET json_path = '{prefix}' || json_quote(email) || ']' "
+        f"SET json_path = '{prefix}' || {_json_encode_sql('email')} || ']' "
         f"WHERE json_path IS NULL AND email IS NOT NULL"
     )
 
@@ -388,17 +442,19 @@ def _restore_admin_emails_offline() -> None:
 
     Mirrors '_LEGACY_FIELD_RES["email"]': a json_path carrying the frozen
     converted-email shape is decoded back into the 'email' column via
-    SQLite's 'json_extract(..., '$')', which inverts 'json_quote'.
+    '_json_decode_sql' (the inverse of '_json_encode_sql' on both SQLite
+    and PostgreSQL). The 'ends with "]"' test uses 'LIKE ''%]''' rather
+    than a negative-index 'substr', whose semantics differ across
+    backends.
     """
     # Mirrors _token_field_json_path; the prefix has no single quote.
     prefix = "$[?$.email == "
     plen = len(prefix)
+    encoded = f"substr(json_path, {plen + 1}, length(json_path) - {plen + 1})"
     op.execute(
         f"UPDATE admin_users "
-        f"SET email = json_extract("
-        f"substr(json_path, {plen + 1}, length(json_path) - {plen + 1})"
-        f", '$') "
+        f"SET email = {_json_decode_sql(encoded)} "
         f"WHERE json_path IS NOT NULL "
         f"AND substr(json_path, 1, {plen}) = '{prefix}' "
-        f"AND substr(json_path, -1, 1) = ']'"
+        f"AND json_path LIKE '%]'"
     )

--- a/alembic/versions/63edaa5987f6_soliplex_v0_67.py
+++ b/alembic/versions/63edaa5987f6_soliplex_v0_67.py
@@ -45,6 +45,15 @@ def _acl_entries_table() -> sa.Table:
     )
 
 
+def _admin_users_table() -> sa.Table:
+    return sa.table(
+        "admin_users",
+        sa.column("id_", sa.Integer),
+        sa.column("email", sa.String),
+        sa.column("json_path", sa.String),
+    )
+
+
 def upgrade(engine_name: str) -> None:
     """Upgrade schema."""
     globals()[f"upgrade_{engine_name}"]()
@@ -80,9 +89,13 @@ def upgrade_authz() -> None:
     op.drop_column("room_acl_entries", "preferred_username")
     op.drop_column("room_acl_entries", "email")
 
+    _upgrade_admin_users()
+
 
 def downgrade_authz() -> None:
     """Downgrade authz schema."""
+    _downgrade_admin_users()
+
     op.add_column(
         "room_acl_entries",
         sa.Column("preferred_username", sa.String(), nullable=True),
@@ -225,3 +238,167 @@ def _restore_legacy_discriminators_offline() -> None:
             f"AND substr(json_path, 1, {plen}) = '{prefix}' "
             f"AND substr(json_path, -1, 1) = ']'"
         )
+
+
+def _upgrade_admin_users() -> None:
+    """Replace the unique 'email' admin key with a 'json_path' query.
+
+    Email-keyed admins become '$[?$.email == "..."]', matching how
+    'room_acl_entries' stores its converted email discriminator and how
+    'check_admin_access' now matches the user token.
+
+    SQLite cannot 'DROP' a column that carries a UNIQUE constraint, so
+    the table is rebuilt -- the same move-and-copy alembic batch mode
+    performs, written explicitly here so it also runs under '--sql'
+    offline mode. The rebuilt table mirrors 'create_all' for a fresh DB.
+    """
+    op.add_column(
+        "admin_users", sa.Column("json_path", sa.String(), nullable=True)
+    )
+    _convert_admin_emails()
+    op.execute(
+        "CREATE TABLE _new_admin_users ("
+        "id_ INTEGER NOT NULL, "
+        "json_path VARCHAR NOT NULL, "
+        "created TIMESTAMP NOT NULL, "
+        "CONSTRAINT pk_admin_users PRIMARY KEY (id_), "
+        "CONSTRAINT uq_admin_users_json_path UNIQUE (json_path))"
+    )
+    op.execute(
+        "INSERT INTO _new_admin_users (id_, json_path, created) "
+        "SELECT id_, json_path, created FROM admin_users"
+    )
+    op.execute("DROP TABLE admin_users")
+    op.execute("ALTER TABLE _new_admin_users RENAME TO admin_users")
+
+
+def _downgrade_admin_users() -> None:
+    """Reverse _upgrade_admin_users, restoring the unique 'email' key.
+
+    Only email-shaped json_paths can be represented by the legacy
+    column; admins created with a non-email '--json-path' query have no
+    email and are dropped (as the 'room_acl_entries' downgrade drops
+    genuine json_path entries).
+    """
+    op.add_column(
+        "admin_users", sa.Column("email", sa.String(), nullable=True)
+    )
+    _restore_admin_emails()
+    op.execute("DELETE FROM admin_users WHERE email IS NULL")
+    op.execute(
+        "CREATE TABLE _new_admin_users ("
+        "id_ INTEGER NOT NULL, "
+        "email VARCHAR NOT NULL, "
+        "created TIMESTAMP NOT NULL, "
+        "CONSTRAINT pk_admin_users PRIMARY KEY (id_), "
+        "CONSTRAINT uq_admin_users_email UNIQUE (email))"
+    )
+    op.execute(
+        "INSERT INTO _new_admin_users (id_, email, created) "
+        "SELECT id_, email, created FROM admin_users"
+    )
+    op.execute("DROP TABLE admin_users")
+    op.execute("ALTER TABLE _new_admin_users RENAME TO admin_users")
+
+
+def _convert_admin_emails() -> None:
+    """Translate the legacy 'email' admin key to a 'json_path' query.
+
+    Offline ('--sql') mode has no connection to read rows from, so it
+    gets a set-based rewrite; online mode keeps the row-by-row form.
+    """
+    if context.is_offline_mode():
+        _convert_admin_emails_offline()
+    else:
+        _convert_admin_emails_online()
+
+
+def _convert_admin_emails_online() -> None:
+    """Row-by-row conversion against a live connection."""
+    admin = _admin_users_table()
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.select(admin.c.id_, admin.c.email).where(
+            admin.c.json_path.is_(None),
+            admin.c.email.is_not(None),
+        )
+    ).all()
+    for row in rows:
+        bind.execute(
+            sa.update(admin)
+            .where(admin.c.id_ == row.id_)
+            .values(json_path=_token_field_json_path("email", row.email))
+        )
+
+
+def _convert_admin_emails_offline() -> None:
+    """Set-based conversion emitted as SQL for '--sql' mode.
+
+    SQLite's 'json_quote' mirrors 'json.dumps' for ASCII emails (see
+    the room_acl_entries note), so the rendered query matches the online
+    branch and the JSONPath evaluator.
+    """
+    # Mirrors _token_field_json_path; the prefix has no single quote.
+    prefix = "$[?$.email == "
+    op.execute(
+        f"UPDATE admin_users "
+        f"SET json_path = '{prefix}' || json_quote(email) || ']' "
+        f"WHERE json_path IS NULL AND email IS NOT NULL"
+    )
+
+
+def _restore_admin_emails() -> None:
+    """Reverse _convert_admin_emails before dropping json_path.
+
+    Only json_path values matching the converted-email shape are
+    restored. Genuine '--json-path' entries cannot be represented by the
+    legacy column and are dropped by '_downgrade_admin_users'.
+
+    Offline ('--sql') mode has no connection to read rows from, so it
+    gets a set-based rewrite; online mode keeps the row-by-row form.
+    """
+    if context.is_offline_mode():
+        _restore_admin_emails_offline()
+    else:
+        _restore_admin_emails_online()
+
+
+def _restore_admin_emails_online() -> None:
+    """Row-by-row restore against a live connection."""
+    admin = _admin_users_table()
+    bind = op.get_bind()
+    pattern = _LEGACY_FIELD_RES["email"]
+    rows = bind.execute(
+        sa.select(admin.c.id_, admin.c.json_path).where(
+            admin.c.json_path.is_not(None)
+        )
+    ).all()
+    for row in rows:
+        match = pattern.match(row.json_path)
+        if match is not None:
+            bind.execute(
+                sa.update(admin)
+                .where(admin.c.id_ == row.id_)
+                .values(email=json.loads(match.group("value")))
+            )
+
+
+def _restore_admin_emails_offline() -> None:
+    """Set-based restore emitted as SQL for '--sql' mode.
+
+    Mirrors '_LEGACY_FIELD_RES["email"]': a json_path carrying the frozen
+    converted-email shape is decoded back into the 'email' column via
+    SQLite's 'json_extract(..., '$')', which inverts 'json_quote'.
+    """
+    # Mirrors _token_field_json_path; the prefix has no single quote.
+    prefix = "$[?$.email == "
+    plen = len(prefix)
+    op.execute(
+        f"UPDATE admin_users "
+        f"SET email = json_extract("
+        f"substr(json_path, {plen + 1}, length(json_path) - {plen + 1})"
+        f", '$') "
+        f"WHERE json_path IS NOT NULL "
+        f"AND substr(json_path, 1, {plen}) = '{prefix}' "
+        f"AND substr(json_path, -1, 1) = ']'"
+    )

--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -1174,16 +1174,34 @@ All three commands share the following conventions:
   installation configuration. May be a YAML file or a directory
   containing an `installation.yaml`. If omitted, falls back to the
   `SOLIPLEX_INSTALLATION_PATH` environment variable.
-- On completion, the current admin-user list is printed as a single
-  JSON object on stdout:
+- On completion, the current admin-user list is dumped as a single
+  JSON object on stdout (emitted via plain `print(...)`, not Rich, so
+  the output pipes cleanly into `jq` or other tooling):
 
   ```json
   {"admin_users": ["alice@example.com", "bob@example.com"]}
   ```
 
-  Emitted via plain `print(...)` (not Rich), so the output pipes
-  cleanly into `jq` or other tooling.
-- Exit status is `0` on success, or `1` when the RAM-DB guard fires.
+- The `-v` / `--verbose` and `-q` / `--quiet` flags at the **group**
+  level (`soliplex-cli admin-users -v <subcommand> …`) toggle between
+  the default JSON dump and a human-focused, Rich-rendered summary.
+  Resolution: `--quiet` always forces JSON; `--verbose` (without
+  `--quiet`) forces the human summary; with neither, the
+  per-deployment default applies (currently JSON, set via
+  `_DEFAULT_VERBOSE` in `cli/admin_users.py`). `--quiet` is intended
+  as the override for scripts in a deployment that has flipped the
+  default to verbose. Example verbose output:
+
+  ```text
+  ─── Admin users ───
+  Admin users (2):
+    1. alice@example.com
+    2. bob@example.com
+  ```
+
+- Exit status is `0` on success, or `1` when the RAM-DB guard fires
+  (or, for [`admin-users add`](#admin-users-add), when the email is
+  already an admin).
 
 ### `admin-users list`
 
@@ -1229,11 +1247,14 @@ soliplex-cli admin-users add [OPTIONS] INSTALLATION_CONFIG_PATH EMAIL
 
 #### Behavior Notes
 
-- **No deduplication.** The command inserts a row unconditionally; if
-  the same email is added twice, two rows are created (whether that
-  is rejected or quietly tolerated depends on the schema of the
-  authorization table you have configured). Use `admin-users list`
-  first if you need to check for an existing entry.
+- **Rejects duplicates.** Before inserting, the command checks whether
+  the email is already an admin. If it is, the command prints a note
+  and exits with status `1` without touching the table — the
+  `AdminUser.email` column is unique, so a blind second insert would
+  otherwise fail with a backend-specific `IntegrityError`. Re-adding
+  an already-present admin is thus a safe, non-destructive no-op,
+  signalled by the non-zero exit code; run `admin-users list` to see
+  the current set.
 - **Compare with `serve --add-admin-user`.** The `serve` subcommand's
   `--add-admin-user` option bootstraps a single admin during startup
   and is incompatible with `--no-auth-mode`. The standalone

--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -44,10 +44,12 @@ soliplex-cli serve [OPTIONS] [INSTALLATION_CONFIG_PATH]
 ### Authentication Options
 
 - `--no-auth-mode` — disable OIDC authentication providers
-  (development/testing only). **Never use in production.** Incompatible with
-  `--add-admin-user`.
-- `--add-admin-user USERNAME` — add `USERNAME` to the authorization
-  database as an admin before starting. Incompatible with `--no-auth-mode`.
+  (development/testing only). **Never use in production.**
+- `--add-admin-user USERNAME` — **removed.** Passing it now fails with a
+  non-zero exit and a pointer to seed admins out of band with
+  [`admin-users add`](#admin-users-add). The option is retained only so
+  that scripts still passing it get a clear error rather than an
+  "unknown option" failure.
 
 ### Hot Reload Options
 
@@ -119,11 +121,12 @@ soliplex-cli serve example/installation.yaml \
   --workers 4
 ```
 
-Bootstrap the first admin user on a fresh authz database:
+Bootstrap the first admin user on a fresh authz database (seed out of
+band, then start the server):
 
 ```bash
-soliplex-cli serve example/installation.yaml \
-  --add-admin-user alice@example.com
+soliplex-cli admin-users add example/installation.yaml alice@example.com
+soliplex-cli serve example/installation.yaml
 ```
 
 ## `audit`
@@ -1151,11 +1154,13 @@ soliplex-cli audit -q ollama example/installation.yaml
 ## `admin-users`
 
 The `admin-users` group manages the installation's admin-user table.
-Admin users are entries in the installation's authorization database,
-keyed by email address. A user whose OIDC-authenticated email matches
-an entry in this table is granted administrator privileges by the
-Soliplex authorization policy engine. The subcommands below read from
-and modify that table directly.
+Each admin entry is an RFC 9535 JSONPath query stored in the
+installation's authorization database; a user whose OIDC token matches
+any admin entry's query is granted administrator privileges by the
+Soliplex authorization policy engine. The common case — an admin keyed
+by email — is stored as `$[?$.email == "..."]`, mirroring how
+`room-authz` ACL entries store their discriminators. The subcommands
+below read from and modify that table directly.
 
 This group replaces the deprecated flat `list-admin-users` /
 `add-admin-user` / `clear-admin-users` commands; see
@@ -1176,10 +1181,12 @@ All three commands share the following conventions:
   `SOLIPLEX_INSTALLATION_PATH` environment variable.
 - On completion, the current admin-user list is dumped as a single
   JSON object on stdout (emitted via plain `print(...)`, not Rich, so
-  the output pipes cleanly into `jq` or other tooling):
+  the output pipes cleanly into `jq` or other tooling). Email-keyed
+  admins surface as their email; an admin added with a non-email
+  `--json-path` query surfaces as the raw query string:
 
   ```json
-  {"admin_users": ["alice@example.com", "bob@example.com"]}
+  {"admin_users": ["alice@example.com", "$[?$.role == \"admin\"]"]}
   ```
 
 - The `-v` / `--verbose` and `-q` / `--quiet` flags at the **group**
@@ -1200,8 +1207,8 @@ All three commands share the following conventions:
   ```
 
 - Exit status is `0` on success, or `1` when the RAM-DB guard fires
-  (or, for [`admin-users add`](#admin-users-add), when the email is
-  already an admin).
+  (or, for [`admin-users add`](#admin-users-add), when the discriminator
+  selection is invalid or the resolved entry is already an admin).
 
 ### `admin-users list`
 
@@ -1230,43 +1237,71 @@ soliplex-cli admin-users list example/installation.yaml \
 
 ### `admin-users add`
 
-Insert a new admin-user row into the installation's authorization
-database and then dump the resulting list. (Replaces the deprecated
+Insert a new admin entry into the installation's authorization database
+and then dump the resulting list. (Replaces the deprecated
 `soliplex-cli add-admin-user`.)
 
 ```bash
-soliplex-cli admin-users add [OPTIONS] INSTALLATION_CONFIG_PATH EMAIL
+soliplex-cli admin-users add [OPTIONS] INSTALLATION_CONFIG_PATH [EMAIL]
 ```
+
+Exactly one discriminator must be supplied, naming which user token(s)
+the entry grants admin to: the positional `EMAIL` (shorthand for the
+common case), `--preferred-username USERNAME`, or `--json-path QUERY`.
+Each is stored as an RFC 9535 JSONPath query — `EMAIL` and
+`--preferred-username` as `$[?$.email == "..."]` /
+`$[?$.preferred_username == "..."]`, and `--json-path` verbatim (after
+validation). `check_admin_access` admits a user when their token matches
+any stored query, so `--json-path` can grant admin by an arbitrary
+claim (e.g. group membership).
 
 #### Positional Arguments
 
 - `INSTALLATION_CONFIG_PATH` — as described above.
-- `EMAIL` — the email address to grant admin privileges. This is the
-  value Soliplex will match against the authenticated user's
-  OIDC-asserted email; no format validation is performed by the CLI.
+- `EMAIL` — optional; the email address to grant admin privileges,
+  matched against the authenticated user's OIDC-asserted `email` claim.
+  No format validation is performed by the CLI. Mutually exclusive with
+  `--preferred-username` and `--json-path`.
+
+#### Options
+
+- `--preferred-username USERNAME` — grant admin by OIDC
+  `preferred_username` claim. Mutually exclusive with `EMAIL` and
+  `--json-path`.
+- `--json-path QUERY` — grant admin to any user token matched by this
+  RFC 9535 JSONPath query. The query is validated; a malformed query is
+  reported and the command exits non-zero. Mutually exclusive with
+  `EMAIL` and `--preferred-username`.
 
 #### Behavior Notes
 
+- **Exactly one discriminator.** Supplying none — or more than one — of
+  `EMAIL` / `--preferred-username` / `--json-path` is reported and the
+  command exits with status `1` without touching the table.
 - **Rejects duplicates.** Before inserting, the command checks whether
-  the email is already an admin. If it is, the command prints a note
-  and exits with status `1` without touching the table — the
-  `AdminUser.email` column is unique, so a blind second insert would
-  otherwise fail with a backend-specific `IntegrityError`. Re-adding
-  an already-present admin is thus a safe, non-destructive no-op,
-  signalled by the non-zero exit code; run `admin-users list` to see
-  the current set.
-- **Compare with `serve --add-admin-user`.** The `serve` subcommand's
-  `--add-admin-user` option bootstraps a single admin during startup
-  and is incompatible with `--no-auth-mode`. The standalone
-  `admin-users add` subcommand is for offline / ongoing administration
-  and has no such interaction with `--no-auth-mode`.
+  the resolved query is already an admin. If it is, the command prints a
+  note and exits with status `1` without touching the table — the
+  `AdminUser.json_path` column is unique, so a blind second insert would
+  otherwise fail with a backend-specific `IntegrityError`. Re-adding an
+  already-present admin is thus a safe, non-destructive no-op, signalled
+  by the non-zero exit code; run `admin-users list` to see the current
+  set.
 
 #### Examples
 
-Grant admin privileges to a new operator:
+Grant admin privileges to a new operator by email:
 
 ```bash
 soliplex-cli admin-users add example/installation.yaml alice@example.com
+```
+
+Grant admin by `preferred_username`, or by an arbitrary claim:
+
+```bash
+soliplex-cli admin-users add example/installation.yaml \
+  --preferred-username alice
+soliplex-cli admin-users add example/installation.yaml \
+  --json-path '$[?$.groups[?@ == "admins"]]'
 ```
 
 ### `admin-users clear`
@@ -2320,7 +2355,7 @@ future major release. New scripts should use the grouped form.
 | `show-room-authz`             | `room-authz show`          |
 | `pull-models`                 | `ollama pull`              |
 
-The `serve --add-admin-user` option on the `serve` subcommand is **not**
-affected by this rename: it remains spelled `--add-admin-user` and is
-distinct from the standalone `admin-users add` subcommand (see the note
-under [`admin-users add`](#admin-users-add)).
+The `serve --add-admin-user` option is unrelated to this rename: it has
+been **removed**, and passing it now fails with a non-zero exit pointing
+to [`admin-users add`](#admin-users-add). Seed admins out of band with
+that subcommand instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ markers = [
 [tool.coverage.run]
 omit = [
     "src/soliplex/cli/__init__.py",
-    "src/soliplex/cli/admin_users.py",
     "src/soliplex/cli/serve.py",
 
     "src/soliplex/examples.py",

--- a/src/soliplex/authz/__init__.py
+++ b/src/soliplex/authz/__init__.py
@@ -149,7 +149,11 @@ class AuthorizationPolicy(abc.ABC):
 
     @abc.abstractmethod
     async def list_admin_users(self) -> list[str]:
-        """List user emails in the admin users table."""
+        """List admin users in the admin users table.
+
+        Email-keyed admins surface as their email; admins keyed by a
+        non-email JSONPath query surface as the raw query string.
+        """
 
     @abc.abstractmethod
     async def add_admin_user(self, email: str):
@@ -161,7 +165,11 @@ class AuthorizationPolicy(abc.ABC):
 
     @abc.abstractmethod
     async def check_admin_access(self, user_token: UserToken) -> bool:
-        """Is the user represented by 'user_token' an admin user?"""
+        """Is the user represented by 'user_token' an admin user?
+
+        Matches 'user_token' against each admin entry's JSONPath query;
+        the user is an admin when any query matches.
+        """
 
     @abc.abstractmethod
     async def check_room_access(

--- a/src/soliplex/authz/persistence.py
+++ b/src/soliplex/authz/persistence.py
@@ -30,16 +30,25 @@ class NotAdminUser(ValueError):
         super().__init__(f"Non-admin user, email: {email}")
 
 
-async def _find_admin_user(
-    email: str,
+async def _find_admin_user_by_json_path(
+    json_path: str,
     session,
 ) -> authz_schema.AdminUser | None:
     query = sqla_sql.select(authz_schema.AdminUser).where(
-        authz_schema.AdminUser.email == email
+        authz_schema.AdminUser.json_path == json_path
     )
     user = (await session.scalars(query)).first()
 
     return user
+
+
+async def _user_is_admin(user_token, session) -> bool:
+    """Does any admin entry's JSONPath query match 'user_token'?"""
+    query = sqla_sql.select(authz_schema.AdminUser)
+    for admin_user in await session.scalars(query):
+        if admin_user.check_token(user_token):
+            return True
+    return False
 
 
 async def _find_room_policy(
@@ -65,29 +74,42 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
             yield self._session
 
     async def list_admin_users(self) -> list[str]:
-        """List user emails in the admin users table."""
+        """List admin users in the admin users table.
+
+        An email-keyed admin (stored as '$[?$.email == "..."]') is
+        surfaced as its email; an admin created with a non-email
+        JSONPath query is surfaced as the raw query string.
+        """
         query = sqla_sql.select(authz_schema.AdminUser)
         async with self.session as session:
-            result = [
-                admin_user.email for admin_user in await session.scalars(query)
-            ]
+            result = []
+            for admin_user in await session.scalars(query):
+                parsed = authz_package.parse_token_field_json_path(
+                    admin_user.json_path
+                )
+                if parsed is not None and parsed[0] == "email":
+                    result.append(parsed[1])
+                else:
+                    result.append(admin_user.json_path)
             return result
 
     async def add_admin_user(self, email: str):
-        """Add a user to the admin users table."""
+        """Add a user to the admin users table, keyed by email."""
+        json_path = authz_package.token_field_json_path("email", email)
         async with self.session as session:
-            user = await _find_admin_user(email, session)
+            user = await _find_admin_user_by_json_path(json_path, session)
 
             if user is not None:
                 raise AdminUserExists(email=email)
 
-            user = authz_schema.AdminUser(email=email)
+            user = authz_schema.AdminUser(json_path=json_path)
             session.add(user)
 
     async def remove_admin_user(self, email: str):
-        """Remove a user from the admin users table."""
+        """Remove a user from the admin users table, keyed by email."""
+        json_path = authz_package.token_field_json_path("email", email)
         async with self.session as session:
-            user = await _find_admin_user(email, session)
+            user = await _find_admin_user_by_json_path(json_path, session)
 
             if user is None:
                 raise NoSuchAdminUser(email=email)
@@ -100,9 +122,7 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
     ) -> bool:
         """Is the user represented by 'user_token' an admin user?"""
         async with self.session as session:
-            user = await _find_admin_user(user_token["email"], session)
-
-        return user is not None
+            return await _user_is_admin(user_token, session)
 
     async def check_room_access(
         self,
@@ -158,11 +178,8 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
     ) -> models.RoomPolicy | None:
         """Return the authorization policy for the room"""
         async with self.session as session:
-            email = user_token["email"]
-            user = await _find_admin_user(email, session)
-
-            if user is None:
-                raise NotAdminUser(email)
+            if not await _user_is_admin(user_token, session):
+                raise NotAdminUser(user_token["email"])
 
             policy = await _find_room_policy(room_id, session)
 
@@ -180,11 +197,8 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
     ) -> None:
         """Update the authorization policy for the room"""
         async with self.session as session:
-            email = user_token["email"]
-            user = await _find_admin_user(email, session)
-
-            if user is None:
-                raise NotAdminUser(email)
+            if not await _user_is_admin(user_token, session):
+                raise NotAdminUser(user_token["email"])
 
             policy = await _find_room_policy(room_id, session)
 
@@ -208,11 +222,8 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
     ) -> None:
         """Delete any existing authorization policy for the room"""
         async with self.session as session:
-            email = user_token["email"]
-            user = await _find_admin_user(email, session)
-
-            if user is None:
-                raise NotAdminUser(email)
+            if not await _user_is_admin(user_token, session):
+                raise NotAdminUser(user_token["email"])
 
             policy = await _find_room_policy(room_id, session)
 

--- a/src/soliplex/authz/schema.py
+++ b/src/soliplex/authz/schema.py
@@ -52,19 +52,38 @@ class Base(AsyncAttrs, DeclarativeBase):
 class AdminUser(Base):
     """Info for users configured as admins.
 
-    'email': email address
+    'json_path': an RFC 9535 JSONPath query matched against the user
+        token; the user is an admin when the query matches at least one
+        node. Email-keyed admins are stored as '$[?$.email == "..."]'
+        (see 'authz.token_field_json_path'), mirroring how 'ACLEntry'
+        stores its 'email' / 'preferred_username' discriminators.
     """
 
     __tablename__ = "admin_users"
 
     id_: Mapped[int] = mapped_column(primary_key=True)
 
-    email: Mapped[str] = mapped_column(unique=True)
+    json_path: Mapped[str] = mapped_column(unique=True)
 
     created: Mapped[datetime.datetime] = mapped_column(
         sqla_sqltypes.TIMESTAMP(timezone=True),
         default=_timestamp,
     )
+
+    @sqla_orm.validates("json_path")
+    def _check_json_path(self, _key, value):
+        return authz_package.validate_json_path(value)
+
+    def check_token(
+        self,
+        user_token: authz_package.UserToken | None,
+    ) -> bool:
+        """Does 'user_token' match our JSONPath query?"""
+        token = user_token or {}
+        match = authz_package.the_jsonpath_environment.match(
+            self.json_path, token
+        )
+        return match is not None
 
 
 class RoomPolicy(Base):

--- a/src/soliplex/cli/admin_users.py
+++ b/src/soliplex/cli/admin_users.py
@@ -18,7 +18,95 @@ app = typer.Typer(
 )
 
 
-def _dump_admin_users(session):
+# Flip this to True to make human-focused output the default.
+# '--quiet' will still force JSON.
+_DEFAULT_VERBOSE = False
+
+
+@app.callback()
+def _admin_users_callback(
+    ctx: typer.Context,
+    verbose: bool = typer.Option(
+        False,
+        "-v",
+        "--verbose",
+        help=(
+            "Print human-focused output instead of a JSON dump. "
+            "Overridden by '--quiet'."
+        ),
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "-q",
+        "--quiet",
+        help=(
+            "Force JSON output, overriding '--verbose' and any "
+            "verbose-by-default setting."
+        ),
+    ),
+):
+    if quiet:
+        effective = False
+    elif verbose:
+        effective = True
+    else:
+        effective = _DEFAULT_VERBOSE
+    ctx.obj = {"verbose": effective}
+
+
+def _check_existing_admin(session, email):
+    """Reject 'admin-users add' for an email that is already an admin.
+
+    Inserting a second row for the same email would violate the
+    'AdminUser.email' uniqueness constraint; rather than surface that as
+    an opaque IntegrityError traceback (exit code depending on the
+    backend), report it cleanly and exit non-zero.
+    """
+    existing = (
+        session.query(
+            authz_schema.AdminUser,
+        )
+        .where(
+            authz_schema.AdminUser.email == email,
+        )
+        .first()
+    )
+    if existing is None:
+        return
+
+    the_console.rule(f"{email} is already an admin")
+    the_console.print("Nothing to do.")
+    raise typer.Exit(1)
+
+
+def _dump(ctx, session):
+    if ctx.obj and ctx.obj.get("verbose"):
+        _human_dump_admin_users(session)
+    else:
+        _dump_admin_users(session)
+
+
+def _human_dump_admin_users(session):  # pragma NO COVER UI ONLY
+    with session:
+        emails = [
+            admin_user.email
+            for admin_user in session.query(
+                authz_schema.AdminUser,
+            )
+        ]
+
+    the_console.rule("Admin users")
+
+    if not emails:
+        the_console.print("No admin users configured.")
+        return
+
+    the_console.print(f"Admin users ({len(emails)}):")
+    for index, email in enumerate(emails, 1):
+        the_console.print(f"  {index}. {email}")
+
+
+def _dump_admin_users(session):  # pragma NO COVER UI ONLY
     with session:
         admin_users = [
             admin_user.email
@@ -33,7 +121,7 @@ def _dump_admin_users(session):
 def list_admin_users(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
-):
+):  # pragma NO COVER command
     """Show admin users defined in the installation's authz database."""
     the_installation = cli_util.get_installation(installation_path)
     dburi = the_installation.authorization_dburi_sync
@@ -41,14 +129,14 @@ def list_admin_users(
     cli_util._check_ram_dburi(dburi, "admin-users list")
 
     session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-    _dump_admin_users(session)
+    _dump(ctx, session)
 
 
 @app.command("clear")
 def clear_admin_users(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
-):
+):  # pragma NO COVER command
     """Clear admin users from the installation's authz database."""
     the_installation = cli_util.get_installation(installation_path)
     dburi = the_installation.authorization_dburi_sync
@@ -62,7 +150,7 @@ def clear_admin_users(
             session.delete(admin_user)
         session.commit()
 
-        _dump_admin_users(session)
+    _dump(ctx, session)
 
 
 @app.command("add")
@@ -70,8 +158,12 @@ def add_admin_user(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
     admin_user_email: str,
-):
-    """Add an admin user to the installation's authz database."""
+):  # pragma NO COVER command
+    """Add an admin user to the installation's authz database.
+
+    If the email is already an admin, the command reports that and
+    exits non-zero without inserting a duplicate row.
+    """
     the_installation = cli_util.get_installation(installation_path)
     dburi = the_installation.authorization_dburi_sync
 
@@ -80,8 +172,9 @@ def add_admin_user(
     session = authz_schema.get_session(engine_url=dburi, init_schema=True)
 
     with session:
+        _check_existing_admin(session, admin_user_email)
         admin_user = authz_schema.AdminUser(email=admin_user_email)
         session.add(admin_user)
         session.commit()
 
-        _dump_admin_users(session)
+    _dump(ctx, session)

--- a/src/soliplex/cli/admin_users.py
+++ b/src/soliplex/cli/admin_users.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import typing
 
 import typer
 
+from soliplex import authz as authz_package
 from soliplex.authz import schema as authz_schema
 from soliplex.cli import cli_util
 from soliplex.cli import types
@@ -54,27 +56,91 @@ def _admin_users_callback(
     ctx.obj = {"verbose": effective}
 
 
-def _check_existing_admin(session, email):
-    """Reject 'admin-users add' for an email that is already an admin.
+def _resolve_admin_json_path(email, preferred_username, json_path) -> str:
+    """Resolve the JSONPath for an admin entry from the CLI flags.
 
-    Inserting a second row for the same email would violate the
-    'AdminUser.email' uniqueness constraint; rather than surface that as
-    an opaque IntegrityError traceback (exit code depending on the
-    backend), report it cleanly and exit non-zero.
+    Exactly one discriminator must be supplied: the positional EMAIL
+    (shorthand for the common case), '--preferred-username', or
+    '--json-path'. 'email' / 'preferred_username' are stored as
+    equivalent JSONPath queries (see 'authz.token_field_json_path'),
+    mirroring how 'room-authz add-acl-entry' handles its discriminators.
+    Reports the problem and raises 'typer.Exit(1)' on a bad selection
+    or a malformed '--json-path'.
+    """
+    selected = [
+        name
+        for name, present in (
+            ("EMAIL", email is not None),
+            ("--preferred-username", preferred_username is not None),
+            ("--json-path", json_path is not None),
+        )
+        if present
+    ]
+    if len(selected) != 1:
+        the_console.rule("Exactly one discriminator required")
+        the_console.print(
+            "Pass exactly one of EMAIL, '--preferred-username', or "
+            f"'--json-path'. Got: {selected or ['(none)']}.",
+        )
+        raise typer.Exit(1)
+
+    if email is not None:
+        return authz_package.token_field_json_path("email", email)
+    if preferred_username is not None:
+        return authz_package.token_field_json_path(
+            "preferred_username", preferred_username
+        )
+
+    try:
+        authz_package.validate_json_path(json_path)
+    except authz_package.InvalidJSONPath as exc:
+        the_console.rule("Invalid JSONPath")
+        the_console.print(str(exc))
+        raise typer.Exit(1) from exc
+    return json_path
+
+
+def _describe_admin(json_path) -> str:
+    """Human-friendly descriptor for an admin entry's JSONPath."""
+    parsed = authz_package.parse_token_field_json_path(json_path)
+    if parsed is not None:
+        field, value = parsed
+        return f"{field}={value}"
+    return f"json_path={json_path}"
+
+
+def _admin_display(json_path) -> str:
+    """Value to show for an admin entry in the JSON dump.
+
+    Email-keyed admins show their email; others show the raw query.
+    """
+    parsed = authz_package.parse_token_field_json_path(json_path)
+    if parsed is not None and parsed[0] == "email":
+        return parsed[1]
+    return json_path
+
+
+def _check_existing_admin(session, json_path):
+    """Reject 'admin-users add' for a JSONPath that is already an admin.
+
+    Inserting a second row for the same query would violate the
+    'AdminUser.json_path' uniqueness constraint; rather than surface
+    that as an opaque IntegrityError traceback (exit code depending on
+    the backend), report it cleanly and exit non-zero.
     """
     existing = (
         session.query(
             authz_schema.AdminUser,
         )
         .where(
-            authz_schema.AdminUser.email == email,
+            authz_schema.AdminUser.json_path == json_path,
         )
         .first()
     )
     if existing is None:
         return
 
-    the_console.rule(f"{email} is already an admin")
+    the_console.rule(f"{_describe_admin(json_path)} is already an admin")
     the_console.print("Nothing to do.")
     raise typer.Exit(1)
 
@@ -88,8 +154,8 @@ def _dump(ctx, session):
 
 def _human_dump_admin_users(session):  # pragma NO COVER UI ONLY
     with session:
-        emails = [
-            admin_user.email
+        json_paths = [
+            admin_user.json_path
             for admin_user in session.query(
                 authz_schema.AdminUser,
             )
@@ -97,19 +163,19 @@ def _human_dump_admin_users(session):  # pragma NO COVER UI ONLY
 
     the_console.rule("Admin users")
 
-    if not emails:
+    if not json_paths:
         the_console.print("No admin users configured.")
         return
 
-    the_console.print(f"Admin users ({len(emails)}):")
-    for index, email in enumerate(emails, 1):
-        the_console.print(f"  {index}. {email}")
+    the_console.print(f"Admin users ({len(json_paths)}):")
+    for index, json_path in enumerate(json_paths, 1):
+        the_console.print(f"  {index}. {_describe_admin(json_path)}")
 
 
 def _dump_admin_users(session):  # pragma NO COVER UI ONLY
     with session:
         admin_users = [
-            admin_user.email
+            _admin_display(admin_user.json_path)
             for admin_user in session.query(
                 authz_schema.AdminUser,
             )
@@ -157,13 +223,43 @@ def clear_admin_users(
 def add_admin_user(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
-    admin_user_email: str,
+    admin_user_email: typing.Annotated[
+        str | None,
+        typer.Argument(
+            metavar="EMAIL",
+            help=(
+                "Email address to grant admin (the common case). "
+                "Mutually exclusive with '--preferred-username' / "
+                "'--json-path'."
+            ),
+        ),
+    ] = None,
+    preferred_username: str | None = typer.Option(
+        None,
+        "--preferred-username",
+        help="Grant admin by OIDC preferred_username claim.",
+    ),
+    json_path: str | None = typer.Option(
+        None,
+        "--json-path",
+        help=(
+            "Grant admin to any user token matched by this RFC 9535 "
+            "JSONPath query."
+        ),
+    ),
 ):  # pragma NO COVER command
     """Add an admin user to the installation's authz database.
 
-    If the email is already an admin, the command reports that and
-    exits non-zero without inserting a duplicate row.
+    Exactly one discriminator must be supplied: the positional EMAIL
+    (shorthand for the common case), '--preferred-username', or
+    '--json-path'. If the resolved entry is already an admin, the
+    command reports that and exits non-zero without inserting a
+    duplicate row.
     """
+    resolved = _resolve_admin_json_path(
+        admin_user_email, preferred_username, json_path
+    )
+
     the_installation = cli_util.get_installation(installation_path)
     dburi = the_installation.authorization_dburi_sync
 
@@ -172,8 +268,8 @@ def add_admin_user(
     session = authz_schema.get_session(engine_url=dburi, init_schema=True)
 
     with session:
-        _check_existing_admin(session, admin_user_email)
-        admin_user = authz_schema.AdminUser(email=admin_user_email)
+        _check_existing_admin(session, resolved)
+        admin_user = authz_schema.AdminUser(json_path=resolved)
         session.add(admin_user)
         session.commit()
 

--- a/src/soliplex/cli/serve.py
+++ b/src/soliplex/cli/serve.py
@@ -76,19 +76,15 @@ def serve(
     no_auth_mode: bool = typer.Option(
         False,
         "--no-auth-mode",
-        help="""\
-Disable OIDC authentication providers
-
-Incompatible with '--add-admin-user'.
-""",
+        help="Disable OIDC authentication providers",
     ),
     add_admin_user: str | None = typer.Option(
         None,
         "--add-admin-user",
         help="""\
-Add an admin user to the authorization database
+Removed: seed admins with 'soliplex-cli admin-users add' instead.
 
-Incompatible with '--no-auth-mode'.
+Passing this option now fails with a non-zero exit.
 """,
     ),
     host: str = typer.Option(
@@ -151,12 +147,14 @@ Incompatible with '--no-auth-mode'.
     app_maker=app_maker_option,
 ):
     """Run the Soliplex server"""
-    if no_auth_mode and (add_admin_user is not None):
-        the_console.rule("Incompatible CLI arguments")
+    if add_admin_user is not None:
+        the_console.rule("'--add-admin-user' has been removed")
         the_console.print(
-            "'--no-auth-mode' and '--add-admin-user' are incompatible."
+            "Seed admin users out of band with "
+            "'soliplex-cli admin-users add INSTALLATION_CONFIG_PATH "
+            "EMAIL' instead."
         )
-        raise typer.Exit()
+        raise typer.Exit(1)
 
     # Temporary, to permit updating logging config if not passed on CLI.
     the_installation = cli_util.get_installation(installation_path)
@@ -226,9 +224,6 @@ Incompatible with '--no-auth-mode'.
         if log_config is not None:  # pass to the app, disable Uvicorn.
             os.environ["_SOLIPLEX_LOG_CONFIG_FILE"] = str(log_config)
 
-        if add_admin_user is not None:
-            os.environ["_SOLIPLEX_ADD_ADMIN_USER"] = add_admin_user
-
         if app_factory_name is None:
             app_factory_name = "soliplex.main:create_app_from_environment"
 
@@ -248,6 +243,5 @@ Incompatible with '--no-auth-mode'.
             installation_path=installation_path,
             no_auth_mode=no_auth_mode,
             log_config_file=log_config,
-            add_admin_user=add_admin_user,
         )
         uvicorn.run(app, **uvicorn_kw)

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -494,8 +494,9 @@ def apply_logfire_configuration(
 
 
 def add_user_as_admin(connection, *, email):
+    json_path = authz_package.token_field_json_path("email", email)
     insert_stmt = sqla_sql.insert(authz_schema.AdminUser).values(
-        email=email,
+        json_path=json_path,
     )
     connection.execute(insert_stmt)
 
@@ -516,7 +517,6 @@ async def lifespan(
     installation_path: pathlib.Path,
     no_auth_mode: bool = False,
     log_config_file: str = None,
-    add_admin_user: str = None,
 ):
     i_config = config_installation.load_installation(installation_path)
 
@@ -566,12 +566,7 @@ async def lifespan(
         await ra_connection.run_sync(
             authz_schema.Base.metadata.create_all,
         )
-        if add_admin_user:
-            await ra_connection.run_sync(
-                add_user_as_admin,
-                email=add_admin_user,
-            )
-        elif no_auth_mode:
+        if no_auth_mode:
             await ra_connection.run_sync(
                 add_no_auth_user_as_admin,
             )

--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -23,7 +23,6 @@ def curry_lifespan(
     installation_path: pathlib.Path,
     no_auth_mode: bool,
     log_config_file: str = None,
-    add_admin_user: str = None,
 ):
     installation_path = pathlib.Path(installation_path)
 
@@ -32,7 +31,6 @@ def curry_lifespan(
         installation_path=installation_path,
         no_auth_mode=no_auth_mode,
         log_config_file=log_config_file,
-        add_admin_user=add_admin_user,
     )
 
 
@@ -97,7 +95,6 @@ def create_app(
     installation_path: pathlib.Path,
     no_auth_mode: bool,
     log_config_file: str = None,
-    add_admin_user: str = None,
     curry_lifespan=None,
     app_with_lifespan=None,
     app_with_cors=None,
@@ -126,7 +123,6 @@ def create_app(
         installation_path=installation_path,
         no_auth_mode=no_auth_mode,
         log_config_file=log_config_file,
-        add_admin_user=add_admin_user,
     )
     app = app_with_lifespan(curried_lifespan)
     app = app_with_cors(app)
@@ -153,13 +149,11 @@ def create_app_from_environment():
     installation_path = pathlib.Path(installation_path_str)
     no_auth_mode = os.environ.get("_SOLIPLEX_NO_AUTH_MODE") == "Y"
     log_config_file = os.environ.get("_SOLIPLEX_LOG_CONFIG_FILE")
-    add_admin_user = os.environ.get("_SOLIPLEX_ADD_ADMIN_USER")
 
     return create_app(
         installation_path=installation_path,
         log_config_file=log_config_file,
         no_auth_mode=no_auth_mode,
-        add_admin_user=add_admin_user,
     )
 
 

--- a/tests/unit/authz/test_authz_persistence.py
+++ b/tests/unit/authz/test_authz_persistence.py
@@ -9,6 +9,7 @@ from soliplex.authz import persistence as authz_persistence
 from soliplex.authz import schema as authz_schema
 
 EMAIL = "phreddy@example.com"
+JSON_PATH = authz_package.token_field_json_path("email", EMAIL)
 USER_TOKEN = {
     "email": EMAIL,
 }
@@ -46,8 +47,8 @@ async def test_authorizationpolicy_crud_admin_user(the_async_session):
     assert found == []
 
     await ap.add_admin_user(email=EMAIL)
-    user = await authz_persistence._find_admin_user(
-        email=EMAIL,
+    user = await authz_persistence._find_admin_user_by_json_path(
+        json_path=JSON_PATH,
         session=the_async_session,
     )
     assert user is not None
@@ -60,8 +61,8 @@ async def test_authorizationpolicy_crud_admin_user(the_async_session):
     with pytest.raises(authz_persistence.AdminUserExists):
         await ap.add_admin_user(email=EMAIL)
 
-    no_dupe = await authz_persistence._find_admin_user(
-        email=EMAIL,
+    no_dupe = await authz_persistence._find_admin_user_by_json_path(
+        json_path=JSON_PATH,
         session=the_async_session,
     )
     assert no_dupe is user
@@ -72,8 +73,8 @@ async def test_authorizationpolicy_crud_admin_user(the_async_session):
     await the_async_session.commit()
 
     await ap.remove_admin_user(email=EMAIL)
-    gone = await authz_persistence._find_admin_user(
-        email=EMAIL,
+    gone = await authz_persistence._find_admin_user_by_json_path(
+        json_path=JSON_PATH,
         session=the_async_session,
     )
     assert gone is None
@@ -100,6 +101,29 @@ async def test_authorizationpolicy_check_admin_access(the_async_session):
     await ap.remove_admin_user(email=EMAIL)
 
     assert not await ap.check_admin_access(USER_TOKEN)
+
+
+@pytest.mark.asyncio
+async def test_authorizationpolicy_check_admin_access_json_path(
+    the_async_session,
+):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    # An admin keyed by a non-email JSONPath query (e.g. a role claim),
+    # as produced by 'admin-users add --json-path'.
+    the_async_session.add(
+        authz_schema.AdminUser(json_path='$[?$.role == "admin"]'),
+    )
+    await the_async_session.commit()
+
+    assert await ap.check_admin_access({"role": "admin"})
+    assert not await ap.check_admin_access({"role": "user"})
+    # A role-keyed admin is not matched by an unrelated email token.
+    assert not await ap.check_admin_access(USER_TOKEN)
+
+    # A non-email admin surfaces as its raw JSONPath query, not an email.
+    listed = await ap.list_admin_users()
+    assert listed == ['$[?$.role == "admin"]']
 
 
 @pytest.mark.asyncio

--- a/tests/unit/authz/test_authz_schema.py
+++ b/tests/unit/authz/test_authz_schema.py
@@ -14,6 +14,7 @@ from soliplex.config import installation as config_installation
 NOW = datetime.datetime.now(datetime.UTC)
 
 EMAIL = "phreddy@example.com"
+JSON_PATH = authz_package.token_field_json_path("email", EMAIL)
 
 ROOM_ID = "test-room"
 
@@ -44,10 +45,34 @@ def test__timestamp(dt, tz):
 
 
 def test_adminuser_ctor(the_session):
-    admin_user = authz_schema.AdminUser(email=EMAIL)
+    admin_user = authz_schema.AdminUser(json_path=JSON_PATH)
 
     the_session.add(admin_user)
     the_session.commit()
+
+
+def test_adminuser_ctor_invalid_json_path():
+    with pytest.raises(authz_package.InvalidJSONPath):
+        authz_schema.AdminUser(json_path="$[?(bogus")
+
+
+@pytest.mark.parametrize(
+    "w_json_path, w_token, exp",
+    [
+        # Email-shaped query matches the matching email claim.
+        (JSON_PATH, {"email": EMAIL}, True),
+        (JSON_PATH, {"email": "other@example.com"}, False),
+        # A missing / empty token never matches.
+        (JSON_PATH, None, False),
+        # An arbitrary (non-email) query matches on its own field.
+        ('$[?$.role == "admin"]', {"role": "admin"}, True),
+        ('$[?$.role == "admin"]', {"role": "user"}, False),
+    ],
+)
+def test_adminuser_check_token(w_json_path, w_token, exp):
+    admin_user = authz_schema.AdminUser(json_path=w_json_path)
+
+    assert admin_user.check_token(w_token) is exp
 
 
 def test_roompolicy_ctor(the_session):

--- a/tests/unit/cli/test_cli_admin_users.py
+++ b/tests/unit/cli/test_cli_admin_users.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import typer
+
+from soliplex.cli import admin_users as cli_admin_users
+
+
+@pytest.fixture
+def ctx():
+    return mock.create_autospec(typer.Context, obj={})
+
+
+@pytest.mark.parametrize(
+    "w_verbose, w_quiet, w_default_verbose, exp_effective",
+    [
+        # Neither flag: falls back to the module default.
+        (False, False, False, False),
+        (False, False, True, True),
+        # --verbose alone forces human.
+        (True, False, False, True),
+        (True, False, True, True),
+        # --quiet alone forces JSON, regardless of the default.
+        (False, True, False, False),
+        (False, True, True, False),
+        # --quiet wins when both flags are passed.
+        (True, True, False, False),
+        (True, True, True, False),
+    ],
+)
+def test__admin_users_callback(
+    ctx,
+    w_verbose,
+    w_quiet,
+    w_default_verbose,
+    exp_effective,
+):
+    with mock.patch.object(
+        cli_admin_users,
+        "_DEFAULT_VERBOSE",
+        w_default_verbose,
+    ):
+        cli_admin_users._admin_users_callback(
+            ctx,
+            verbose=w_verbose,
+            quiet=w_quiet,
+        )
+
+    assert ctx.obj == {"verbose": exp_effective}
+
+
+@pytest.mark.parametrize(
+    "w_exists",
+    [
+        # No existing admin: the insert may proceed.
+        False,
+        # Existing admin: reject to avoid a uniqueness-constraint blowup.
+        True,
+    ],
+)
+@mock.patch("soliplex.cli.admin_users.the_console")
+def test__check_existing_admin(the_console, w_exists):
+    email = "alice@example.com"
+    existing = mock.Mock() if w_exists else None
+
+    session = mock.Mock()
+    session.query.return_value.where.return_value.first.return_value = existing
+
+    if not w_exists:
+        cli_admin_users._check_existing_admin(session, email)
+
+        the_console.rule.assert_not_called()
+        the_console.print.assert_not_called()
+        return
+
+    with pytest.raises(typer.Exit) as excinfo:
+        cli_admin_users._check_existing_admin(session, email)
+
+    (return_code,) = excinfo.value.args
+    assert return_code == 1
+
+    the_console.rule.assert_called_once_with(
+        f"{email} is already an admin",
+    )
+    the_console.print.assert_called_once_with("Nothing to do.")
+
+
+@pytest.mark.parametrize(
+    "w_obj, exp_human",
+    [
+        # No ctx.obj at all -> JSON dispatch.
+        (None, False),
+        # Empty ctx.obj -> JSON dispatch.
+        ({}, False),
+        # ctx.obj['verbose'] falsy -> JSON dispatch.
+        ({"verbose": False}, False),
+        # ctx.obj['verbose'] truthy -> human dispatch.
+        ({"verbose": True}, True),
+    ],
+)
+@mock.patch("soliplex.cli.admin_users._human_dump_admin_users")
+@mock.patch("soliplex.cli.admin_users._dump_admin_users")
+def test__dump(
+    _dump_admin_users,
+    _human_dump_admin_users,
+    ctx,
+    w_obj,
+    exp_human,
+):
+    ctx.obj = w_obj
+    session = mock.Mock()
+
+    cli_admin_users._dump(ctx, session)
+
+    if exp_human:
+        _human_dump_admin_users.assert_called_once_with(session)
+        _dump_admin_users.assert_not_called()
+    else:
+        _dump_admin_users.assert_called_once_with(session)
+        _human_dump_admin_users.assert_not_called()

--- a/tests/unit/cli/test_cli_admin_users.py
+++ b/tests/unit/cli/test_cli_admin_users.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 import typer
 
+from soliplex import authz as authz_package
 from soliplex.cli import admin_users as cli_admin_users
 
 
@@ -62,29 +63,122 @@ def test__admin_users_callback(
 )
 @mock.patch("soliplex.cli.admin_users.the_console")
 def test__check_existing_admin(the_console, w_exists):
-    email = "alice@example.com"
+    json_path = authz_package.token_field_json_path(
+        "email", "alice@example.com"
+    )
     existing = mock.Mock() if w_exists else None
 
     session = mock.Mock()
     session.query.return_value.where.return_value.first.return_value = existing
 
     if not w_exists:
-        cli_admin_users._check_existing_admin(session, email)
+        cli_admin_users._check_existing_admin(session, json_path)
 
         the_console.rule.assert_not_called()
         the_console.print.assert_not_called()
         return
 
     with pytest.raises(typer.Exit) as excinfo:
-        cli_admin_users._check_existing_admin(session, email)
+        cli_admin_users._check_existing_admin(session, json_path)
 
     (return_code,) = excinfo.value.args
     assert return_code == 1
 
     the_console.rule.assert_called_once_with(
-        f"{email} is already an admin",
+        "email=alice@example.com is already an admin",
     )
     the_console.print.assert_called_once_with("Nothing to do.")
+
+
+@pytest.mark.parametrize(
+    "w_email, w_pref, w_jp, exp",
+    [
+        (
+            "alice@example.com",
+            None,
+            None,
+            authz_package.token_field_json_path("email", "alice@example.com"),
+        ),
+        (
+            None,
+            "bob",
+            None,
+            authz_package.token_field_json_path("preferred_username", "bob"),
+        ),
+        (None, None, '$[?$.role == "admin"]', '$[?$.role == "admin"]'),
+    ],
+)
+@mock.patch("soliplex.cli.admin_users.the_console")
+def test__resolve_admin_json_path(the_console, w_email, w_pref, w_jp, exp):
+    found = cli_admin_users._resolve_admin_json_path(w_email, w_pref, w_jp)
+
+    assert found == exp
+    the_console.rule.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "w_email, w_pref, w_jp",
+    [
+        # Nothing selected.
+        (None, None, None),
+        # More than one selected.
+        ("alice@example.com", None, '$[?$.role == "admin"]'),
+        ("alice@example.com", "bob", None),
+        ("alice@example.com", "bob", '$[?$.role == "admin"]'),
+    ],
+)
+@mock.patch("soliplex.cli.admin_users.the_console")
+def test__resolve_admin_json_path_not_exactly_one(
+    the_console, w_email, w_pref, w_jp
+):
+    with pytest.raises(typer.Exit) as excinfo:
+        cli_admin_users._resolve_admin_json_path(w_email, w_pref, w_jp)
+
+    (return_code,) = excinfo.value.args
+    assert return_code == 1
+    the_console.rule.assert_called_once_with(
+        "Exactly one discriminator required",
+    )
+
+
+@mock.patch("soliplex.cli.admin_users.the_console")
+def test__resolve_admin_json_path_invalid(the_console):
+    with pytest.raises(typer.Exit) as excinfo:
+        cli_admin_users._resolve_admin_json_path(None, None, "$[?(bogus")
+
+    (return_code,) = excinfo.value.args
+    assert return_code == 1
+    the_console.rule.assert_called_once_with("Invalid JSONPath")
+
+
+@pytest.mark.parametrize(
+    "w_json_path, exp_describe, exp_display",
+    [
+        # Email-shaped query: email descriptor, email display.
+        (
+            authz_package.token_field_json_path("email", "alice@example.com"),
+            "email=alice@example.com",
+            "alice@example.com",
+        ),
+        # preferred_username-shaped: field descriptor, raw query display.
+        (
+            authz_package.token_field_json_path("preferred_username", "bob"),
+            "preferred_username=bob",
+            authz_package.token_field_json_path("preferred_username", "bob"),
+        ),
+        # Other token-field query: field descriptor, raw query display.
+        (
+            '$[?$.role == "admin"]',
+            "role=admin",
+            '$[?$.role == "admin"]',
+        ),
+        # Non-token-field query: raw query for both.
+        ("$.weird[*]", "json_path=$.weird[*]", "$.weird[*]"),
+    ],
+)
+def test__describe_and_display_admin(w_json_path, exp_describe, exp_display):
+    assert cli_admin_users._describe_admin(w_json_path) == exp_describe
+    assert cli_admin_users._admin_display(w_json_path) == exp_display
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -1369,7 +1369,6 @@ def mcp_apps():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("w_max_age", [7200, "7200"])
-@pytest.mark.parametrize("w_add_admin_user", [None, ADMIN_USER_EMAIL])
 @pytest.mark.parametrize(
     "w_ic_logging_config",
     [
@@ -1387,7 +1386,6 @@ def mcp_apps():
     ],
 )
 @mock.patch("soliplex.installation.add_no_auth_user_as_admin")
-@mock.patch("soliplex.installation.add_user_as_admin")
 @mock.patch("soliplex.installation.apply_logfire_configuration")
 @mock.patch("soliplex.secrets.resolve_secrets")
 @mock.patch("soliplex.mcp_server.setup_mcp_for_rooms")
@@ -1401,7 +1399,6 @@ async def test_lifespan(
     smfr,
     srs,
     alc,
-    auaa,
     anauaa,
     mcp_apps,
     temp_dir,
@@ -1409,7 +1406,6 @@ async def test_lifespan(
     exp_oidc_paths,
     w_log_config_file,
     w_ic_logging_config,
-    w_add_admin_user,
     w_max_age,
 ):
     INSTALLATION_PATH = "/path/to/installation"
@@ -1460,9 +1456,6 @@ root:
 """)
         kwargs["log_config_file"] = str(w_log_config_file)
 
-    if w_add_admin_user is not None:
-        kwargs["add_admin_user"] = w_add_admin_user
-
     found = [
         item
         async for item in installation.lifespan(
@@ -1512,12 +1505,7 @@ root:
         lcdc.assert_not_called()
         exp_lc_disable = False
 
-    if w_add_admin_user:
-        (auaa_called,) = auaa.call_args_list
-        (conn,) = auaa_called.args
-        assert isinstance(conn, sqlalchemy.Connection)
-        assert auaa_called.kwargs == {"email": w_add_admin_user}
-    elif exp_no_auth_mode:
+    if exp_no_auth_mode:
         (anauaa_called,) = anauaa.call_args_list
         (conn,) = anauaa_called.args
         assert isinstance(conn, sqlalchemy.Connection)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -9,7 +9,6 @@ from starlette.middleware import sessions as starlette_mw_sessions
 
 from soliplex import main
 
-ADMIN_USER_EMAIL = "admin@example.com"
 LOG_CONFIG_FILE_PATH = "/path/to/logging.yaml"
 EXPLICIT_INST_PATH = "/explicit"
 
@@ -19,16 +18,6 @@ def explicit_inst_dir(temp_dir):
     result = temp_dir / "explicit"
     result.mkdir()
     return result
-
-
-@pytest.fixture(scope="module", params=[None, ADMIN_USER_EMAIL])
-def add_admin_user_kwargs(request):
-    kw = {}
-
-    if request.param is not None:
-        kw["add_admin_user"] = request.param
-
-    return kw
 
 
 @pytest.fixture(scope="module", params=[False, True])
@@ -48,16 +37,10 @@ def log_config_file_kwargs(request):
 
 
 def test_curry_lifespan(
-    add_admin_user_kwargs,
     no_auth_mode_kwargs,
     log_config_file_kwargs,
 ):
     exp_path = EXPLICIT_INST_PATH
-
-    if add_admin_user_kwargs:
-        exp_add_admin_user = add_admin_user_kwargs["add_admin_user"]
-    else:
-        exp_add_admin_user = None
 
     exp_no_auth_mode = no_auth_mode_kwargs["no_auth_mode"]
 
@@ -68,7 +51,6 @@ def test_curry_lifespan(
 
     found = main.curry_lifespan(
         installation_path=EXPLICIT_INST_PATH,
-        **add_admin_user_kwargs,
         **no_auth_mode_kwargs,
         **log_config_file_kwargs,
     )
@@ -78,7 +60,6 @@ def test_curry_lifespan(
     assert found.keywords == {
         "installation_path": pathlib.Path(exp_path),
         "no_auth_mode": exp_no_auth_mode,
-        "add_admin_user": exp_add_admin_user,
         "log_config_file": exp_log_config_file,
     }
 
@@ -193,18 +174,13 @@ secrets:
 
 
 @pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
-@pytest.mark.parametrize("w_add_admin_user", [None, ADMIN_USER_EMAIL])
 @pytest.mark.parametrize("w_no_auth_mode", [False, True])
 def test_create_app_with_explicit_overrides(
     installation_w_session_token,
     w_no_auth_mode,
-    w_add_admin_user,
     w_log_config_file,
 ):
     kwargs = {}
-
-    if w_add_admin_user is not None:
-        kwargs["add_admin_user"] = w_add_admin_user
 
     if w_log_config_file is not None:
         kwargs["log_config_file"] = w_log_config_file
@@ -243,24 +219,18 @@ def test_create_app_with_explicit_overrides(
     curry_lifespan.assert_called_once_with(
         installation_path=installation_w_session_token,
         no_auth_mode=w_no_auth_mode,
-        add_admin_user=w_add_admin_user,
         log_config_file=w_log_config_file,
     )
 
 
 @pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
-@pytest.mark.parametrize("w_add_admin_user", [None, ADMIN_USER_EMAIL])
 @pytest.mark.parametrize("w_no_auth_mode", [False, True])
 def test_create_app_wo_explicit_overrides(
     installation_w_session_token,
     w_no_auth_mode,
-    w_add_admin_user,
     w_log_config_file,
 ):
     kwargs = {}
-
-    if w_add_admin_user is not None:
-        kwargs["add_admin_user"] = w_add_admin_user
 
     if w_log_config_file is not None:
         kwargs["log_config_file"] = w_log_config_file
@@ -302,20 +272,17 @@ def test_create_app_wo_explicit_overrides(
     curry_lifespan.assert_called_once_with(
         installation_path=installation_w_session_token,
         no_auth_mode=w_no_auth_mode,
-        add_admin_user=w_add_admin_user,
         log_config_file=w_log_config_file,
     )
 
 
 @pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
-@pytest.mark.parametrize("w_add_admin_user", [None, ADMIN_USER_EMAIL])
 @pytest.mark.parametrize("w_no_auth_mode", [False, True])
 @mock.patch("soliplex.main.create_app")
 def test_create_app_from_environment(
     create_app,
     temp_dir,
     w_no_auth_mode,
-    w_add_admin_user,
     w_log_config_file,
 ):
     i_path = temp_dir / "installation.yaml"
@@ -324,9 +291,6 @@ def test_create_app_from_environment(
 
     if w_no_auth_mode:
         env_patch["_SOLIPLEX_NO_AUTH_MODE"] = "Y"
-
-    if w_add_admin_user:
-        env_patch["_SOLIPLEX_ADD_ADMIN_USER"] = w_add_admin_user
 
     if w_log_config_file:
         env_patch["_SOLIPLEX_LOG_CONFIG_FILE"] = w_log_config_file
@@ -339,6 +303,5 @@ def test_create_app_from_environment(
     create_app.assert_called_once_with(
         installation_path=i_path,
         no_auth_mode=w_no_auth_mode,
-        add_admin_user=w_add_admin_user,
         log_config_file=w_log_config_file,
     )


### PR DESCRIPTION
See #935.

-  (CLI) 'admin-users add' options: '--json-path' and '--preferred-username'.
- (CLI) drop 'serve --add-admin-user' option: it now errors, pointing to 'admin-users add'
-  'authz.schema.AdminUser' stores only 'json_path', converted from 'email' in migration.
- Previous v0.67 migration extended, fixed to work correctly w/ Postgres.