### PR TITLE
Upgrade haiku.rag to 0.51.0

### DIFF
--- a/example/haiku.rag.yaml
+++ b/example/haiku.rag.yaml
@@ -8,14 +8,6 @@ storage:
   auto_vacuum: true
   vacuum_retention_seconds: 86400
 
-# This section is used to configure how files are added to the RAG
-# database.  It is not currently working for the 'haiku-rag serve --monitor'
-# usecase (see https://github.com/ggozad/haiku.rag/issues/132).
-monitor:
-  directories: ["docs"]
-  ignore_patterns: ["*.png"]
-  include_patterns: ["*.md"]
-
 # This section is for configuring LanceDB in various "remote" modes.
 # Leave it commented out to use local filesystem databases.
 #lancedb:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "fastmcp >= 3.3.0, < 3.4",
     "fakeredis != 2.35.0",  # brownbag
     "greenlet",
-    "haiku.rag-slim >= 0.50.0, < 0.51",
+    "haiku.rag-slim >= 0.51.0, < 0.52",
     "haiku-skills >= 0.17.1, < 0.18",
     "idna >= 3.15",
     "itsdangerous",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "fastmcp >= 3.3.0, < 3.4",
     "fakeredis != 2.35.0",  # brownbag
     "greenlet",
-    "haiku.rag-slim >= 0.48.1, < 0.49",
+    "haiku.rag-slim >= 0.50.0, < 0.51",
     "haiku-skills >= 0.17.1, < 0.18",
     "idna >= 3.15",
     "itsdangerous",

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ wheels = [
 
 [[package]]
 name = "haiku-rag-slim"
-version = "0.50.0"
+version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docling-core" },
@@ -1116,9 +1116,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/ba/523c37780dd742d3c363977378160f7c1412c0fc050e32855d2813eb0a1a/haiku_rag_slim-0.50.0.tar.gz", hash = "sha256:19f821d6c19dd96f30cdda35e5bc505af08758d6a0438c0aa4320e0bf537b554", size = 181939, upload-time = "2026-05-27T13:25:18.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/0d/01780312967a98738494dd4e3258727465018e424300db582095da9f6d1b/haiku_rag_slim-0.51.0.tar.gz", hash = "sha256:a706ef9d138284e267e7a17354829e848bbb64c1b279b2f7914b883c5a01c3df", size = 184367, upload-time = "2026-05-29T08:48:06.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/8c/3cd74a20cafe7ac78bfd44bdf9e58ca5596172914e67876f19b8a869d05a/haiku_rag_slim-0.50.0-py3-none-any.whl", hash = "sha256:244381eea3690e36137c89e541ec952cffc7dd88dd42dc476dba95c1d56b55d0", size = 254728, upload-time = "2026-05-27T13:25:16.504Z" },
+    { url = "https://files.pythonhosted.org/packages/13/73/73930e65d6dd5b03c6440415f6d6e62c7687dd07424698c181ab260b0e3b/haiku_rag_slim-0.51.0-py3-none-any.whl", hash = "sha256:b811c72335eaf3fce1581fda16246631225d07cc9736458484f0970838716da2", size = 257382, upload-time = "2026-05-29T08:48:05.414Z" },
 ]
 
 [[package]]
@@ -3392,7 +3392,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.3.0,<3.4" },
     { name = "greenlet" },
-    { name = "haiku-rag-slim", specifier = ">=0.50.0,<0.51" },
+    { name = "haiku-rag-slim", specifier = ">=0.51.0,<0.52" },
     { name = "haiku-skills", specifier = ">=0.17.1,<0.18" },
     { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous" },

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ wheels = [
 
 [[package]]
 name = "haiku-rag-slim"
-version = "0.48.1"
+version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docling-core" },
@@ -1108,6 +1108,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-ai-slim", extra = ["ag-ui", "fastmcp", "logfire", "openai"] },
     { name = "pydantic-monty" },
+    { name = "pypdfium2" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -1115,9 +1116,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/e8/da39f77db6f3df424dd5afcaa28a5f26856d7282996a66731a7c02696aea/haiku_rag_slim-0.48.1.tar.gz", hash = "sha256:e96c07a84b4ea568b8fb8c7d076ef4c8fc5bf0222aba5acacfda268b10bcd969", size = 139729, upload-time = "2026-05-21T11:37:11.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/ba/523c37780dd742d3c363977378160f7c1412c0fc050e32855d2813eb0a1a/haiku_rag_slim-0.50.0.tar.gz", hash = "sha256:19f821d6c19dd96f30cdda35e5bc505af08758d6a0438c0aa4320e0bf537b554", size = 181939, upload-time = "2026-05-27T13:25:18.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/88/fb33f98840db93a7051764661fdaa6c48c25a7bf2bc846a9b659cbb85e22/haiku_rag_slim-0.48.1-py3-none-any.whl", hash = "sha256:a5f459cce4de8390b30aa1116a19f300b74440622024f9e61fc875093969950c", size = 192490, upload-time = "2026-05-21T11:37:10.318Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8c/3cd74a20cafe7ac78bfd44bdf9e58ca5596172914e67876f19b8a869d05a/haiku_rag_slim-0.50.0-py3-none-any.whl", hash = "sha256:244381eea3690e36137c89e541ec952cffc7dd88dd42dc476dba95c1d56b55d0", size = 254728, upload-time = "2026-05-27T13:25:16.504Z" },
 ]
 
 [[package]]
@@ -2791,6 +2792,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdfium2"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/3d/dc934d3b606c51c3ecc95b6731d84b7dd7ab8e513a50b0e98a4da6c8a719/pypdfium2-5.8.0.tar.gz", hash = "sha256:049397c647e50f83115ee951c49394dab9e9ba52ebdd5a11ab1109390eb3d34e", size = 271934, upload-time = "2026-05-04T17:39:43.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/8c/6b75b923cb81368fa3ea7c48a0616b839620a3aeff899885bd930449b89e/pypdfium2-5.8.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:f67b6c74b716d9ac725ad1af49ae786ad813ac20823d45606d59f1fc06caa8af", size = 3374554, upload-time = "2026-05-04T17:39:05.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/61/a885c7f36efba89ec98e3d1fe95c83b48c2d6dea321e9194ac6460e7a834/pypdfium2-5.8.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:53e82bf3e6a2da170b1bda83f93b7eec57cb6efe3cacd05cba78823879a85203", size = 2831667, upload-time = "2026-05-04T17:39:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1f/04b5627f6dba312d3e707e5b019c9f24d8b03b5aa366866a9e02ec00f8d4/pypdfium2-5.8.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:085e633dcc89b65ff4035a4787e98ce7ae636836eb39c83dd0db26113d9774bc", size = 3450815, upload-time = "2026-05-04T17:39:09.551Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/77/8e3a2aba2bc4aef5abe1b1306d05b00588dc0bf7f5c850d1adf6164c786b/pypdfium2-5.8.0-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:bc84b7c6efede88fcfb9467f81daf416f26b973a54fc1cf4d3410d622fda6d7a", size = 3634395, upload-time = "2026-05-04T17:39:11.225Z" },
+    { url = "https://files.pythonhosted.org/packages/93/11/6f2b1847d9fa457b3b7251afc2bba2706d104a0c6f01431dfae5d679a839/pypdfium2-5.8.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a63bf09b2e13ba8545c930d243f0650c664a1b51314daa3b5f38df6d1a17b4bc", size = 3617413, upload-time = "2026-05-04T17:39:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/fd/99ce639de5ca06d21743c740dd988cd209dda623bc763ae10b8a162022e1/pypdfium2-5.8.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:937881c1698456749ed203a58db1895baa5eb7178cdb837ef84867790638da28", size = 3347639, upload-time = "2026-05-04T17:39:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/47/82864cc6e26dd8969d5594c168635acb16458d35cf5fed65d6b2e32abb42/pypdfium2-5.8.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6be9dc2b84a8694ad7e626bab133244e8241014d5ed1930d865a9bdf90df1e24", size = 3746404, upload-time = "2026-05-04T17:39:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/82/58/e41e49bba951f61921bac7289e67fe02af5ac57192d0bbfb5f459dc3691d/pypdfium2-5.8.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7f27bd82891ae302dd02d736b14809661f6d1220ee1e96dbed9b23e2811922a3", size = 4177893, upload-time = "2026-05-04T17:39:18.729Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/15/fa7031010d5cf6853dadb4864680a0bfb7782c5bb6a1a401e0c25c4fca87/pypdfium2-5.8.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26c1089cdbbdc7fe1248f6d17fe3f30214be4f287dd0196b31aaee18a1564240", size = 3665152, upload-time = "2026-05-04T17:39:20.207Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/5a3520a8b0cfa8d7fdc3f03a07ad9d6146c28ffd519330706f64fd8939a8/pypdfium2-5.8.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1c038a9290864aaa4862dd32e591993d82551ca4d152b4e8ce6d43ba37dc04a8", size = 3095365, upload-time = "2026-05-04T17:39:22.054Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d3/845bae4de3cfa36865959046156edb5bf9baea400ccdecdd84fdd911b0f5/pypdfium2-5.8.0-py3-none-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f104bc1a6d8bfc1ff088aa50db13b9729cfdb3722b44975c3c457e9a7b9c7318", size = 2961801, upload-time = "2026-05-04T17:39:23.817Z" },
+    { url = "https://files.pythonhosted.org/packages/99/76/cf54eabee4a172241dfcfe63533bd1e11e2162114a983453a5a40bfec114/pypdfium2-5.8.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:04ca7c57a553facf8d46c6ea8ba6fa557e698670cfa4a58e0e01fdae2f6be87d", size = 4133067, upload-time = "2026-05-04T17:39:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/77/66/dcf871d19187ca04ea184a99801a6e7e556d8347aa49540fee33cda6dfc5/pypdfium2-5.8.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ad42b9c22477b32dbedcbc8232833f385d92fd0cf92822547b02383cf9a476d7", size = 3749100, upload-time = "2026-05-04T17:39:27.203Z" },
+    { url = "https://files.pythonhosted.org/packages/32/67/0d456c79660959ca45ad307b4d67161d29f9ed4083ee1e8fe8c6925b7c82/pypdfium2-5.8.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:388e3119cf5ca0979b7d5f6d40b7fcd5ab49e17ed4e6de6af89ba116061acfda", size = 4339212, upload-time = "2026-05-04T17:39:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/76/89/e5b0e0f7936be341c91c0f45cd70d693878894ed62aed93a6ee32e9c43c4/pypdfium2-5.8.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:aa05bbfa485ce7916217aa78d856c9f9cd86b08b20846c650392a67975ee72e9", size = 4383943, upload-time = "2026-05-04T17:39:31.287Z" },
+    { url = "https://files.pythonhosted.org/packages/82/21/4502ed255f082f579cd3537c2971cf1a57778d43703a08bcd1a92253189f/pypdfium2-5.8.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:f0813a16bb39d5ebd173ea5484430bb67a89b4b181db0a636c73b64ad063c3ea", size = 3925680, upload-time = "2026-05-04T17:39:33.241Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/4f/2e59723e7a07779439bd885c1b4960079c9710603308888d29ac926ae69a/pypdfium2-5.8.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:a3c78f7d20dd821bec6c072efdb21a1370b9efe10fdeeb68c969e67608e25385", size = 4269560, upload-time = "2026-05-04T17:39:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4e/7b6b1bde3788c8b880d4b8131d95d9d339cebafb3ad9102d82e234bb65be/pypdfium2-5.8.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:86d302e207c138c827b885a72784f7b306d840646ebeae07e8efdbc39321c629", size = 4182434, upload-time = "2026-05-04T17:39:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7b/6ed4782e0d7a5278330598ce8c4b2df7255f4585a0b3d04520fa580d6507/pypdfium2-5.8.0-py3-none-win32.whl", hash = "sha256:3f25fd436920a907291462b41bdc0ab9f8235c3944b4c9c15398da595ffd1fed", size = 3636680, upload-time = "2026-05-04T17:39:38.49Z" },
+    { url = "https://files.pythonhosted.org/packages/19/55/da7223d4202b2461f4f889b0baf10dddec3db7f88e6fd8c52db4a516eecd/pypdfium2-5.8.0-py3-none-win_amd64.whl", hash = "sha256:55592af0bddd2d62bed18e0053c546c9b72041430c5115e54870f7f6163125b0", size = 3754962, upload-time = "2026-05-04T17:39:40.13Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7a/f3dcefe6ee7389aad3ca1488c177e8fbf978206de21c7a99ccf487ea38ab/pypdfium2-5.8.0-py3-none-win_arm64.whl", hash = "sha256:3f17ed97ae8a5a1705301ca93af256a5b02f9009dee4e99c5e175831d46ebd7c", size = 3548362, upload-time = "2026-05-04T17:39:42.304Z" },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3362,7 +3392,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.3.0,<3.4" },
     { name = "greenlet" },
-    { name = "haiku-rag-slim", specifier = ">=0.48.1,<0.49" },
+    { name = "haiku-rag-slim", specifier = ">=0.50.0,<0.51" },
     { name = "haiku-skills", specifier = ">=0.17.1,<0.18" },
     { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous" },


### PR DESCRIPTION
Upgrades haiku.rag to latest (0.50.0)
No major changes (other than db migration) the focus of 0.50.0 is the ingester.
I will make another PR for `soliplex-template` for the ingester.