### PR TITLE
tests: optimize full runs

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -48,11 +48,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --group dev
 
+      # '-n auto' parallelizes via pytest-xdist (one worker per core); CI
+      # runners have few cores, so 'auto' is portable here (locally, '-n 8'
+      # on a 16-core box is faster -- see README "Running tests").
       - name: Run unit tests with coverage
-        run: uv run py.test -s ${{ matrix.pytest-args }}
+        run: uv run py.test -s -n auto ${{ matrix.pytest-args }}
 
       - name: Run functional tests
-        run: uv run py.test -s --no-cov -m "not needs_llm" tests/functional/
+        run: uv run py.test -s -n auto --no-cov -m "not needs_llm" tests/functional/
 
       - name: Notify Slack on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ and will NOT work with `[dependency-groups]`. Always use `--group dev` instead.
 # Run unit tests with coverage
 pytest
 
+# Run in parallel with pytest-xdist (much faster on multi-core machines)
+pytest -n 8
+
 # Run with specific coverage threshold (CI enforces 100%)
 pytest --cov-fail-under=100
 
@@ -260,6 +263,14 @@ ruff check
 # Check formatting
 ruff format --check
 ```
+
+The full suite with coverage is CPU-bound, so parallelizing it with
+`pytest-xdist` (the `-n` option) is the biggest single speedup. Coverage
+instrumentation is itself CPU-heavy, so the fastest worker count is *fewer*
+than the core count -- `-n 8` is a good default on a 16-core box. Tune `-n`
+to roughly half your physical cores, or use `-n auto` to let pytest-xdist
+pick one worker per core (portable, but slightly slower than the hand-tuned
+value when coverage is enabled).
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "pytest >= 9.0.2, < 9.1",
     "pytest-cov >= 7.0.0, < 7.1",
     "pytest-asyncio >= 1.3.0, < 1.4",
+    "pytest-xdist >= 3.8.0, < 3.9",
     "ruff >= 0.15.6, < 0.16",
     "skills-ref",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "python-keycloak",
     "sqlmodel",
     "starlette >= 1.0.1",  # PYSEC-2026-161
-    "trio",
     "uvicorn[standard]",
     "certifi >= 2025.11.12",
 ]
@@ -56,7 +55,6 @@ dev = [
     "pytest-asyncio >= 1.3.0, < 1.4",
     "ruff >= 0.15.6, < 0.16",
     "skills-ref",
-    "trio >= 0.33.0, < 0.34",
 ]
 docs = [
     "zensical>=0.0.43",

--- a/tests/unit/agui/test_agui_schema.py
+++ b/tests/unit/agui/test_agui_schema.py
@@ -41,7 +41,14 @@ def test_run_thread_id():
     assert run.thread_id == agui_constants.THREAD_UUID
 
 
-@pytest.mark.parametrize("w_parent_id", [None, agui_constants.PARENT_RUN_ID])
+# 'PARENT_RUN_ID' is a fresh 'uuid4()' generated at import time, so the
+# auto-derived parametrize id differs between processes. Pin explicit
+# 'ids' to keep collection identical across pytest-xdist workers.
+@pytest.mark.parametrize(
+    "w_parent_id",
+    [None, agui_constants.PARENT_RUN_ID],
+    ids=["no_parent", "w_parent"],
+)
 def test_run_parent_run_id(w_parent_id):
     thread = agui_schema.Thread(thread_id=agui_constants.THREAD_UUID)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -30,6 +30,12 @@ def _auth_systems(n_auth_systems):
     ]
 
 
+@pytest.fixture(scope="module")
+def anyio_backend():
+    """Run anyio-marked tests on asyncio only (no trio)."""
+    return "asyncio"
+
+
 @pytest.fixture
 def temp_dir() -> pathlib.Path:
     with tempfile.TemporaryDirectory() as td:

--- a/uv.lock
+++ b/uv.lock
@@ -2088,18 +2088,6 @@ wheels = [
 ]
 
 [[package]]
-name = "outcome"
-version = "1.3.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3321,7 +3309,6 @@ dependencies = [
     { name = "python-keycloak" },
     { name = "sqlmodel" },
     { name = "starlette" },
-    { name = "trio" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -3334,7 +3321,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "skills-ref" },
-    { name = "trio" },
 ]
 docs = [
     { name = "zensical" },
@@ -3376,7 +3362,6 @@ requires-dist = [
     { name = "python-keycloak" },
     { name = "sqlmodel" },
     { name = "starlette", specifier = ">=1.0.1" },
-    { name = "trio" },
     { name = "uvicorn", extras = ["standard"] },
 ]
 
@@ -3389,7 +3374,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0,<7.1" },
     { name = "ruff", specifier = ">=0.15.6,<0.16" },
     { name = "skills-ref" },
-    { name = "trio", specifier = ">=0.33.0,<0.34" },
 ]
 docs = [{ name = "zensical", specifier = ">=0.0.43" }]
 postgres = [
@@ -3675,23 +3659,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
-]
-
-[[package]]
-name = "trio"
-version = "0.33.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
-    { name = "idna" },
-    { name = "outcome" },
-    { name = "sniffio" },
-    { name = "sortedcontainers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/b6/c744031c6f89b18b3f5f4f7338603ab381d740a7f45938c4607b2302481f/trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970", size = 605109, upload-time = "2026-02-14T18:40:55.386Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/93/dab25dc87ac48da0fe0f6419e07d0bfd98799bed4e05e7b9e0f85a1a4b4b/trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b", size = 510294, upload-time = "2026-02-14T18:40:53.313Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -778,6 +778,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2831,6 +2840,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3319,6 +3341,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "skills-ref" },
 ]
@@ -3372,6 +3395,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2,<9.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<1.4" },
     { name = "pytest-cov", specifier = ">=7.0.0,<7.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0,<3.9" },
     { name = "ruff", specifier = ">=0.15.6,<0.16" },
     { name = "skills-ref" },
 ]


### PR DESCRIPTION
- Remove `trio` dependency, which we don't actually use, but which doubled number of runs for async testcases.
- Add `pytest-xdist`, and use it for CI (suggest for local dev).

Reduces full-unittest-suite-with-coverage time from ~260s locally to ~60s locally.