### PR TITLE
tests: (CLI) end-to-end `room-authz` command coverage

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -54,8 +54,11 @@ jobs:
       - name: Run unit tests with coverage
         run: uv run py.test -s -n auto ${{ matrix.pytest-args }}
 
+      # Functional tests run serially: they share on-disk state (e.g. the
+      # 'sandbox/workdirs' tree, keyed by a constant room id) and
+      # module-scoped app fixtures, so xdist workers race each other.
       - name: Run functional tests
-        run: uv run py.test -s -n auto --no-cov -m "not needs_llm" tests/functional/
+        run: uv run py.test -s --no-cov -m "not needs_llm" tests/functional/
 
       - name: Notify Slack on failure
         if: failure()

--- a/src/soliplex/agui/schema.py
+++ b/src/soliplex/agui/schema.py
@@ -532,6 +532,22 @@ def get_engine(
         **engine_kwargs,
     )
 
+    @sqlalchemy.event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(  # pragma: no cover
+        dbapi_connection, connection_record
+    ):
+        # SQLite ignores foreign-key constraints -- and hence the
+        # 'ON DELETE CASCADE' threading thread -> run -> events -- unless
+        # they are enabled per connection. Mirrors
+        # 'soliplex.installation._set_sqlite_pragma' (issue #950) for the
+        # sync engine; without it, deleting a parent row orphans its
+        # children instead of cascading.
+        if engine.dialect.name != "sqlite":
+            return
+        cursor_fk = dbapi_connection.cursor()
+        cursor_fk.execute("PRAGMA foreign_keys=ON")
+        cursor_fk.close()
+
     if init_schema:
         with engine.connect() as connection:
             Base.metadata.create_all(connection)

--- a/src/soliplex/authz/schema.py
+++ b/src/soliplex/authz/schema.py
@@ -294,6 +294,23 @@ def get_engine(
         json_serializer=util.serialize_sqla_json,
         **engine_kwargs,
     )
+
+    @sqlalchemy.event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(  # pragma: no cover
+        dbapi_connection, connection_record
+    ):
+        # SQLite ignores foreign-key constraints -- and hence the
+        # 'ON DELETE CASCADE' on room_acl_entries -- unless they are
+        # enabled per connection. Mirrors
+        # 'soliplex.installation._set_sqlite_pragma' (issue #950) for the
+        # sync engine the CLI uses; without it, deleting a RoomPolicy
+        # orphans its ACL rows instead of cascading.
+        if engine.dialect.name != "sqlite":
+            return
+        cursor_fk = dbapi_connection.cursor()
+        cursor_fk.execute("PRAGMA foreign_keys=ON")
+        cursor_fk.close()
+
     if init_schema:
         with engine.connect() as connection:
             Base.metadata.create_all(connection)

--- a/src/soliplex/cli/cli_util.py
+++ b/src/soliplex/cli/cli_util.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import pathlib
 
 import typer
@@ -7,6 +8,7 @@ from rich import console
 
 from soliplex import authz as authz_package
 from soliplex import installation
+from soliplex.authz import schema as authz_schema
 from soliplex.config import installation as config_installation
 
 the_console = console.Console()
@@ -35,6 +37,23 @@ def _check_ram_dburi(dburi: str, command: str):
         the_console.rule("Authorization DB is RAM-based")
         the_console.print(f"'{command}' is a no-op with a RAM-based database")
         raise typer.Exit(1)
+
+
+@contextlib.contextmanager
+def _authz_session(dburi):
+    """Yield a sync authz session, disposing its engine on exit.
+
+    'authz_schema.get_session' builds a fresh engine (and connection
+    pool) per call. Disposing it when the caller finishes -- on both the
+    success and 'typer.Exit' paths -- closes the underlying SQLite
+    connection deterministically instead of leaking it until garbage
+    collection.
+    """
+    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
+    try:
+        yield session
+    finally:
+        session.get_bind().dispose()
 
 
 def _check_exactly_one_discriminator(

--- a/src/soliplex/cli/room_authz.py
+++ b/src/soliplex/cli/room_authz.py
@@ -265,7 +265,7 @@ def show_room_authz(
             "by a removed or renamed room can still be inspected."
         ),
     ),
-):  # pragma NO COVER command
+):
     """Show room ACL entries defined in the installation's authz database."""
     the_installation = cli_util.get_installation(installation_path)
     dburi = the_installation.authorization_dburi_sync
@@ -302,7 +302,7 @@ def room_authz_as_yaml(
             "by a removed or renamed room can still be dumped."
         ),
     ),
-):  # pragma NO COVER command
+):
     """Dump a room's RoomPolicy and ACL entries as YAML.
 
     With '--output', the YAML is written to the given file path;
@@ -361,7 +361,7 @@ def room_authz_from_yaml(
             ),
         ),
     ] = None,
-):  # pragma NO COVER command
+):
     """Load a room's RoomPolicy and ACL entries from YAML.
 
     The YAML uses the same shape produced by 'room-authz as-yaml'.
@@ -434,7 +434,7 @@ def make_room_private(
             "(preserving existing ACL entries)."
         ),
     ),
-):  # pragma NO COVER command
+):
     """Ensure a room is private
 
     A room with no RoomPolicy row is public-to-all-authenticated-users
@@ -505,7 +505,7 @@ def make_room_public(
             "(preserving existing ACL entries)."
         ),
     ),
-):  # pragma NO COVER command
+):
     """Ensure a room is public
 
     A room with no RoomPolicy row is public-to-all-authenticated-users
@@ -564,7 +564,7 @@ def clear_room_acl(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
     room_id: str,
-):  # pragma NO COVER command
+):
     """Clear ACL entries from a room's policy, preserving the policy
 
     Unlike 'clear', this command does not delete the room's
@@ -729,7 +729,7 @@ def add_acl_entry(
         "--email",
         help="Match a user by OIDC email claim.",
     ),
-):  # pragma NO COVER command
+):
     """Add an ACL entry to a room's policy.
 
     Exactly one of '--allow' or '--deny' must be supplied.
@@ -854,7 +854,7 @@ def delete_acl_entry(
             "been removed) can still be matched and removed."
         ),
     ),
-):  # pragma NO COVER command
+):
     """Delete an ACL entry from a room's policy.
 
     The entry to delete is identified by the combination of

--- a/src/soliplex/cli/room_authz.py
+++ b/src/soliplex/cli/room_authz.py
@@ -274,9 +274,8 @@ def show_room_authz(
     if not allow_stale:
         _check_room_id(the_installation, room_id)
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-
-    _dump(ctx, session, room_id)
+    with cli_util._authz_session(dburi) as session:
+        _dump(ctx, session, room_id)
 
 
 @app.command("as-yaml")
@@ -318,19 +317,18 @@ def room_authz_as_yaml(
     if not allow_stale:
         _check_room_id(the_installation, room_id)
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
+    with cli_util._authz_session(dburi) as session:
+        with session:
+            policy = (
+                session.query(
+                    authz_schema.RoomPolicy,
+                )
+                .where(
+                    authz_schema.RoomPolicy.room_id == room_id,
+                )
+                .first()
             )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
-        )
-        yaml_text = _room_policy_as_yaml(policy)
+            yaml_text = _room_policy_as_yaml(policy)
 
     if output is not None:
         output.write_text(yaml_text)
@@ -397,27 +395,26 @@ def room_authz_from_yaml(
 
     _check_room_id(the_installation, room_id)
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-
-    with session:
-        existing = (
-            session.query(
-                authz_schema.RoomPolicy,
+    with cli_util._authz_session(dburi) as session:
+        with session:
+            existing = (
+                session.query(
+                    authz_schema.RoomPolicy,
+                )
+                .where(
+                    authz_schema.RoomPolicy.room_id == room_id,
+                )
+                .first()
             )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
-        )
-        if existing is not None:
-            session.delete(existing)
-            session.commit()
+            if existing is not None:
+                session.delete(existing)
+                session.commit()
 
-        if model is not None:
-            new_policy = authz_schema.RoomPolicy.from_model(model)
-            new_policy.room_id = room_id
-            session.add(new_policy)
-            session.commit()
+            if model is not None:
+                new_policy = authz_schema.RoomPolicy.from_model(model)
+                new_policy.room_id = room_id
+                session.add(new_policy)
+                session.commit()
 
 
 @app.command("make-private")
@@ -457,38 +454,37 @@ def make_room_private(
     cli_util._check_ram_dburi(dburi, "room-authz make-private")
     _check_room_id(the_installation, room_id)
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
-            )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
-        )
-
-        if policy is None:
-            policy = authz_schema.RoomPolicy(room_id=room_id)
-            session.add(policy)
-            session.commit()
-        elif policy.default_allow_deny == authz_package.AllowDeny.ALLOW:
-            if not update:
-                the_console.rule(
-                    "Room policy already exists with default ALLOW",
+    with cli_util._authz_session(dburi) as session:
+        with session:
+            policy = (
+                session.query(
+                    authz_schema.RoomPolicy,
                 )
-                the_console.print(
-                    f"Room '{room_id}' has an existing policy with "
-                    "default_allow_deny=ALLOW; pass '--update' to "
-                    "flip it to DENY.",
+                .where(
+                    authz_schema.RoomPolicy.room_id == room_id,
                 )
-                raise typer.Exit(1)
-            policy.default_allow_deny = authz_package.AllowDeny.DENY
-            session.commit()
+                .first()
+            )
 
-    _dump(ctx, session, room_id)
+            if policy is None:
+                policy = authz_schema.RoomPolicy(room_id=room_id)
+                session.add(policy)
+                session.commit()
+            elif policy.default_allow_deny == authz_package.AllowDeny.ALLOW:
+                if not update:
+                    the_console.rule(
+                        "Room policy already exists with default ALLOW",
+                    )
+                    the_console.print(
+                        f"Room '{room_id}' has an existing policy with "
+                        "default_allow_deny=ALLOW; pass '--update' to "
+                        "flip it to DENY.",
+                    )
+                    raise typer.Exit(1)
+                policy.default_allow_deny = authz_package.AllowDeny.DENY
+                session.commit()
+
+        _dump(ctx, session, room_id)
 
 
 @app.command("make-public")
@@ -527,36 +523,35 @@ def make_room_public(
     cli_util._check_ram_dburi(dburi, "room-authz make-public")
     _check_room_id(the_installation, room_id)
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
-            )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
-        )
-
-        if policy is not None and (
-            policy.default_allow_deny == authz_package.AllowDeny.DENY
-        ):
-            if not update:
-                the_console.rule(
-                    "Room policy already exists with default DENY",
+    with cli_util._authz_session(dburi) as session:
+        with session:
+            policy = (
+                session.query(
+                    authz_schema.RoomPolicy,
                 )
-                the_console.print(
-                    f"Room '{room_id}' has an existing policy with "
-                    "default_allow_deny=DENY; pass '--update' to "
-                    "flip it to ALLOW.",
+                .where(
+                    authz_schema.RoomPolicy.room_id == room_id,
                 )
-                raise typer.Exit(1)
-            policy.default_allow_deny = authz_package.AllowDeny.ALLOW
-            session.commit()
+                .first()
+            )
 
-    _dump(ctx, session, room_id)
+            if policy is not None and (
+                policy.default_allow_deny == authz_package.AllowDeny.DENY
+            ):
+                if not update:
+                    the_console.rule(
+                        "Room policy already exists with default DENY",
+                    )
+                    the_console.print(
+                        f"Room '{room_id}' has an existing policy with "
+                        "default_allow_deny=DENY; pass '--update' to "
+                        "flip it to ALLOW.",
+                    )
+                    raise typer.Exit(1)
+                policy.default_allow_deny = authz_package.AllowDeny.ALLOW
+                session.commit()
+
+        _dump(ctx, session, room_id)
 
 
 @app.command("clear-acl")
@@ -581,25 +576,24 @@ def clear_room_acl(
     cli_util._check_ram_dburi(dburi, "room-authz clear-acl")
     _check_room_id(the_installation, room_id)
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
+    with cli_util._authz_session(dburi) as session:
+        with session:
+            policy = (
+                session.query(
+                    authz_schema.RoomPolicy,
+                )
+                .where(
+                    authz_schema.RoomPolicy.room_id == room_id,
+                )
+                .first()
             )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
-        )
 
-        if policy is not None:
-            for acl_entry in policy.acl_entries:
-                session.delete(acl_entry)
-            session.commit()
+            if policy is not None:
+                for acl_entry in policy.acl_entries:
+                    session.delete(acl_entry)
+                session.commit()
 
-    _dump(ctx, session, room_id)
+        _dump(ctx, session, room_id)
 
 
 def _resolve_allow_deny(allow: bool, deny: bool) -> authz_package.AllowDeny:
@@ -760,48 +754,47 @@ def add_acl_entry(
         "room-authz add-acl-entry",
     )
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
+    with cli_util._authz_session(dburi) as session:
+        with session:
+            policy = (
+                session.query(
+                    authz_schema.RoomPolicy,
+                )
+                .where(
+                    authz_schema.RoomPolicy.room_id == room_id,
+                )
+                .first()
             )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
+
+            if policy is None:
+                the_console.rule(f"No policy exists for room '{room_id}'")
+                the_console.print(
+                    f"Run 'room-authz make-private' or "
+                    "'room-authz make-public' to establish a policy "
+                    f"for '{room_id}' before adding ACL entries.",
+                )
+                raise typer.Exit(1)
+
+            for entry in list(policy.acl_entries):
+                if everyone and entry.everyone:
+                    session.delete(entry)
+                elif authenticated and entry.authenticated:
+                    session.delete(entry)
+                elif json_path is not None and entry.json_path == json_path:
+                    session.delete(entry)
+            session.commit()
+
+            new_acl = authz_schema.ACLEntry(
+                room_policy=policy,
+                allow_deny=allow_deny,
+                everyone=everyone,
+                authenticated=authenticated,
+                json_path=json_path,
             )
-            .first()
-        )
+            session.add(new_acl)
+            session.commit()
 
-        if policy is None:
-            the_console.rule(f"No policy exists for room '{room_id}'")
-            the_console.print(
-                f"Run 'room-authz make-private' or "
-                "'room-authz make-public' to establish a policy "
-                f"for '{room_id}' before adding ACL entries.",
-            )
-            raise typer.Exit(1)
-
-        for entry in list(policy.acl_entries):
-            if everyone and entry.everyone:
-                session.delete(entry)
-            elif authenticated and entry.authenticated:
-                session.delete(entry)
-            elif json_path is not None and entry.json_path == json_path:
-                session.delete(entry)
-        session.commit()
-
-        new_acl = authz_schema.ACLEntry(
-            room_policy=policy,
-            allow_deny=allow_deny,
-            everyone=everyone,
-            authenticated=authenticated,
-            json_path=json_path,
-        )
-        session.add(new_acl)
-        session.commit()
-
-    _dump(ctx, session, room_id)
+        _dump(ctx, session, room_id)
 
 
 @app.command("delete-acl-entry")
@@ -884,50 +877,49 @@ def delete_acl_entry(
         allow_invalid_json_path=allow_invalid_json_path,
     )
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
+    with cli_util._authz_session(dburi) as session:
+        with session:
+            policy = (
+                session.query(
+                    authz_schema.RoomPolicy,
+                )
+                .where(
+                    authz_schema.RoomPolicy.room_id == room_id,
+                )
+                .first()
             )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
-        )
 
-        if policy is None:
-            the_console.rule(f"No policy exists for room '{room_id}'")
-            the_console.print(
-                f"Room '{room_id}' has no RoomPolicy; nothing to delete.",
-            )
-            raise typer.Exit(1)
+            if policy is None:
+                the_console.rule(f"No policy exists for room '{room_id}'")
+                the_console.print(
+                    f"Room '{room_id}' has no RoomPolicy; nothing to delete.",
+                )
+                raise typer.Exit(1)
 
-        matches = []
-        for entry in policy.acl_entries:
-            if entry.allow_deny != allow_deny:
-                continue
-            if everyone and entry.everyone:
-                matches.append(entry)
-            elif authenticated and entry.authenticated:
-                matches.append(entry)
-            elif json_path is not None and entry.json_path == json_path:
-                matches.append(entry)
+            matches = []
+            for entry in policy.acl_entries:
+                if entry.allow_deny != allow_deny:
+                    continue
+                if everyone and entry.everyone:
+                    matches.append(entry)
+                elif authenticated and entry.authenticated:
+                    matches.append(entry)
+                elif json_path is not None and entry.json_path == json_path:
+                    matches.append(entry)
 
-        if not matches:
-            the_console.rule("No matching ACL entry found")
-            the_console.print(
-                f"Room '{room_id}' has no ACL entry matching the "
-                "supplied --allow/--deny and discriminator.",
-            )
-            raise typer.Exit(1)
+            if not matches:
+                the_console.rule("No matching ACL entry found")
+                the_console.print(
+                    f"Room '{room_id}' has no ACL entry matching the "
+                    "supplied --allow/--deny and discriminator.",
+                )
+                raise typer.Exit(1)
 
-        for entry in matches:
-            session.delete(entry)
-        session.commit()
+            for entry in matches:
+                session.delete(entry)
+            session.commit()
 
-    _dump(ctx, session, room_id)
+        _dump(ctx, session, room_id)
 
 
 # Deprecated and hidden BBB commands.

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -45,12 +45,31 @@ NO_AUTH_MODE_USER_TOKEN = {
 
 
 def _create_async_engine(url, **kwargs):
-    """Create an async engine with SQLite WAL support.
+    """Create an async engine, tuned for file-based SQLite.
 
-    For file-based SQLite databases, enables WAL journal mode
-    (persistent), uses NullPool to avoid pool-exhaustion under
-    async concurrency, and sets a 30-second busy timeout so
-    concurrent writers wait rather than raise immediately.
+    For file-based SQLite databases this applies three PRAGMAs, in two
+    different ways depending on their scope in SQLite:
+
+    - 'journal_mode=WAL' (Write-Ahead Logging) lets readers and the
+      writer proceed concurrently. It is a *persistent*, database-level
+      setting stored in the file header, so it is set exactly once on a
+      dedicated throwaway connection before the engine (and its pool)
+      exist -- switching journal mode requires no other connection to be
+      holding a lock. It does not apply to ':memory:' databases.
+
+    - 'synchronous=NORMAL' and 'foreign_keys=ON' are *per-connection*
+      settings that SQLite resets to its defaults (and 'foreign_keys'
+      defaults to OFF) on every new connection, so they are re-applied
+      from a 'connect' event listener that fires for each pooled
+      connection. 'synchronous=NORMAL' is the recommended, fsync-light
+      companion to WAL (crash-safe; only an OS crash / power loss can
+      drop the last un-checkpointed transactions, never corrupt the
+      file). 'foreign_keys=ON' turns on FK enforcement -- including
+      'ON DELETE CASCADE' -- which SQLite otherwise leaves off.
+
+    File-based SQLite additionally uses NullPool to avoid
+    pool-exhaustion under async concurrency, and a 30-second busy
+    timeout so concurrent writers wait rather than raise immediately.
     """
     connect_args = {}
     if "sqlite" in url:
@@ -59,6 +78,8 @@ def _create_async_engine(url, **kwargs):
         if db_path and db_path != ":memory:":
             connect_args["timeout"] = 30
             kwargs["poolclass"] = NullPool
+            # WAL is persisted in the database file, so set it once here
+            # rather than on every connection.
             db = sqlite3.connect(db_path)
             try:
                 with db as conn:
@@ -78,11 +99,18 @@ def _create_async_engine(url, **kwargs):
         def _set_sqlite_pragma(  # pragma: no cover
             dbapi_connection, connection_record
         ):
+            # Both PRAGMAs below are per-connection and reset to their
+            # defaults on every new connection, so they must be set here
+            # (unlike WAL, which persists in the file).
+
+            # 'NORMAL' is the recommended fsync level under WAL: much
+            # faster than the 'FULL' default, still crash-safe.
             cursor_sync = dbapi_connection.cursor()
             cursor_sync.execute("PRAGMA synchronous=NORMAL")
             cursor_sync.close()
 
-            # Fix https://github.com/soliplex/soliplex/issues/950
+            # Enable FK enforcement / 'ON DELETE CASCADE' (off by
+            # default). Fix https://github.com/soliplex/soliplex/issues/950
             cursor_fk = dbapi_connection.cursor()
             cursor_fk.execute("PRAGMA foreign_keys=ON")
             cursor_fk.close()

--- a/tests/unit/agui/test_agui_schema.py
+++ b/tests/unit/agui/test_agui_schema.py
@@ -339,11 +339,13 @@ async def test_run_events(the_session):
 
 
 @pytest.mark.parametrize("init_schema", [None, False, True])
+@mock.patch("sqlalchemy.event.listens_for")
 @mock.patch("sqlalchemy.create_engine")
 @mock.patch("soliplex.agui.schema.metadata.create_all")
 def test_get_engine(
     ca,
     ce,
+    lf,
     init_schema,
 ):
     kwargs = {}
@@ -359,6 +361,9 @@ def test_get_engine(
         config_installation.SYNC_MEMORY_ENGINE_URL,
         json_serializer=util.serialize_sqla_json,
     )
+
+    # A 'connect' listener is registered to enable SQLite foreign keys.
+    lf.assert_called_once_with(ce.return_value, "connect")
 
     if init_schema:
         connection = ce.return_value.connect.return_value

--- a/tests/unit/authz/test_authz_schema.py
+++ b/tests/unit/authz/test_authz_schema.py
@@ -462,11 +462,13 @@ def test_aclentry_check_token_w_email(
 
 
 @pytest.mark.parametrize("init_schema", [None, False, True])
+@mock.patch("sqlalchemy.event.listens_for")
 @mock.patch("sqlalchemy.create_engine")
 @mock.patch("soliplex.authz.schema.metadata.create_all")
 def test_get_engine(
     ca,
     ce,
+    lf,
     init_schema,
 ):
     kwargs = {}
@@ -482,6 +484,9 @@ def test_get_engine(
         config_installation.SYNC_MEMORY_ENGINE_URL,
         json_serializer=util.serialize_sqla_json,
     )
+
+    # A 'connect' listener is registered to enable SQLite foreign keys.
+    lf.assert_called_once_with(ce.return_value, "connect")
 
     if init_schema:
         connection = ce.return_value.connect.return_value

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import re
+import shutil
+
+import pytest
+from typer.testing import CliRunner
+
+from soliplex.authz import schema as authz_schema
+
+# 'tests/unit/cli/conftest.py' -> parents[3] is the repo root.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_EXAMPLE_DIR = _REPO_ROOT / "example"
+
+# Matches the 'authorization_dburi' stanza in 'example/minimal.yaml' so a
+# scratch copy can be repointed at a throwaway sqlite file.
+_AUTHZ_DBURI_RE = re.compile(
+    r'authorization_dburi:\n  sync: "[^"]*"\n  async: "[^"]*"',
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class ScratchInstallation:
+    """A throwaway copy of an example installation with a scratch authz DB.
+
+    'path' is the installation YAML to hand to a CLI command;
+    'dburi' / 'db_path' locate the (initially empty) sync authz database
+    that the installation's 'authorization_dburi' has been repointed at.
+    'session()' opens a sync SQLAlchemy session against that database,
+    creating the authz schema on first use.
+    """
+
+    path: pathlib.Path
+    dburi: str
+    db_path: pathlib.Path
+
+    def session(self):
+        return authz_schema.get_session(
+            engine_url=self.dburi,
+            init_schema=True,
+        )
+
+
+def _point_authz_db(config_path: pathlib.Path, db_path: pathlib.Path) -> None:
+    """Repoint a copied installation's authz DB at an absolute scratch file.
+
+    An absolute 'sqlite:///<abs>' URI (four leading slashes once the
+    leading '/' of the path is included) keeps the database independent
+    of the process working directory.
+    """
+    text = config_path.read_text()
+    replacement = (
+        "authorization_dburi:\n"
+        f'  sync: "sqlite:///{db_path}"\n'
+        f'  async: "sqlite+aiosqlite:///{db_path}"'
+    )
+    text, n_subs = _AUTHZ_DBURI_RE.subn(replacement, text)
+    # Fail loudly if the example config's shape drifts out from under us.
+    assert n_subs == 1, f"expected one authz_dburi stanza, found {n_subs}"
+    config_path.write_text(text)
+
+
+@pytest.fixture(scope="module")
+def _installation_template(tmp_path_factory):
+    """Copy the example installation once per module (copytree is slow)."""
+    base = tmp_path_factory.mktemp("cli_installation")
+    dst = base / "example"
+    shutil.copytree(_EXAMPLE_DIR, dst)
+
+    config_path = dst / "minimal.yaml"
+    db_path = base / "authz.sqlite"
+    _point_authz_db(config_path, db_path)
+
+    return config_path, db_path
+
+
+@pytest.fixture
+def scratch_installation(_installation_template) -> ScratchInstallation:
+    """A copy of 'example/minimal.yaml' backed by a fresh, empty authz DB.
+
+    Reuses the module-scoped tree copy but deletes the scratch database
+    before each test, so every test starts from the default-public state
+    (no RoomPolicy / AdminUser rows). Intended to be shared by any CLI
+    suite that needs to drive commands against a real installation and
+    a real-but-disposable authorization database.
+    """
+    config_path, db_path = _installation_template
+    db_path.unlink(missing_ok=True)
+    return ScratchInstallation(
+        path=config_path,
+        dburi=f"sqlite:///{db_path}",
+        db_path=db_path,
+    )
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -20,6 +20,12 @@ _AUTHZ_DBURI_RE = re.compile(
     r'authorization_dburi:\n  sync: "[^"]*"\n  async: "[^"]*"',
 )
 
+# Matches the bare 'OLLAMA_BASE_URL' environment requirement so a scratch
+# copy can pin a dummy value inline (the CLI never connects to it),
+# keeping the installation self-contained rather than depending on an
+# ambient env var or a gitignored repo-root '.env'.
+_OLLAMA_ENV_RE = re.compile(r'^  - "OLLAMA_BASE_URL"$', re.MULTILINE)
+
 
 @dataclasses.dataclass(frozen=True)
 class ScratchInstallation:
@@ -62,6 +68,26 @@ def _point_authz_db(config_path: pathlib.Path, db_path: pathlib.Path) -> None:
     config_path.write_text(text)
 
 
+def _pin_ollama_base_url(config_path: pathlib.Path) -> None:
+    """Pin a dummy 'OLLAMA_BASE_URL' value inline in a copied config.
+
+    'example/minimal.yaml' lists a bare 'OLLAMA_BASE_URL' under
+    'environment', i.e. one that must resolve from the ambient
+    environment. Rewriting it to the 'name'/'value' form (the same shape
+    'INSTALLATION_PATH' already uses) makes the scratch installation
+    self-contained, so the suite does not depend on a host env var or a
+    gitignored repo-root '.env' (which CI lacks). The CLI never connects
+    to it -- the value only needs to resolve at config-load time.
+    """
+    text = config_path.read_text()
+    replacement = (
+        '  - name: "OLLAMA_BASE_URL"\n    value: "http://localhost:11434"'
+    )
+    text, n_subs = _OLLAMA_ENV_RE.subn(replacement, text)
+    assert n_subs == 1, f"expected one OLLAMA_BASE_URL entry, found {n_subs}"
+    config_path.write_text(text)
+
+
 @pytest.fixture(scope="module")
 def _installation_template(tmp_path_factory):
     """Copy the example installation once per module (copytree is slow)."""
@@ -72,6 +98,7 @@ def _installation_template(tmp_path_factory):
     config_path = dst / "minimal.yaml"
     db_path = base / "authz.sqlite"
     _point_authz_db(config_path, db_path)
+    _pin_ollama_base_url(config_path)
 
     return config_path, db_path
 

--- a/tests/unit/cli/test_cli_room_authz.py
+++ b/tests/unit/cli/test_cli_room_authz.py
@@ -9,6 +9,7 @@ import yaml
 from soliplex import authz as authz_package
 from soliplex import installation
 from soliplex import models
+from soliplex.authz import schema as authz_schema
 from soliplex.cli import room_authz as cli_room_authz
 from soliplex.config import installation as config_installation
 
@@ -657,13 +658,649 @@ def test__check_acl_entry_args_allow_invalid_json_path(
     )
 
 
-# _human_dump_room_policy: ui only
-# _dump_room_policy: ui only
-# show_room_authz: command
-# make_room_private: command
-# make_room_public: command
-# clear_room_acl: command
-# add_acl_entry: command
-# delete_acl_entry: command
-# add_room_user: command (deprecated)
-# clear_room_authz: command (deprecated)
+# ---------------------------------------------------------------------------
+# Command-level tests.
+#
+# These drive the actual 'room-authz' subcommands through a Typer
+# 'CliRunner' against a throwaway copy of 'example/minimal.yaml' backed by
+# a scratch authorization database (see the 'scratch_installation' and
+# 'cli_runner' fixtures in 'tests/unit/cli/conftest.py'). Every active
+# command body is now exercised here rather than coverage-excluded; the
+# two '_*_dump_room_policy' helpers stay '# pragma NO COVER UI ONLY', and
+# the deprecated/hidden 'add-user' / 'clear' commands keep their
+# '# pragma NO COVER command'.
+# ---------------------------------------------------------------------------
+
+ALLOW = authz_package.AllowDeny.ALLOW
+DENY = authz_package.AllowDeny.DENY
+
+ALICE_EMAIL = "alice@example.com"
+ALICE_EMAIL_JP = authz_package.token_field_json_path("email", ALICE_EMAIL)
+
+
+def _entry(allow_deny, *, everyone=False, authenticated=False, json_path=None):
+    """An ACL-entry kwargs dict in the shape the commands build/store."""
+    return {
+        "allow_deny": allow_deny,
+        "everyone": everyone,
+        "authenticated": authenticated,
+        "json_path": json_path,
+    }
+
+
+def _seed_policy(scratch, room_id, default_allow_deny, entries=()):
+    """Insert a RoomPolicy (and ACL entries) straight into the scratch DB."""
+    session = scratch.session()
+    with session:
+        policy = authz_schema.RoomPolicy(
+            room_id=room_id,
+            default_allow_deny=default_allow_deny,
+        )
+        session.add(policy)
+        session.flush()
+        for entry_kw in entries:
+            session.add(
+                authz_schema.ACLEntry(room_policy=policy, **entry_kw),
+            )
+        session.commit()
+    session.bind.dispose()
+
+
+def _read_policy(scratch, room_id):
+    """Read a room's policy back from the scratch DB, or None.
+
+    ACL entries are returned as a set of '(allow_deny, everyone,
+    authenticated, json_path)' tuples -- a set because the 'AllowDeny'
+    enum is not orderable, so sets sidestep ordering entirely.
+    """
+    session = scratch.session()
+    with session:
+        policy = (
+            session.query(authz_schema.RoomPolicy)
+            .where(authz_schema.RoomPolicy.room_id == room_id)
+            .first()
+        )
+        if policy is None:
+            result = None
+        else:
+            result = {
+                "default": policy.default_allow_deny,
+                "entries": {
+                    (
+                        entry.allow_deny,
+                        entry.everyone,
+                        entry.authenticated,
+                        entry.json_path,
+                    )
+                    for entry in policy.acl_entries
+                },
+            }
+    session.bind.dispose()
+    return result
+
+
+def _invoke(cli_runner, scratch, subcommand, *rest, **kwargs):
+    return cli_runner.invoke(
+        cli_room_authz.app,
+        [subcommand, str(scratch.path), *rest],
+        **kwargs,
+    )
+
+
+# -- show -------------------------------------------------------------------
+
+
+def test_show_configured_room(scratch_installation, cli_runner):
+    _seed_policy(scratch_installation, "chat", DENY)
+
+    result = _invoke(cli_runner, scratch_installation, "show", "chat")
+
+    assert result.exit_code == 0
+    assert '"room_id": "chat"' in result.output
+
+
+def test_show_unconfigured_room_requires_allow_stale(
+    scratch_installation,
+    cli_runner,
+):
+    # A policy left behind by a removed/renamed room.
+    _seed_policy(scratch_installation, "ghost", DENY)
+
+    # Without '--allow-stale' the configured-room check rejects it.
+    rejected = _invoke(cli_runner, scratch_installation, "show", "ghost")
+    assert rejected.exit_code == 1
+
+    # With '--allow-stale' the stale policy can still be inspected.
+    allowed = _invoke(
+        cli_runner,
+        scratch_installation,
+        "show",
+        "ghost",
+        "--allow-stale",
+    )
+    assert allowed.exit_code == 0
+    assert '"room_id": "ghost"' in allowed.output
+
+
+# -- make-private -----------------------------------------------------------
+
+
+def test_make_private_creates_policy(scratch_installation, cli_runner):
+    result = _invoke(cli_runner, scratch_installation, "make-private", "chat")
+
+    assert result.exit_code == 0
+    assert _read_policy(scratch_installation, "chat") == {
+        "default": DENY,
+        "entries": set(),
+    }
+
+
+def test_make_private_noop_when_already_deny(
+    scratch_installation,
+    cli_runner,
+):
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        DENY,
+        [_entry(ALLOW, everyone=True)],
+    )
+
+    result = _invoke(cli_runner, scratch_installation, "make-private", "chat")
+
+    assert result.exit_code == 0
+    # Existing default + ACL entries are left untouched.
+    policy = _read_policy(scratch_installation, "chat")
+    assert policy["default"] == DENY
+    assert policy["entries"] == {(ALLOW, True, False, None)}
+
+
+def test_make_private_existing_allow_requires_update(
+    scratch_installation,
+    cli_runner,
+):
+    _seed_policy(scratch_installation, "chat", ALLOW)
+
+    result = _invoke(cli_runner, scratch_installation, "make-private", "chat")
+
+    assert result.exit_code == 1
+    # Left as ALLOW because '--update' was not supplied.
+    assert _read_policy(scratch_installation, "chat")["default"] == ALLOW
+
+
+def test_make_private_update_flips_allow_to_deny(
+    scratch_installation,
+    cli_runner,
+):
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        ALLOW,
+        [_entry(ALLOW, everyone=True)],
+    )
+
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "make-private",
+        "chat",
+        "--update",
+    )
+
+    assert result.exit_code == 0
+    policy = _read_policy(scratch_installation, "chat")
+    assert policy["default"] == DENY
+    # ACL entries are preserved across the flip.
+    assert policy["entries"] == {(ALLOW, True, False, None)}
+
+
+# -- make-public ------------------------------------------------------------
+
+
+def test_make_public_noop_when_no_policy(scratch_installation, cli_runner):
+    result = _invoke(cli_runner, scratch_installation, "make-public", "chat")
+
+    assert result.exit_code == 0
+    # A room with no policy is already public-by-default; none is created.
+    assert _read_policy(scratch_installation, "chat") is None
+
+
+def test_make_public_noop_when_already_allow(
+    scratch_installation,
+    cli_runner,
+):
+    _seed_policy(scratch_installation, "chat", ALLOW)
+
+    result = _invoke(cli_runner, scratch_installation, "make-public", "chat")
+
+    assert result.exit_code == 0
+    assert _read_policy(scratch_installation, "chat")["default"] == ALLOW
+
+
+def test_make_public_existing_deny_requires_update(
+    scratch_installation,
+    cli_runner,
+):
+    _seed_policy(scratch_installation, "chat", DENY)
+
+    result = _invoke(cli_runner, scratch_installation, "make-public", "chat")
+
+    assert result.exit_code == 1
+    assert _read_policy(scratch_installation, "chat")["default"] == DENY
+
+
+def test_make_public_update_flips_deny_to_allow(
+    scratch_installation,
+    cli_runner,
+):
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        DENY,
+        [_entry(DENY, everyone=True)],
+    )
+
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "make-public",
+        "chat",
+        "--update",
+    )
+
+    assert result.exit_code == 0
+    policy = _read_policy(scratch_installation, "chat")
+    assert policy["default"] == ALLOW
+    assert policy["entries"] == {(DENY, True, False, None)}
+
+
+# -- clear-acl --------------------------------------------------------------
+
+
+def test_clear_acl_noop_when_no_policy(scratch_installation, cli_runner):
+    result = _invoke(cli_runner, scratch_installation, "clear-acl", "chat")
+
+    assert result.exit_code == 0
+    assert _read_policy(scratch_installation, "chat") is None
+
+
+def test_clear_acl_removes_entries_preserving_policy(
+    scratch_installation,
+    cli_runner,
+):
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        DENY,
+        [
+            _entry(ALLOW, everyone=True),
+            _entry(ALLOW, authenticated=True),
+        ],
+    )
+
+    result = _invoke(cli_runner, scratch_installation, "clear-acl", "chat")
+
+    assert result.exit_code == 0
+    # Policy row (and its default) survives; only ACL entries are cleared.
+    assert _read_policy(scratch_installation, "chat") == {
+        "default": DENY,
+        "entries": set(),
+    }
+
+
+# -- add-acl-entry ----------------------------------------------------------
+
+
+def test_add_acl_entry_requires_existing_policy(
+    scratch_installation,
+    cli_runner,
+):
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "add-acl-entry",
+        "chat",
+        "--allow",
+        "--everyone",
+    )
+
+    assert result.exit_code == 1
+    assert _read_policy(scratch_installation, "chat") is None
+
+
+def test_add_acl_entry_replaces_matching_discriminators(
+    scratch_installation,
+    cli_runner,
+):
+    # One entry of each discriminator kind, so each replace branch fires.
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        DENY,
+        [
+            _entry(ALLOW, everyone=True),
+            _entry(ALLOW, authenticated=True),
+            _entry(ALLOW, json_path=ALICE_EMAIL_JP),
+        ],
+    )
+
+    # 'everyone' branch: replaces the existing everyone entry (ALLOW->DENY).
+    res = _invoke(
+        cli_runner,
+        scratch_installation,
+        "add-acl-entry",
+        "chat",
+        "--deny",
+        "--everyone",
+    )
+    assert res.exit_code == 0
+
+    # 'authenticated' branch.
+    res = _invoke(
+        cli_runner,
+        scratch_installation,
+        "add-acl-entry",
+        "chat",
+        "--allow",
+        "--authenticated",
+    )
+    assert res.exit_code == 0
+
+    # 'json_path' (via --email) branch.
+    res = _invoke(
+        cli_runner,
+        scratch_installation,
+        "add-acl-entry",
+        "chat",
+        "--allow",
+        "--email",
+        ALICE_EMAIL,
+    )
+    assert res.exit_code == 0
+
+    policy = _read_policy(scratch_installation, "chat")
+    # Each discriminator still appears exactly once (replaced, not dup'd).
+    assert policy["entries"] == {
+        (DENY, True, False, None),
+        (ALLOW, False, True, None),
+        (ALLOW, False, False, ALICE_EMAIL_JP),
+    }
+
+
+# -- delete-acl-entry -------------------------------------------------------
+
+
+def test_delete_acl_entry_requires_existing_policy(
+    scratch_installation,
+    cli_runner,
+):
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "delete-acl-entry",
+        "chat",
+        "--allow",
+        "--everyone",
+    )
+
+    assert result.exit_code == 1
+
+
+def test_delete_acl_entry_no_match_errors(scratch_installation, cli_runner):
+    # The only entry has the opposite allow/deny, so nothing matches.
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        DENY,
+        [_entry(DENY, everyone=True)],
+    )
+
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "delete-acl-entry",
+        "chat",
+        "--allow",
+        "--everyone",
+    )
+
+    assert result.exit_code == 1
+    # The non-matching entry is left in place.
+    assert _read_policy(scratch_installation, "chat")["entries"] == {
+        (DENY, True, False, None),
+    }
+
+
+def test_delete_acl_entry_removes_matching(scratch_installation, cli_runner):
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        DENY,
+        [
+            _entry(ALLOW, everyone=True),
+            _entry(ALLOW, authenticated=True),
+            _entry(ALLOW, json_path=ALICE_EMAIL_JP),
+            # Opposite allow/deny: skipped via the 'continue' branch.
+            _entry(DENY, everyone=True),
+        ],
+    )
+
+    for discriminator in (
+        ("--everyone",),
+        ("--authenticated",),
+        ("--email", ALICE_EMAIL),
+    ):
+        res = _invoke(
+            cli_runner,
+            scratch_installation,
+            "delete-acl-entry",
+            "chat",
+            "--allow",
+            *discriminator,
+        )
+        assert res.exit_code == 0
+
+    # Only the opposite-sense DENY entry that never matched remains.
+    assert _read_policy(scratch_installation, "chat")["entries"] == {
+        (DENY, True, False, None),
+    }
+
+
+# -- as-yaml / from-yaml ----------------------------------------------------
+
+
+def test_as_yaml_to_stdout(scratch_installation, cli_runner):
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        DENY,
+        [_entry(ALLOW, json_path=ALICE_EMAIL_JP)],
+    )
+
+    result = _invoke(cli_runner, scratch_installation, "as-yaml", "chat")
+
+    assert result.exit_code == 0
+    dumped = yaml.safe_load(result.output)
+    assert dumped["room_id"] == "chat"
+    assert dumped["default_allow_deny"] == "DENY"
+    assert dumped["acl_entries"][0]["email"] == ALICE_EMAIL
+
+
+def test_as_yaml_allow_stale_to_file(
+    scratch_installation,
+    cli_runner,
+    tmp_path,
+):
+    # A stale (unconfigured) room dumped to a file via '--allow-stale'.
+    _seed_policy(scratch_installation, "ghost", ALLOW)
+    out = tmp_path / "ghost.yaml"
+
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "as-yaml",
+        "ghost",
+        "--allow-stale",
+        "-o",
+        str(out),
+    )
+
+    assert result.exit_code == 0
+    assert yaml.safe_load(out.read_text())["room_id"] == "ghost"
+
+
+def test_as_yaml_then_from_yaml_populates_other_room(
+    scratch_installation,
+    cli_runner,
+    tmp_path,
+):
+    # Build a fully-configured policy on 'chat' through the CLI ...
+    assert (
+        _invoke(
+            cli_runner, scratch_installation, "make-private", "chat"
+        ).exit_code
+        == 0
+    )
+    assert (
+        _invoke(
+            cli_runner,
+            scratch_installation,
+            "add-acl-entry",
+            "chat",
+            "--allow",
+            "--email",
+            ALICE_EMAIL,
+        ).exit_code
+        == 0
+    )
+    assert (
+        _invoke(
+            cli_runner,
+            scratch_installation,
+            "add-acl-entry",
+            "chat",
+            "--deny",
+            "--everyone",
+        ).exit_code
+        == 0
+    )
+
+    # ... dump it to YAML ...
+    dump = tmp_path / "chat-policy.yaml"
+    assert (
+        _invoke(
+            cli_runner,
+            scratch_installation,
+            "as-yaml",
+            "chat",
+            "-o",
+            str(dump),
+        ).exit_code
+        == 0
+    )
+
+    # ... and use it to populate a *different* room, 'search'. The
+    # explicit ROOM_ID overrides the 'room_id' recorded in the YAML.
+    assert (
+        _invoke(
+            cli_runner,
+            scratch_installation,
+            "from-yaml",
+            "search",
+            "-i",
+            str(dump),
+        ).exit_code
+        == 0
+    )
+
+    chat = _read_policy(scratch_installation, "chat")
+    search = _read_policy(scratch_installation, "search")
+    assert search["default"] == chat["default"]
+    assert search["entries"] == chat["entries"]
+
+
+def test_from_yaml_replaces_existing_policy(
+    scratch_installation,
+    cli_runner,
+    tmp_path,
+):
+    # 'search' already has a policy; importing replaces it wholesale.
+    _seed_policy(
+        scratch_installation,
+        "search",
+        ALLOW,
+        [_entry(ALLOW, everyone=True)],
+    )
+    doc = tmp_path / "policy.yaml"
+    doc.write_text(
+        yaml.safe_dump(
+            {
+                "room_id": "search",
+                "default_allow_deny": "DENY",
+                "acl_entries": [
+                    {
+                        "allow_deny": "ALLOW",
+                        "everyone": False,
+                        "authenticated": True,
+                        "preferred_username": None,
+                        "email": None,
+                        "json_path": None,
+                    },
+                ],
+            },
+        )
+    )
+
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "from-yaml",
+        "search",
+        "-i",
+        str(doc),
+    )
+
+    assert result.exit_code == 0
+    assert _read_policy(scratch_installation, "search") == {
+        "default": DENY,
+        "entries": {(ALLOW, False, True, None)},
+    }
+
+
+def test_from_yaml_stdin_null_removes_existing(
+    scratch_installation,
+    cli_runner,
+):
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        DENY,
+        [_entry(ALLOW, everyone=True)],
+    )
+
+    # 'null' read from stdin removes the target room's policy entirely.
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "from-yaml",
+        "chat",
+        input="null\n",
+    )
+
+    assert result.exit_code == 0
+    assert _read_policy(scratch_installation, "chat") is None
+
+
+def test_from_yaml_null_without_room_id_errors(
+    scratch_installation,
+    cli_runner,
+):
+    # A 'null' document with no explicit ROOM_ID has no target room.
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "from-yaml",
+        input="null\n",
+    )
+
+    assert result.exit_code == 1


### PR DESCRIPTION
- fix: avoid leaking SQLA engines from the commands
- fix: add SQLite `PRAGMA foreign_keys=ON` for sync engine