### PR TITLE
klangk plugin: consume the streaming browser-delegate bridge

### DIFF
--- a/klangk-plugin/extension.ts
+++ b/klangk-plugin/extension.ts
@@ -2,6 +2,10 @@ import { Type } from "@sinclair/typebox";
 
 const BRIDGE_URL = process.env.KLANGK_BRIDGE_URL;
 
+// Per-chunk read timeout (ms). If no data arrives within this window,
+// the stream is considered stalled and the accumulated result is returned.
+const CHUNK_READ_TIMEOUT_MS = 120_000;
+
 type ToolUpdate = (partial: {
   content: { type: "text"; text: string }[];
   details: Record<string, unknown>;
@@ -75,7 +79,13 @@ async function bridgeStream(
   };
 
   for (;;) {
-    const { done, value } = await reader.read();
+    const readOrTimeout = Promise.race([
+      reader.read(),
+      new Promise<{ done: true; value: undefined }>((resolve) =>
+        setTimeout(() => resolve({ done: true, value: undefined }), CHUNK_READ_TIMEOUT_MS),
+      ),
+    ]);
+    const { done, value } = await readOrTimeout;
     if (done) break;
     buf += decoder.decode(value, { stream: true });
     let nl: number;

--- a/klangk-plugin/extension.ts
+++ b/klangk-plugin/extension.ts
@@ -2,28 +2,93 @@ import { Type } from "@sinclair/typebox";
 
 const BRIDGE_URL = process.env.KLANGK_BRIDGE_URL;
 
-async function bridgeRequest(action: string, params: Record<string, string> = {}): Promise<string> {
+type ToolUpdate = (partial: {
+  content: { type: "text"; text: string }[];
+  details: Record<string, unknown>;
+}) => void;
+
+/**
+ * Call a browser-delegate action over the streaming bridge.
+ *
+ * POSTs to /api/browser-delegate/stream and reads the NDJSON the backend
+ * relays from the browser: zero or more {"type":"chunk","delta":...} as the
+ * answer streams in, then a terminal {"type":"done","result":...} or
+ * {"type":"error","error":...}. Each chunk is surfaced to the agent via
+ * [onUpdate] so the user sees tokens live, and there is no single bounded
+ * round-trip — the only limit is the backend's per-chunk idle timeout, so a
+ * long RAG+LLM query no longer times out mid-stream.
+ */
+async function bridgeStream(
+  action: string,
+  params: Record<string, string>,
+  onUpdate?: ToolUpdate,
+): Promise<string> {
   const token = process.env.KLANGK_BRIDGE_TOKEN;
-  const resp = await fetch(`${BRIDGE_URL}/api/browser-delegate`, {
+  const resp = await fetch(`${BRIDGE_URL}/api/browser-delegate/stream`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ action, token, ...params }),
   });
   if (!resp.ok) {
-    if (resp.status === 401 || resp.status === 502) {
-      return (
-        "Temporary authentication error (HTTP " + resp.status + "). " +
-        "The OIDC token may have expired and is being refreshed. " +
-        "Retry this tool call — it is not permanently broken."
-      );
+    // 403 = bad/expired bridge token; 502 = no browser connected. These are
+    // real conditions, not the "OIDC refresh, retry" the old code claimed.
+    return `Error: bridge returned HTTP ${resp.status}`;
+  }
+  if (!resp.body) {
+    return "Error: bridge returned no response body";
+  }
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let accumulated = "";
+
+  const handle = (line: string): string | null => {
+    let evt: { type?: string; delta?: string; result?: any; error?: string };
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      return null; // ignore non-JSON keepalive/blank lines
     }
-    return `Error: bridge returned ${resp.status}`;
+    if (evt.type === "chunk") {
+      accumulated += evt.delta ?? "";
+      if (onUpdate) {
+        try {
+          onUpdate({
+            content: [{ type: "text", text: accumulated }],
+            details: {},
+          });
+        } catch {
+          // onUpdate is best-effort progress; never fail the tool on it.
+        }
+      }
+      return null;
+    }
+    if (evt.type === "done") {
+      const r = evt.result ?? {};
+      return r.result ?? (accumulated || JSON.stringify(r));
+    }
+    if (evt.type === "error") {
+      return `Error: ${evt.error}`;
+    }
+    return null;
+  };
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let nl: number;
+    while ((nl = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (!line) continue;
+      const final = handle(line);
+      if (final !== null) return final;
+    }
   }
-  const data = await resp.json();
-  if (data.error) {
-    return `Error: ${data.error}`;
-  }
-  return data.result ?? JSON.stringify(data);
+  // Stream closed without an explicit done/error.
+  return accumulated || "(no response from Soliplex)";
 }
 
 export default function (pi: any) {
@@ -40,10 +105,10 @@ export default function (pi: any) {
       _toolCallId: string,
       _params: {},
       _signal: AbortSignal | undefined,
-      _onUpdate: any,
+      onUpdate: ToolUpdate | undefined,
       _ctx: any,
     ) {
-      const response = await bridgeRequest("soliplex_list_rooms");
+      const response = await bridgeStream("soliplex_list_rooms", {}, onUpdate);
       return {
         content: [{ type: "text", text: response || "No rooms available." }],
         details: {},
@@ -77,14 +142,15 @@ export default function (pi: any) {
       _toolCallId: string,
       params: { room_id?: string; question: string },
       _signal: AbortSignal | undefined,
-      _onUpdate: any,
+      onUpdate: ToolUpdate | undefined,
       _ctx: any,
     ) {
       const roomId = params.room_id || "search";
-      const response = await bridgeRequest("soliplex_query", {
-        room_id: roomId,
-        question: params.question,
-      });
+      const response = await bridgeStream(
+        "soliplex_query",
+        { room_id: roomId, question: params.question },
+        onUpdate,
+      );
       return {
         content: [
           {


### PR DESCRIPTION
Layer 3 of the bridge-streaming stack (depends on klangk backend **mcdonc/klangk#79**).

## What
Switch the soliplex Pi tools from the single-shot `/api/browser-delegate` (one JSON response, capped at a 30s bridge wait → HTTP 502 mid-query) to **`/api/browser-delegate/stream`**:
- Read the backend's NDJSON: incremental `{type:chunk,delta}` surfaced live via `onUpdate`, then terminal `{type:done,result}` / `{type:error}`.
- No single bounded round-trip — only a per-chunk idle timeout, so long RAG+LLM queries no longer time out.
- Stop mislabeling HTTP 502/403 as an 'OIDC expired, retry' error (which caused retry loops).

## Stack
1. mcdonc/klangk#79 — backend streaming endpoint + protocol (this PR depends on it)
2. (klangk `macos-native`) — Flutter `soliplex_tools` emits `browser_chunk` deltas (enables true token streaming; until then this still works, relaying the final result)
3. **this PR** — Pi extension consumes the stream

Backward compatible: if the browser sends only a final response (no chunks), this relays it as the result.