### PR TITLE
ci: move workflows to Node 24 actions

### DIFF
--- a/.github/workflows/build-docs-skill.yaml
+++ b/.github/workflows/build-docs-skill.yaml
@@ -45,10 +45,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload workflow artifact
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: soliplex-docs-skill
           path: |
@@ -171,7 +171,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification when new issue is opened
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/pr-opened.yaml
+++ b/.github/workflows/pr-opened.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification when new PR is opened
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -31,10 +31,10 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -52,7 +52,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -35,10 +35,10 @@ jobs:
             - python-version: "3.12"
               pytest-args: "--no-cov"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -62,7 +62,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
Bump JavaScript actions still on the deprecated **Node 20** runtime to their Node 24-native versions ahead of GitHub's **2026-06-26** cutover (after which `runs.using: node20` actions are force-run on Node 24).

| Action | From | To | node24 from |
|--------|------|----|-------------|
| `actions/checkout` | `@v4` | `@v6` | v5 |
| `astral-sh/setup-uv` | `@v6` | `@v7` | v7 |
| `actions/upload-artifact` | `@v4` | `@v6` | v6 |
| `slackapi/slack-github-action` | `@v2.1.0` / `@v2.1.1` | `@v3` | v3 |

Targets match the versions already standardized in `soliplex/ingester`.

**Left unchanged (already unaffected):** `actions/setup-python@v6` (node24), the `gitleaks`/`trufflehog` `checkout@v6` pins, `rtCamp/action-slack-notify@v2` (composite), and `trufflesecurity/trufflehog@main` (Docker).

**Notes**
- The `slack-github-action` v2→v3 bump keeps the same `webhook` / `webhook-type` / `payload` input shape that `ingester` already runs on `@v3.0.1`, so no payload changes were needed.
- `actionlint` passes (via pre-commit).

Fixes #1052