### PR TITLE
fix: CLI 'audit ollama --check-responsive'

### DIFF
--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -1186,6 +1186,13 @@ endpoint) and compare it against the set of model names the
 installation requires for that URL. Models named by the installation
 but absent from the server are reported as needing to be pulled.
 
+By default this confirms only that a model is *installed*. Pass
+`-r` / `--check-responsive` to additionally send each installed model a
+minimal chat-completion request (to the same OpenAI-compatible
+`/v1/chat/completions` endpoint the application uses) and flag any model
+that fails to answer. This is slower — it contacts every installed
+model — and is therefore opt-in.
+
 ```bash
 soliplex-cli audit [OPTIONS] ollama [INSTALLATION_CONFIG_PATH]
 ```
@@ -1198,6 +1205,13 @@ See [Group Options](#group-options) for the available `[OPTIONS]`.
   May be a YAML file, or a directory containing an `installation.yaml`.
   If omitted, falls back to the `SOLIPLEX_INSTALLATION_PATH` environment
   variable.
+
+#### Options
+
+- `-r` / `--check-responsive` — also confirm each installed model
+  answers a minimal chat-completion request. Only models that are both
+  required and installed are probed; missing models are reported as
+  missing, not unresponsive.
 
 #### Output
 
@@ -1216,6 +1230,15 @@ points to the `ollama pull` command:
   Run 'soliplex-cli ollama pull' to pull missing models.
 ```
 
+With `--check-responsive`, any installed model that fails to answer is
+listed under an `UNRESPONSIVE:` line, with the per-model error indented
+below it:
+
+```text
+  UNRESPONSIVE: mistral
+    - mistral: ('Connection refused',)
+```
+
 If the installation references no Ollama URLs, a single
 `No Ollama URLs referenced by the installation.` line is printed and
 the command exits cleanly.
@@ -1223,9 +1246,11 @@ the command exits cleanly.
 #### Exit Status
 
 - `0` — every required Ollama model is available on its server (or the
-  installation references no Ollama URLs).
+  installation references no Ollama URLs), and — under
+  `--check-responsive` — every installed model answered.
 - `1` — at least one server is unreachable, **or** at least one
-  required model is missing from a reachable server.
+  required model is missing from a reachable server, **or** — under
+  `--check-responsive` — at least one installed model failed to answer.
 
 When the group's `-q` / `--quiet` flag is in effect, a `1` exit is
 accompanied by a single JSON document on stdout under the `ollama` key:
@@ -1233,14 +1258,19 @@ accompanied by a single JSON document on stdout under the `ollama` key:
 ```json
 {
   "ollama": {
-    "http://a.example.com": {"missing_models": ["mistral", "phi3"]},
+    "http://a.example.com": {
+      "missing_models": ["phi3"],
+      "unresponsive_models": {"mistral": "('Connection refused',)"}
+    },
     "http://b.example.com": {"unreachable": "('Connection refused',)"}
   }
 }
 ```
 
 A URL appears under `ollama` only when something went wrong on it;
-reachable servers with no missing models are omitted from the JSON.
+reachable servers with no missing or unresponsive models are omitted
+from the JSON. The `unresponsive_models` key is present only when
+`--check-responsive` was requested.
 
 #### Examples
 
@@ -1248,6 +1278,12 @@ Audit Ollama availability for an installation:
 
 ```bash
 soliplex-cli audit ollama example/installation.yaml
+```
+
+Also verify that each installed model actually responds:
+
+```bash
+soliplex-cli audit ollama --check-responsive example/installation.yaml
 ```
 
 Drive the audit from automation, capturing missing-models JSON:

--- a/src/soliplex/cli/audit.py
+++ b/src/soliplex/cli/audit.py
@@ -1150,15 +1150,38 @@ def audit_logfire(
     _emit_errors(errors, quiet)
 
 
+def _unresponsive_ollama_models(rest_api, model_names) -> dict:
+    """Return ``{model_name: error}`` for models that fail to respond.
+
+    Sends a minimal chat-completion request to each name in
+    ``model_names`` (which should already be present on the server) and
+    records those that raise a network error or non-2xx response. The
+    result is empty when every model responds.
+    """
+    unresponsive: dict[str, str] = {}
+
+    for model_name in model_names:
+        try:
+            rest_api.chat_completion(model_name)
+        except requests.RequestException as exc:
+            unresponsive[model_name] = str(exc.args)
+
+    return unresponsive
+
+
 def _missing_ollama_models(
     the_installation: installation.Installation,
+    *,
+    check_responsive: bool = False,
 ) -> dict:
-    """Return per-URL info about Ollama models missing from each server.
+    """Return per-URL info about Ollama models on each server.
 
-    Each value is either ``{"unreachable": str}`` (the server refused
-    the connection or returned an HTTP error) or
-    ``{"missing_models": [str, ...]}`` (the server is reachable but is
-    missing one or more models the installation references).
+    Each value may carry ``{"unreachable": str}`` (the server refused
+    the connection or returned an HTTP error), ``{"missing_models":
+    [str, ...]}`` (the server is reachable but missing one or more
+    models the installation references), and -- when ``check_responsive``
+    is set -- ``{"unresponsive_models": {name: error}}`` (a model is
+    installed but failed to answer a minimal chat-completion request).
     """
     ollama_url_models = the_installation.all_provider_info.get("ollama", {})
     per_url: dict[str, dict] = {}
@@ -1177,8 +1200,21 @@ def _missing_ollama_models(
 
         available = {entry["name"] for entry in response.get("models", ())}
         missing = sorted(required - available)
+
+        url_info: dict = {}
         if missing:
-            per_url[url] = {"missing_models": missing}
+            url_info["missing_models"] = missing
+
+        if check_responsive:
+            unresponsive = _unresponsive_ollama_models(
+                rest_api,
+                sorted(required & available),
+            )
+            if unresponsive:
+                url_info["unresponsive_models"] = unresponsive
+
+        if url_info:
+            per_url[url] = url_info
 
     if per_url:
         return {"ollama": per_url}
@@ -1188,6 +1224,8 @@ def _missing_ollama_models(
 def _audit_ollama_section(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
+    *,
+    check_responsive: bool = False,
 ) -> dict:  # pragma NO COVER UI ONLY
     """Print the Ollama section (rule header + per-URL availability check)."""
     quiet = ctx.obj["quiet"]
@@ -1199,7 +1237,10 @@ def _audit_ollama_section(
     tc_line()
 
     ollama_url_models = the_installation.all_provider_info.get("ollama", {})
-    errors = _missing_ollama_models(the_installation)
+    errors = _missing_ollama_models(
+        the_installation,
+        check_responsive=check_responsive,
+    )
     per_url = errors.get("ollama", {})
 
     if not ollama_url_models:
@@ -1212,15 +1253,23 @@ def _audit_ollama_section(
         url_errors = per_url.get(url, {})
         unreachable = url_errors.get("unreachable")
         missing = url_errors.get("missing_models")
+        unresponsive = url_errors.get("unresponsive_models")
         if unreachable is not None:
             tc_print(f"  ERROR: {unreachable}")
-        elif missing:
-            tc_print(f"  MISSING: {', '.join(missing)}")
-            tc_print(
-                "  Run 'soliplex-cli ollama pull' to pull missing models.",
-            )
         else:
-            tc_print("  OK")
+            if missing:
+                tc_print(f"  MISSING: {', '.join(missing)}")
+                tc_print(
+                    "  Run 'soliplex-cli ollama pull' to pull missing models.",
+                )
+            if unresponsive:
+                tc_print(
+                    f"  UNRESPONSIVE: {', '.join(sorted(unresponsive))}",
+                )
+                for model_name in sorted(unresponsive):
+                    tc_print(f"    - {model_name}: {unresponsive[model_name]}")
+            if not missing and not unresponsive:
+                tc_print("  OK")
         tc_line()
 
     return errors
@@ -1230,8 +1279,21 @@ def _audit_ollama_section(
 def audit_ollama(
     ctx: typer.Context,
     installation_path: types.installation_path_type,
+    check_responsive: bool = typer.Option(
+        False,
+        "-r",
+        "--check-responsive",
+        help=(
+            "Also confirm each installed model answers a minimal "
+            "chat-completion request (slower; contacts each model)"
+        ),
+    ),
 ):  # pragma NO COVER command
     """Compare configured Ollama models against each server's available set"""
     quiet = ctx.obj["quiet"]
-    errors = _audit_ollama_section(ctx, installation_path)
+    errors = _audit_ollama_section(
+        ctx,
+        installation_path,
+        check_responsive=check_responsive,
+    )
     _emit_errors(errors, quiet)

--- a/src/soliplex/ollama.py
+++ b/src/soliplex/ollama.py
@@ -44,6 +44,28 @@ class REST_API:
 
         return response.json()
 
+    def chat_completion(self, model_name: str, prompt: str = "ping"):
+        """Send a minimal chat-completion request and return the response.
+
+        Posts to the OpenAI-compatible ``/v1/chat/completions`` endpoint --
+        the same path the application uses to talk to Ollama -- so a
+        successful call confirms the model actually responds, not merely
+        that it is installed. Raises ``requests.RequestException`` on a
+        network error or non-2xx response.
+        """
+        url = f"{self.ollama_base_url}/v1/chat/completions"
+        data = {
+            "model": model_name,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 1,
+            "stream": False,
+        }
+
+        response = requests.post(url, json=data)
+        response.raise_for_status()
+
+        return response.json()
+
     def get_version(self):
         """Return the version of the Ollama server"""
         return self._get_endpoint("version")

--- a/tests/unit/cli/test_cli_audit.py
+++ b/tests/unit/cli/test_cli_audit.py
@@ -1521,5 +1521,122 @@ def test__missing_ollama_models_reports_unreachable_server(
     }
 
 
+def test__unresponsive_ollama_models_all_respond():
+    rest_api = mock.Mock()
+
+    found = cli_audit._unresponsive_ollama_models(
+        rest_api,
+        ["llama3", "mistral"],
+    )
+
+    assert found == {}
+    assert rest_api.chat_completion.call_args_list == [
+        mock.call("llama3"),
+        mock.call("mistral"),
+    ]
+
+
+def test__unresponsive_ollama_models_records_failures():
+    rest_api = mock.Mock()
+    rest_api.chat_completion.side_effect = [
+        None,
+        requests.ConnectionError("boom"),
+    ]
+
+    found = cli_audit._unresponsive_ollama_models(
+        rest_api,
+        ["llama3", "mistral"],
+    )
+
+    assert found == {"mistral": "('boom',)"}
+
+
+@mock.patch("soliplex.cli.audit.ollama.REST_API")
+def test__missing_ollama_models_checks_responsiveness_when_requested(
+    rest_api_cls,
+    the_installation,
+):
+    the_installation._all_provider_info = {
+        "ollama": {"http://a.example.com": {"llama3", "mistral", "phi3"}},
+    }
+
+    instance = mock.Mock()
+    instance.get_available_models.return_value = {
+        "models": [{"name": "llama3"}, {"name": "mistral"}],
+    }
+
+    # 'llama3' answers; 'mistral' fails. 'phi3' is missing, so never probed.
+    def chat_completion(model_name):
+        if model_name == "mistral":
+            raise requests.ConnectionError("boom")
+
+    instance.chat_completion.side_effect = chat_completion
+    rest_api_cls.return_value = instance
+
+    found = cli_audit._missing_ollama_models(
+        the_installation,
+        check_responsive=True,
+    )
+
+    assert found == {
+        "ollama": {
+            "http://a.example.com": {
+                "missing_models": ["phi3"],
+                "unresponsive_models": {"mistral": "('boom',)"},
+            },
+        },
+    }
+    # Only installed-and-required models are probed for responsiveness.
+    assert instance.chat_completion.call_args_list == [
+        mock.call("llama3"),
+        mock.call("mistral"),
+    ]
+
+
+@mock.patch("soliplex.cli.audit.ollama.REST_API")
+def test__missing_ollama_models_responsive_all_ok(
+    rest_api_cls,
+    the_installation,
+):
+    the_installation._all_provider_info = {
+        "ollama": {"http://a.example.com": {"llama3"}},
+    }
+
+    instance = mock.Mock()
+    instance.get_available_models.return_value = {
+        "models": [{"name": "llama3"}],
+    }
+    rest_api_cls.return_value = instance
+
+    found = cli_audit._missing_ollama_models(
+        the_installation,
+        check_responsive=True,
+    )
+
+    assert found == {}
+    instance.chat_completion.assert_called_once_with("llama3")
+
+
+@mock.patch("soliplex.cli.audit.ollama.REST_API")
+def test__missing_ollama_models_skips_responsiveness_by_default(
+    rest_api_cls,
+    the_installation,
+):
+    the_installation._all_provider_info = {
+        "ollama": {"http://a.example.com": {"llama3"}},
+    }
+
+    instance = mock.Mock()
+    instance.get_available_models.return_value = {
+        "models": [{"name": "llama3"}],
+    }
+    rest_api_cls.return_value = instance
+
+    found = cli_audit._missing_ollama_models(the_installation)
+
+    assert found == {}
+    instance.chat_completion.assert_not_called()
+
+
 # _audit_ollama_section: ui only
 # audit_ollama: command

--- a/tests/unit/test_ollama.py
+++ b/tests/unit/test_ollama.py
@@ -347,6 +347,51 @@ def test_ollama_rest_api_delete_model(
     )
 
 
+@pytest.mark.parametrize("w_prompt", [None, "are you there?"])
+@pytest.mark.parametrize(
+    "status_code, expectation",
+    [
+        (None, contextlib.nullcontext()),
+        (400, pytest.raises(requests.exceptions.HTTPError)),
+    ],
+)
+@mock.patch("soliplex.ollama.requests.post")
+def test_ollama_rest_api_chat_completion(
+    r_post,
+    rest_api,
+    status_code,
+    expectation,
+    w_prompt,
+):
+    kwargs = {}
+    exp_prompt = "ping"
+    if w_prompt is not None:
+        kwargs["prompt"] = exp_prompt = w_prompt
+
+    exp_data = {
+        "model": TEST_MODEL_NAME,
+        "messages": [{"role": "user", "content": exp_prompt}],
+        "max_tokens": 1,
+        "stream": False,
+    }
+
+    if status_code is not None:
+        r_post.side_effect = requests.HTTPError(status_code)
+
+    with expectation as expected:
+        found = rest_api.chat_completion(TEST_MODEL_NAME, **kwargs)
+
+    if status_code is not None:
+        assert expected.value.args == (status_code,)
+    else:
+        assert found is r_post.return_value.json.return_value
+
+    r_post.assert_called_once_with(
+        f"{TEST_OLLAMA_URL}/v1/chat/completions",
+        json=exp_data,
+    )
+
+
 # pull_model tests
 
 


### PR DESCRIPTION
Verifies that models actually respond on their '/check/completions' endpoint, allowing disovery of issues due to partial / b0kren results on earlier pulls.

Closes #1067.