### PR TITLE
feat: room stats API

### DIFF
--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -261,6 +261,33 @@ class ThreadStorage(abc.ABC):
         """
 
     @abc.abstractmethod
+    async def get_room_last_activity(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+    ) -> datetime.datetime | None:
+        """Return the user's latest run activity in a room, or None.
+
+        Activity is the latest, across the user's runs in the room, of
+        each run's finish time or -- if it has not finished -- its
+        creation time. None when the user has no runs there.
+        """
+
+    @abc.abstractmethod
+    async def get_rooms_last_activity(
+        self,
+        *,
+        user_name: str,
+    ) -> dict[str, datetime.datetime]:
+        """Return the user's latest run activity for each of their rooms.
+
+        Keyed by room_id; each value is that room's latest activity as
+        in 'get_room_last_activity' (never None). Rooms in which the
+        user has no runs are omitted.
+        """
+
+    @abc.abstractmethod
     async def new_thread(
         self,
         *,

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -25,6 +25,29 @@ class NoFeedbackFound(ValueError):
         super().__init__(f"No feed back found for run: {run_id}")
 
 
+def _as_utc(value: datetime.datetime) -> datetime.datetime:
+    """Re-tag a naive SQLite-read timestamp as UTC.
+
+    The backend writes UTC, but SQLite stores no timezone and SQLAlchemy
+    returns naive datetimes on read. Without re-tagging, FastAPI would
+    serialize the value with no offset and clients would parse it as
+    local time.
+    """
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.UTC)
+    return value
+
+
+# A run's activity time is its finish, or -- while unfinished -- its
+# start; the latest such time across the selected runs.
+_LAST_ACTIVITY = sqla_sql.func.max(
+    sqla_sql.func.coalesce(
+        agui_schema.Run.finished,
+        agui_schema.Run.created,
+    )
+)
+
+
 class ThreadStorage(agui_package.ThreadStorage):
     def __init__(self, session: sqla_asyncio.AsyncSession):
         self._session = session
@@ -113,6 +136,37 @@ class ThreadStorage(agui_package.ThreadStorage):
             )
 
         return result
+
+    async def get_room_last_activity(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+    ) -> datetime.datetime | None:
+        async with self.session as session:
+            query = (
+                sqla_sql.select(_LAST_ACTIVITY)
+                .join(agui_schema.Run.thread)
+                .where(agui_schema.Thread.user_name == user_name)
+                .where(agui_schema.Thread.room_id == room_id)
+            )
+            result = await session.scalar(query)
+        return _as_utc(result) if result is not None else None
+
+    async def get_rooms_last_activity(
+        self,
+        *,
+        user_name: str,
+    ) -> dict[str, datetime.datetime]:
+        async with self.session as session:
+            query = (
+                sqla_sql.select(agui_schema.Thread.room_id, _LAST_ACTIVITY)
+                .join(agui_schema.Run.thread)
+                .where(agui_schema.Thread.user_name == user_name)
+                .group_by(agui_schema.Thread.room_id)
+            )
+            rows = (await session.execute(query)).all()
+        return {room_id: _as_utc(activity) for room_id, activity in rows}
 
     async def new_thread(
         self,

--- a/src/soliplex/config/routing.py
+++ b/src/soliplex/config/routing.py
@@ -192,6 +192,7 @@ _DEFAULT_ROUTER_NAMES = {
     "log_ingest": "soliplex.views.log_ingest.router",
     "quizzes": "soliplex.views.quizzes.router",
     "rooms": "soliplex.views.rooms.router",
+    "stats": "soliplex.views.stats.router",
 }
 
 

--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -79,6 +79,9 @@ ROOM_UNKNOWN_ROOM_ID = "unknown room id: %s"
 ROOM_CHUNK_IMAGES_NOT_AVAILALBE = "chunk images not available: %s"
 ROOM_UNKNOWN_CHUNK_ID = "unknown chunk id: %s"
 
+STATS_GET_ROOMS_STATS = "get rooms stats"
+STATS_GET_ROOM_STATS = "get room stats"
+
 
 class LogWrapper(logging.LoggerAdapter):
     """Context wrapper for capturing extra logging values"""

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -324,6 +324,12 @@ class Room(pydantic.BaseModel):
 ConfiguredRooms = dict[str, Room]
 
 
+class RoomStats(pydantic.BaseModel):
+    room_id: str = KW_ONLY
+    # None means the user has no runs in the room.
+    last_activity: pydantic.AwareDatetime | None = KW_ONLY_NONE
+
+
 class Completion(pydantic.BaseModel):
     id: str
     name: str

--- a/src/soliplex/views/stats.py
+++ b/src/soliplex/views/stats.py
@@ -1,0 +1,99 @@
+import fastapi
+
+from soliplex import agui as agui_package
+from soliplex import authn
+from soliplex import authz as authz_package
+from soliplex import installation
+from soliplex import loggers
+from soliplex import models
+from soliplex import util
+from soliplex import views
+
+router = fastapi.APIRouter(tags=["stats"])
+
+depend_the_installation = installation.depend_the_installation
+depend_the_authz = authz_package.depend_the_authz_policy
+depend_the_threads = agui_package.depend_the_threads
+depend_the_user_claims = views.depend_the_user_claims
+depend_the_logger = views.depend_the_logger
+
+
+@util.logfire_span("GET /v1/stats/rooms")
+@router.get("/v1/stats/rooms")
+async def get_rooms_stats(
+    the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
+    the_threads: agui_package.ThreadStorage = depend_the_threads,
+    the_user_claims: authn.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> dict[str, models.RoomStats]:
+    """Return last-activity stats for each room the user can access.
+
+    One entry per room the authorization policy currently grants the
+    user ('get_room_configs'); last_activity is null for a room they
+    have no runs in. A room they were de-authorized from drops out.
+    """
+    the_logger.debug(loggers.STATS_GET_ROOMS_STATS)
+
+    user_name = the_user_claims.get("preferred_username", "<unknown>")
+
+    room_configs = await the_installation.get_room_configs(
+        user=the_user_claims,
+        the_authz_policy=the_authz_policy,
+        the_logger=the_logger,
+    )
+
+    activity_by_room = await the_threads.get_rooms_last_activity(
+        user_name=user_name,
+    )
+
+    return {
+        room_id: models.RoomStats(
+            room_id=room_id,
+            last_activity=activity_by_room.get(room_id),
+        )
+        for room_id in room_configs
+    }
+
+
+@util.logfire_span("GET /v1/stats/rooms/{room_id}")
+@router.get("/v1/stats/rooms/{room_id}")
+async def get_room_stats(
+    room_id: str,
+    the_installation: installation.Installation = depend_the_installation,
+    the_authz_policy: authz_package.AuthorizationPolicy = depend_the_authz,
+    the_threads: agui_package.ThreadStorage = depend_the_threads,
+    the_user_claims: authn.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> models.RoomStats:
+    """Return last-activity stats for a single room.
+
+    The room-access check rejects unknown or inaccessible rooms with a
+    404; last_activity is null when the user has no runs there.
+    """
+    the_logger.debug(loggers.STATS_GET_ROOM_STATS)
+
+    try:
+        await the_installation.get_room_config(
+            room_id=room_id,
+            user=the_user_claims,
+            the_authz_policy=the_authz_policy,
+            the_logger=the_logger,
+        )
+    except KeyError:
+        # An authz denial is logged by 'get_room_config'; a genuinely
+        # missing room is not, so log the lookup failure here either way.
+        the_logger.exception(loggers.ROOM_UNKNOWN_ROOM_ID, room_id)
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=loggers.ROOM_UNKNOWN_ROOM_ID % room_id,
+        ) from None
+
+    user_name = the_user_claims.get("preferred_username", "<unknown>")
+
+    last_activity = await the_threads.get_room_last_activity(
+        user_name=user_name,
+        room_id=room_id,
+    )
+
+    return models.RoomStats(room_id=room_id, last_activity=last_activity)

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -16,8 +16,14 @@ FeedbackReviewStatus = agui_package.FeedbackReviewStatus
 NOW = datetime.datetime.now(datetime.UTC)
 
 ROOM_ID = "test-room"
+ROOM_ID_2 = "test-room-2"
 USER_NAME = "phreddy"
 EMAIL = "phreddy@example.com"
+OTHER_USER_NAME = "wylma"
+OTHER_EMAIL = "wylma@example.com"
+T_OLD = datetime.datetime(2026, 1, 1, 10, 0, tzinfo=datetime.UTC)
+T_MID = datetime.datetime(2026, 1, 1, 11, 0, tzinfo=datetime.UTC)
+T_NEW = datetime.datetime(2026, 1, 1, 12, 0, tzinfo=datetime.UTC)
 REVIEWER_USER_NAME = "bharney"
 REVIEWER_EMAIL = "bharney@example.com"
 RESOLVER_USER_NAME = "wylma"
@@ -64,6 +70,47 @@ async def the_async_session(the_async_engine):
     session = sqla_asyncio.AsyncSession(bind=the_async_engine)
     yield session
     await session.close()
+
+
+async def _add_run(
+    ts,
+    session,
+    *,
+    user_name,
+    email,
+    room_id,
+    created,
+    finished=None,
+    thread_id=None,
+):
+    """Create a run with explicit 'created'/'finished' timestamps.
+
+    A new thread is created (with its initial run) unless 'thread_id' is
+    given, in which case the run is added to that thread. Returns the
+    thread_id so callers can stack more runs onto the same thread.
+    """
+    if thread_id is None:
+        thread = await ts.new_thread(
+            user_name=user_name,
+            email=email,
+            room_id=room_id,
+        )
+        thread_id = await thread.awaitable_attrs.thread_id
+        await session.commit()
+        (run,) = await thread.list_runs()
+    else:
+        run = await ts.new_run(
+            user_name=user_name,
+            room_id=room_id,
+            thread_id=thread_id,
+        )
+        await session.commit()
+
+    run.created = created
+    run.finished = finished
+    await session.commit()
+
+    return thread_id
 
 
 @pytest.mark.asyncio
@@ -1191,3 +1238,201 @@ async def test_threadstorage_finish_run(
 
     finished = await run.awaitable_attrs.finished
     assert finished == NOW.replace(tzinfo=None)
+
+
+def test_as_utc_naive_tags_utc():
+    naive = datetime.datetime(2026, 1, 1, 12, 0)
+    assert agui_persistence._as_utc(naive) == T_NEW
+
+
+def test_as_utc_already_aware_unchanged():
+    assert agui_persistence._as_utc(T_NEW) is T_NEW
+
+
+@pytest.mark.asyncio
+async def test_get_room_last_activity_empty(the_async_session):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    result = await ts.get_room_last_activity(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_room_last_activity_coalesce_and_max(the_async_session):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    # A finished run whose 'finished' (T_NEW) is later than a newer
+    # unfinished run's 'created' (T_MID): max(coalesce) must be T_NEW.
+    thread_id = await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_OLD,
+        finished=T_NEW,
+    )
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_MID,
+        finished=None,
+        thread_id=thread_id,
+    )
+
+    result = await ts.get_room_last_activity(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+    )
+
+    assert result == T_NEW
+    assert result.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_get_room_last_activity_across_threads_uses_created(
+    the_async_session,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    # Two separate threads in the same room: the room-wide max must
+    # aggregate across threads, and coalesce must fall back to the
+    # unfinished run's 'created' (T_NEW) over the finished run (T_MID).
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_OLD,
+        finished=T_MID,
+    )
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_NEW,
+        finished=None,
+    )
+
+    result = await ts.get_room_last_activity(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+    )
+
+    assert result == T_NEW
+
+
+@pytest.mark.asyncio
+async def test_get_room_last_activity_user_scoping(the_async_session):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_OLD,
+    )
+    # Another user's later run in the same room must not leak in.
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=OTHER_USER_NAME,
+        email=OTHER_EMAIL,
+        room_id=ROOM_ID,
+        created=T_NEW,
+    )
+
+    result = await ts.get_room_last_activity(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+    )
+
+    assert result == T_OLD
+
+
+@pytest.mark.asyncio
+async def test_get_room_last_activity_room_scoping(the_async_session):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_OLD,
+    )
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID_2,
+        created=T_NEW,
+    )
+
+    result = await ts.get_room_last_activity(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+    )
+
+    assert result == T_OLD
+
+
+@pytest.mark.asyncio
+async def test_get_rooms_last_activity_empty(the_async_session):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    result = await ts.get_rooms_last_activity(user_name=USER_NAME)
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_get_rooms_last_activity_grouping_and_scoping(the_async_session):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    # ROOM_ID: coalesce picks 'finished' (T_MID) over 'created' (T_OLD).
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_OLD,
+        finished=T_MID,
+    )
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID_2,
+        created=T_NEW,
+    )
+    # Another user's run must not appear in this user's map.
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=OTHER_USER_NAME,
+        email=OTHER_EMAIL,
+        room_id=ROOM_ID,
+        created=T_NEW,
+    )
+
+    result = await ts.get_rooms_last_activity(user_name=USER_NAME)
+
+    assert result == {ROOM_ID: T_MID, ROOM_ID_2: T_NEW}
+    assert all(v.tzinfo is not None for v in result.values())

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1567,3 +1567,12 @@ def test_aclentry_accepts_single_discriminator(kwargs):
     entry = models.ACLEntry(**kwargs)
 
     assert entry == models.ACLEntry(**kwargs)
+
+
+def test_roomstats_rejects_naive_last_activity():
+    # last_activity must stay tz-aware so it serializes with an offset;
+    # a naive value would be parsed as local time by clients.
+    naive = datetime.datetime(2026, 1, 1, 12, 0)
+
+    with pytest.raises(pydantic.ValidationError):
+        models.RoomStats(room_id="test-room", last_activity=naive)

--- a/tests/unit/views/test_stats_views.py
+++ b/tests/unit/views/test_stats_views.py
@@ -1,0 +1,270 @@
+import contextlib
+import datetime
+from unittest import mock
+
+import fastapi
+import pytest
+from fastapi import testclient
+
+from soliplex import agui as agui_package
+from soliplex import authz as authz_package
+from soliplex import installation
+from soliplex import loggers
+from soliplex import models
+from soliplex import views as views_package
+from soliplex.views import stats as stats_views
+
+ROOM_ID = "test-room"
+ROOM_ID_2 = "test-room-2"
+USER_NAME = "phreddy"
+EMAIL = "phreddy@example.com"
+
+THE_USER_CLAIMS = {"preferred_username": USER_NAME, "email": EMAIL}
+
+T1 = datetime.datetime(2026, 1, 1, 12, 0, tzinfo=datetime.UTC)
+T2 = datetime.datetime(2026, 1, 2, 12, 0, tzinfo=datetime.UTC)
+
+no_error = contextlib.nullcontext
+
+
+def raises_httpexc(*, match, code) -> pytest.raises:
+    def _check(exc):
+        return exc.status_code == code
+
+    return pytest.raises(fastapi.HTTPException, match=match, check=_check)
+
+
+@pytest.fixture
+def the_threads():
+    return mock.create_autospec(agui_package.ThreadStorage)
+
+
+@pytest.fixture
+def the_logger():
+    return mock.create_autospec(loggers.LogWrapper)
+
+
+def _installation_with_rooms(*room_ids):
+    the_installation = mock.create_autospec(installation.Installation)
+    the_installation.get_room_configs.return_value = {
+        room_id: mock.Mock() for room_id in room_ids
+    }
+    return the_installation
+
+
+@pytest.mark.anyio
+async def test_get_rooms_stats(the_threads, the_logger):
+    the_installation = _installation_with_rooms(ROOM_ID, ROOM_ID_2)
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_threads.get_rooms_last_activity.return_value = {
+        ROOM_ID: T1,
+        ROOM_ID_2: T2,
+    }
+
+    found = await stats_views.get_rooms_stats(
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_threads=the_threads,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found == {
+        ROOM_ID: models.RoomStats(room_id=ROOM_ID, last_activity=T1),
+        ROOM_ID_2: models.RoomStats(room_id=ROOM_ID_2, last_activity=T2),
+    }
+    the_threads.get_rooms_last_activity.assert_awaited_once_with(
+        user_name=USER_NAME,
+    )
+    the_installation.get_room_configs.assert_awaited_once_with(
+        user=THE_USER_CLAIMS,
+        the_authz_policy=the_authz_policy,
+        the_logger=the_logger,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_rooms_stats_filters_inaccessible(the_threads, the_logger):
+    # The user has activity in both rooms but currently only has access
+    # to ROOM_ID; the de-authorized ROOM_ID_2 must drop out.
+    the_installation = _installation_with_rooms(ROOM_ID)
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_threads.get_rooms_last_activity.return_value = {
+        ROOM_ID: T1,
+        ROOM_ID_2: T2,
+    }
+
+    found = await stats_views.get_rooms_stats(
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_threads=the_threads,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found == {
+        ROOM_ID: models.RoomStats(room_id=ROOM_ID, last_activity=T1),
+    }
+
+
+@pytest.mark.anyio
+async def test_get_rooms_stats_no_accessible_rooms(the_threads, the_logger):
+    the_installation = _installation_with_rooms()
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_threads.get_rooms_last_activity.return_value = {}
+
+    found = await stats_views.get_rooms_stats(
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_threads=the_threads,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found == {}
+
+
+@pytest.mark.anyio
+async def test_get_rooms_stats_includes_accessible_room_without_activity(
+    the_threads, the_logger
+):
+    # Every accessible room appears; one the user has no runs in carries a
+    # null last_activity rather than being omitted.
+    the_installation = _installation_with_rooms(ROOM_ID, ROOM_ID_2)
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_threads.get_rooms_last_activity.return_value = {ROOM_ID: T1}
+
+    found = await stats_views.get_rooms_stats(
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_threads=the_threads,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found == {
+        ROOM_ID: models.RoomStats(room_id=ROOM_ID, last_activity=T1),
+        ROOM_ID_2: models.RoomStats(room_id=ROOM_ID_2, last_activity=None),
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("last_activity", [T1, None])
+async def test_get_room_stats(the_threads, the_logger, last_activity):
+    the_installation = mock.create_autospec(installation.Installation)
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_threads.get_room_last_activity.return_value = last_activity
+
+    found = await stats_views.get_room_stats(
+        room_id=ROOM_ID,
+        the_installation=the_installation,
+        the_authz_policy=the_authz_policy,
+        the_threads=the_threads,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found == models.RoomStats(
+        room_id=ROOM_ID,
+        last_activity=last_activity,
+    )
+    the_installation.get_room_config.assert_awaited_once_with(
+        room_id=ROOM_ID,
+        user=THE_USER_CLAIMS,
+        the_authz_policy=the_authz_policy,
+        the_logger=the_logger,
+    )
+    the_threads.get_room_last_activity.assert_awaited_once_with(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_room_stats_unknown_room(the_threads, the_logger):
+    the_installation = mock.create_autospec(installation.Installation)
+    the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
+    the_installation.get_room_config.side_effect = KeyError("testing")
+
+    with raises_httpexc(code=404, match="unknown room id"):
+        await stats_views.get_room_stats(
+            room_id=ROOM_ID,
+            the_installation=the_installation,
+            the_authz_policy=the_authz_policy,
+            the_threads=the_threads,
+            the_user_claims=THE_USER_CLAIMS,
+            the_logger=the_logger,
+        )
+
+    the_threads.get_room_last_activity.assert_not_called()
+
+
+@pytest.fixture
+def the_app(the_threads):
+    app = fastapi.FastAPI()
+    app.include_router(stats_views.router, prefix="/api")
+
+    the_installation = _installation_with_rooms(ROOM_ID, ROOM_ID_2)
+    the_threads.get_room_last_activity.return_value = T1
+    the_threads.get_rooms_last_activity.return_value = {ROOM_ID: T1}
+
+    async def _inst():
+        return the_installation
+
+    async def _authz():
+        return mock.create_autospec(authz_package.AuthorizationPolicy)
+
+    async def _threads():
+        return the_threads
+
+    async def _user_claims():
+        return THE_USER_CLAIMS
+
+    async def _logger():
+        return mock.create_autospec(loggers.LogWrapper)
+
+    app.dependency_overrides[installation.get_the_installation] = _inst
+    app.dependency_overrides[authz_package.get_the_authz_policy] = _authz
+    app.dependency_overrides[agui_package.get_the_threads] = _threads
+    app.dependency_overrides[views_package.get_the_user_claims] = _user_claims
+    app.dependency_overrides[views_package.get_the_logger] = _logger
+    return app
+
+
+@pytest.fixture
+def the_client(the_app):
+    with testclient.TestClient(the_app) as client:
+        yield client
+
+
+def test_get_room_stats_serializes_aware_datetime(the_client):
+    # The whole point of '_as_utc' + 'AwareDatetime': the wire value must
+    # carry a UTC offset so clients don't parse it as local time.
+    response = the_client.get(f"/api/v1/stats/rooms/{ROOM_ID}")
+
+    assert response.status_code == 200
+    parsed = datetime.datetime.fromisoformat(response.json()["last_activity"])
+    assert parsed.tzinfo is not None
+    assert parsed == T1
+
+
+def test_get_rooms_stats_serializes_aware_datetime(the_client):
+    response = the_client.get("/api/v1/stats/rooms")
+
+    assert response.status_code == 200
+    parsed = datetime.datetime.fromisoformat(
+        response.json()[ROOM_ID]["last_activity"]
+    )
+    assert parsed.tzinfo is not None
+    assert parsed == T1
+
+
+def test_get_room_stats_serializes_null_activity(the_client, the_threads):
+    # An accessible room with no runs must serialize last_activity as JSON
+    # null over the wire -- not omit the key, not error.
+    the_threads.get_room_last_activity.return_value = None
+
+    response = the_client.get(f"/api/v1/stats/rooms/{ROOM_ID}")
+
+    assert response.status_code == 200
+    assert response.json()["last_activity"] is None


### PR DESCRIPTION
## Summary

Expose per-room last-activity over a small stats API.

- `GET /v1/stats/rooms` — returns one `RoomStats` per room the user can access, with a null `last_activity` for rooms they have no runs in.
- `GET /v1/stats/rooms/{room_id}` — returns a single room's stats, or 404 if the room is unknown or inaccessible.

Both endpoints scope to the requesting user and to the rooms the authorization policy currently grants them. `RoomStats.last_activity` is an aware datetime (or null) and serializes with a UTC offset.

## Implementation

`ThreadStorage` gains `get_room_last_activity` and `get_rooms_last_activity`: a run's activity time is its finish, or — while unfinished — its start. Each query reports the latest such time across the user's runs, scoped to one room or grouped over all of them. Rooms with no runs are reported as `None` / omitted respectively. SQLite returns naive datetimes on read, so UTC-written values are re-tagged as UTC before returning; otherwise FastAPI would serialize them with no offset and clients would read them as local time.

## Testing

- `tests/unit/agui/test_agui_persistence.py` and `tests/unit/views/test_stats_views.py` cover the new queries and endpoints.
- `uv run pytest` — 3452 passed, 100% branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
