### PR TITLE
feat: per-thread last activity for unread markers

### DIFF
--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -288,6 +288,20 @@ class ThreadStorage(abc.ABC):
         """
 
     @abc.abstractmethod
+    async def get_threads_last_activity(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+    ) -> dict[str, datetime.datetime]:
+        """Return the user's latest run activity for each thread in a room.
+
+        Keyed by thread_id (the AG-UI protocol id); each value is that
+        thread's latest activity as in 'get_room_last_activity' (never
+        None). Threads in which the user has no runs are omitted.
+        """
+
+    @abc.abstractmethod
     async def new_thread(
         self,
         *,

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -168,6 +168,23 @@ class ThreadStorage(agui_package.ThreadStorage):
             rows = (await session.execute(query)).all()
         return {room_id: _as_utc(activity) for room_id, activity in rows}
 
+    async def get_threads_last_activity(
+        self,
+        *,
+        user_name: str,
+        room_id: str,
+    ) -> dict[str, datetime.datetime]:
+        async with self.session as session:
+            query = (
+                sqla_sql.select(agui_schema.Thread.thread_id, _LAST_ACTIVITY)
+                .join(agui_schema.Run.thread)
+                .where(agui_schema.Thread.user_name == user_name)
+                .where(agui_schema.Thread.room_id == room_id)
+                .group_by(agui_schema.Thread.thread_id)
+            )
+            rows = (await session.execute(query)).all()
+        return {thread_id: _as_utc(activity) for thread_id, activity in rows}
+
     async def new_thread(
         self,
         *,

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -825,12 +825,18 @@ class AGUI_Thread(pydantic.BaseModel):
     created: datetime.datetime | None = KW_ONLY_NONE
     metadata: AGUI_ThreadMetadata | None = KW_ONLY_NONE
 
+    # Latest run activity in the thread (finish, or start while unfinished),
+    # or None when it has no runs. Distinct from 'created' (the thread's
+    # birth); lets clients mark threads with unseen activity.
+    last_activity: pydantic.AwareDatetime | None = KW_ONLY_NONE
+
     @classmethod
     def from_thread(
         cls,
         a_thread: agui_package.Thread,
         a_thread_meta: AGUI_ThreadMetadata,
         a_thread_runs: AGUI_Runs = None,
+        a_thread_last_activity: datetime.datetime | None = None,
     ):
         return cls(
             room_id=a_thread.room_id,
@@ -838,6 +844,7 @@ class AGUI_Thread(pydantic.BaseModel):
             created=a_thread.created,
             metadata=a_thread_meta,
             runs=a_thread_runs,
+            last_activity=a_thread_last_activity,
         )
 
 

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -121,6 +121,13 @@ async def get_room_agui(
         the_user_claims=the_user_claims,
         the_logger=the_logger,
     )
+    # Per-thread last-activity in one grouped query, so the listing can mark
+    # threads with unseen activity without replaying each thread's runs.
+    last_activity = await the_threads.get_threads_last_activity(
+        user_name=user_name,
+        room_id=room_id,
+    )
+
     model_threads = []
     for a_thread in await the_threads.list_user_threads(
         user_name=user_name,
@@ -135,6 +142,7 @@ async def get_room_agui(
                     thread_meta,
                 ),
                 a_thread_runs=None,
+                a_thread_last_activity=last_activity.get(a_thread.thread_id),
             )
         )
 

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -1436,3 +1436,78 @@ async def test_get_rooms_last_activity_grouping_and_scoping(the_async_session):
 
     assert result == {ROOM_ID: T_MID, ROOM_ID_2: T_NEW}
     assert all(v.tzinfo is not None for v in result.values())
+
+
+@pytest.mark.asyncio
+async def test_get_threads_last_activity_empty(the_async_session):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    result = await ts.get_threads_last_activity(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+    )
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_get_threads_last_activity_grouping_and_scoping(
+    the_async_session,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    # Thread A: two runs; coalesce/max picks the later 'finished' (T_MID)
+    # over either 'created' (T_OLD).
+    thread_a = await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_OLD,
+        finished=T_MID,
+    )
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_OLD,
+        thread_id=thread_a,
+    )
+    # Thread B: a single, newer run in the same room.
+    thread_b = await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID,
+        created=T_NEW,
+    )
+    # A thread in another room is scoped out.
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=USER_NAME,
+        email=EMAIL,
+        room_id=ROOM_ID_2,
+        created=T_NEW,
+    )
+    # Another user's thread in ROOM_ID must not appear.
+    await _add_run(
+        ts,
+        the_async_session,
+        user_name=OTHER_USER_NAME,
+        email=OTHER_EMAIL,
+        room_id=ROOM_ID,
+        created=T_NEW,
+    )
+
+    result = await ts.get_threads_last_activity(
+        user_name=USER_NAME,
+        room_id=ROOM_ID,
+    )
+
+    assert result == {thread_a: T_MID, thread_b: T_NEW}
+    assert all(v.tzinfo is not None for v in result.values())

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -304,6 +304,9 @@ async def test_get_room_agui_only(
         )
 
     the_threads.list_user_threads.return_value = [test_thread]
+    the_threads.get_threads_last_activity.return_value = {
+        TEST_THREAD_ID_STR: NOW,
+    }
 
     found = await agui_views.get_room_agui(
         room_id=TEST_ROOM_ID,
@@ -319,6 +322,7 @@ async def test_get_room_agui_only(
     assert m_thread.room_id == TEST_ROOM_ID
     assert m_thread.thread_id == TEST_THREAD_ID_UUID
     assert m_thread.runs is None
+    assert m_thread.last_activity == NOW
 
     if w_thread_meta:
         assert m_thread.metadata.name == TEST_THREAD_NAME
@@ -326,6 +330,10 @@ async def test_get_room_agui_only(
         assert m_thread.metadata is None
 
     the_threads.list_user_threads.assert_called_once_with(
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+    )
+    the_threads.get_threads_last_activity.assert_called_once_with(
         user_name=USER_NAME,
         room_id=TEST_ROOM_ID,
     )


### PR DESCRIPTION
Follow-up to #1074. That PR added the room-level activity stats (`GET /v1/stats/rooms`, `RoomStats.last_activity`, `get_rooms_last_activity`); this extends the same surface down to the **thread** level so clients can mark individual threads with unseen activity, not just rooms.

## What

- **`AGUI_Thread.last_activity`** — most recent run activity in the thread (finish, or start while unfinished), or `null` when it has no runs. Added to the thread-listing response (`GET /v1/rooms/{room_id}/agui`), filled by one grouped query — no replaying of each threadʼs runs. Distinct from `created` (the threadʼs birth).
- **`ThreadStorage.get_threads_last_activity`** — grouped `max(coalesce(Run.finished, Run.created))` by thread within a room, scoped to the user. Mirrors `get_rooms_last_activity`, reusing the shared `_LAST_ACTIVITY` expression and `_as_utc` normalization.

## Tests

100% branch coverage on the new code; new persistence tests (empty + grouping/scoping) and a thread-listing view assertion. The pre-existing `test_lifespan` failures are an environment issue (they fail identically on a clean `main`), unrelated to this change.

## Client

The Soliplex frontend already reads `last_activity` off both the batch room stats and the thread listing, so this lights up thread-level unread dots with no client change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)