### PR TITLE
feat: 'authz.AuthorizationPolicy' parity w/ `admin-users` CLI

### DIFF
--- a/src/soliplex/authz/__init__.py
+++ b/src/soliplex/authz/__init__.py
@@ -148,20 +148,55 @@ class AuthorizationPolicy(abc.ABC):
     """Protocol for checking / managing authorization policies"""
 
     @abc.abstractmethod
-    async def list_admin_users(self) -> list[str]:
-        """List admin users in the admin users table.
+    async def list_admin_user_discriminators(self) -> list[str]:
+        """List JSONPath discriminators which identify admin users.
 
-        Email-keyed admins surface as their email; admins keyed by a
-        non-email JSONPath query surface as the raw query string.
+        Discriminators may be tied to individuals (e.g., via their
+        email addresses), or to claims which identify groups or
+        roles attached to the user.
         """
 
     @abc.abstractmethod
+    async def add_admin_user_discriminator(self, json_path: str):
+        """Add a user discriminator to the admin users table.
+
+        Discriminators may be tied to individuals (e.g., via their
+        email addresses), or to claims which identify groups or
+        roles attached to the user.
+        """
+
+    @abc.abstractmethod
+    async def remove_admin_user_discriminator(self, json_path: str):
+        """Remove a user discriminator from the admin users table.
+
+        Discriminators may be tied to individuals (e.g., via their
+        email addresses), or to claims which identify groups or
+        roles attached to the user.
+        """
+
+    @abc.abstractmethod
+    async def clear_admin_user_discriminators(self):
+        """Remove all admin user discriminators from the admin users table."""
+
+    @abc.abstractmethod
+    async def list_admin_users(self) -> list[str]:
+        """Deprecated alias for 'list_admin_user_discriminators'."""
+
+    @abc.abstractmethod
     async def add_admin_user(self, email: str):
-        """Add a user to the admin users table."""
+        """Deprecated alias for 'add_admin_user_discriminator'.
+
+        Translates 'email' to the equivalent JSONPath expression,
+        '$[?$.email == "..."]', then delegates.
+        """
 
     @abc.abstractmethod
     async def remove_admin_user(self, email: str):
-        """Remove a user from the admin users table."""
+        """Deprecated alias for 'remove_admin_user_discriminator'.
+
+        Translates 'email' to the equivalent JSONPath expression,
+        '$[?$.email == "..."]', then delegates.
+        """
 
     @abc.abstractmethod
     async def check_admin_access(self, user_token: UserToken) -> bool:

--- a/src/soliplex/authz/persistence.py
+++ b/src/soliplex/authz/persistence.py
@@ -13,15 +13,17 @@ from soliplex.authz import schema as authz_schema
 
 
 class NoSuchAdminUser(ValueError):
-    def __init__(self, email):
-        self.email = email
-        super().__init__(f"No admin user exists with email: {email}")
+    def __init__(self, json_path):
+        self.json_path = json_path
+        super().__init__(f"No admin user exists with json_path: {json_path}")
 
 
 class AdminUserExists(ValueError):
-    def __init__(self, email):
-        self.email = email
-        super().__init__(f"Admin user already exists with email: {email}")
+    def __init__(self, json_path):
+        self.json_path = json_path
+        super().__init__(
+            f"Admin user already exists with json_path: {json_path}"
+        )
 
 
 class NotAdminUser(ValueError):
@@ -73,48 +75,79 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
         async with self._session.begin():
             yield self._session
 
-    async def list_admin_users(self) -> list[str]:
-        """List admin users in the admin users table.
+    async def list_admin_user_discriminators(self) -> list[str]:
+        """List JSONPath discriminators which identify admin users.
 
-        An email-keyed admin (stored as '$[?$.email == "..."]') is
-        surfaced as its email; an admin created with a non-email
-        JSONPath query is surfaced as the raw query string.
+        Discriminators may be tied to individuals (e.g., via their
+        email addresses), or to claims which identify groups or
+        roles attached to the user.
         """
         query = sqla_sql.select(authz_schema.AdminUser)
         async with self.session as session:
-            result = []
-            for admin_user in await session.scalars(query):
-                parsed = authz_package.parse_token_field_json_path(
-                    admin_user.json_path
-                )
-                if parsed is not None and parsed[0] == "email":
-                    result.append(parsed[1])
-                else:
-                    result.append(admin_user.json_path)
-            return result
+            return [
+                admin_user.json_path
+                for admin_user in await session.scalars(query)
+            ]
 
-    async def add_admin_user(self, email: str):
-        """Add a user to the admin users table, keyed by email."""
-        json_path = authz_package.token_field_json_path("email", email)
+    async def add_admin_user_discriminator(self, json_path: str):
+        """Add a user discriminator to the admin users table.
+
+        Discriminators may be tied to individuals (e.g., via their
+        email addresses), or to claims which identify groups or
+        roles attached to the user.
+        """
         async with self.session as session:
             user = await _find_admin_user_by_json_path(json_path, session)
 
             if user is not None:
-                raise AdminUserExists(email=email)
+                raise AdminUserExists(json_path=json_path)
 
             user = authz_schema.AdminUser(json_path=json_path)
             session.add(user)
 
-    async def remove_admin_user(self, email: str):
-        """Remove a user from the admin users table, keyed by email."""
-        json_path = authz_package.token_field_json_path("email", email)
+    async def remove_admin_user_discriminator(self, json_path: str):
+        """Remove a user discriminator from the admin users table.
+
+        Discriminators may be tied to individuals (e.g., via their
+        email addresses), or to claims which identify groups or
+        roles attached to the user.
+        """
         async with self.session as session:
             user = await _find_admin_user_by_json_path(json_path, session)
 
             if user is None:
-                raise NoSuchAdminUser(email=email)
+                raise NoSuchAdminUser(json_path=json_path)
 
             await session.delete(user)
+
+    async def clear_admin_user_discriminators(self):
+        """Remove all admin user discriminators from the admin users table."""
+        query = sqla_sql.select(authz_schema.AdminUser)
+        async with self.session as session:
+            for admin_user in await session.scalars(query):
+                await session.delete(admin_user)
+
+    async def list_admin_users(self) -> list[str]:
+        """Deprecated alias for 'list_admin_user_discriminators'."""
+        return await self.list_admin_user_discriminators()
+
+    async def add_admin_user(self, email: str):
+        """Deprecated alias for 'add_admin_user_discriminator'.
+
+        Translates 'email' to the equivalent JSONPath expression,
+        '$[?$.email == "..."]', then delegates.
+        """
+        json_path = authz_package.token_field_json_path("email", email)
+        await self.add_admin_user_discriminator(json_path)
+
+    async def remove_admin_user(self, email: str):
+        """Deprecated alias for 'remove_admin_user_discriminator'.
+
+        Translates 'email' to the equivalent JSONPath expression,
+        '$[?$.email == "..."]', then delegates.
+        """
+        json_path = authz_package.token_field_json_path("email", email)
+        await self.remove_admin_user_discriminator(json_path)
 
     async def check_admin_access(
         self,

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -898,7 +898,7 @@ RoomPolicyMap = dict[str, RoomPolicy | None]
 
 
 class InstallationAuthorization(pydantic.BaseModel):
-    admin_user_emails: list[str] = pydantic.Field(default_factory=list)
+    admin_user_discriminators: list[str] = pydantic.Field(default_factory=list)
     room_policies: RoomPolicyMap = pydantic.Field(default_factory=dict)
 
 

--- a/src/soliplex/views/authz.py
+++ b/src/soliplex/views/authz.py
@@ -136,7 +136,7 @@ async def get_installation_authz(
             detail=loggers.AUTHZ_ADMIN_ACCESS_REQUIRED,
         ) from None
 
-    admin_user_emails = await the_authz_policy.list_admin_users()
+    discriminators = await the_authz_policy.list_admin_user_discriminators()
 
     room_policies = {
         room_id: await the_authz_policy.get_room_policy(
@@ -151,7 +151,7 @@ async def get_installation_authz(
     }
 
     return models.InstallationAuthorization(
-        admin_user_emails=admin_user_emails,
+        admin_user_discriminators=discriminators,
         room_policies={
             room_id: room_policy if room_policy is not None else None
             for room_id, room_policy in room_policies.items()

--- a/tests/unit/authz/test_authz_persistence.py
+++ b/tests/unit/authz/test_authz_persistence.py
@@ -1,6 +1,8 @@
+import datetime
 from unittest import mock
 
 import pytest
+from sqlalchemy import sql as sqla_sql
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import authz as authz_package
@@ -10,6 +12,8 @@ from soliplex.authz import schema as authz_schema
 
 EMAIL = "phreddy@example.com"
 JSON_PATH = authz_package.token_field_json_path("email", EMAIL)
+ROLE_JSON_PATH = '$[?$.role == "admin"]'
+INVALID_JSON_PATH = "$[?@.role"  # unbalanced -- does not compile
 USER_TOKEN = {
     "email": EMAIL,
 }
@@ -39,7 +43,106 @@ async def test_authorizationpolicy_session(faux_sqlaa_session):
 
 
 @pytest.mark.asyncio
+async def test_list_admin_user_discriminators(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    the_async_session.add(authz_schema.AdminUser(json_path=JSON_PATH))
+    the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
+    await the_async_session.commit()
+
+    found = await ap.list_admin_user_discriminators()
+
+    assert found == [JSON_PATH, ROLE_JSON_PATH]
+
+
+@pytest.mark.asyncio
+async def test_add_admin_user_discriminator(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    await ap.add_admin_user_discriminator(ROLE_JSON_PATH)
+
+    found = await ap.list_admin_user_discriminators()
+    assert found == [ROLE_JSON_PATH]
+
+
+@pytest.mark.asyncio
+async def test_add_admin_user_discriminator_already_exists(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
+    await the_async_session.commit()
+
+    with pytest.raises(authz_persistence.AdminUserExists):
+        await ap.add_admin_user_discriminator(ROLE_JSON_PATH)
+
+
+@pytest.mark.asyncio
+async def test_remove_admin_user_discriminator(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
+    await the_async_session.commit()
+
+    await ap.remove_admin_user_discriminator(ROLE_JSON_PATH)
+
+    found = await ap.list_admin_user_discriminators()
+    assert found == []
+
+
+@pytest.mark.asyncio
+async def test_remove_admin_user_discriminator_absent(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    with pytest.raises(authz_persistence.NoSuchAdminUser):
+        await ap.remove_admin_user_discriminator(ROLE_JSON_PATH)
+
+
+@pytest.mark.asyncio
+async def test_remove_admin_user_discriminator_invalid_json_path(
+    the_async_session,
+):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    # Seed via a core INSERT so the stored value bypasses the ORM
+    # '@validates' hook -- mimicking an entry whose 'json_path' no
+    # longer compiles (e.g. a removed meta-config filter function).
+    await the_async_session.execute(
+        sqla_sql.insert(authz_schema.AdminUser.__table__).values(
+            json_path=INVALID_JSON_PATH,
+            created=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+        )
+    )
+    await the_async_session.commit()
+
+    await ap.remove_admin_user_discriminator(INVALID_JSON_PATH)
+
+    found = await ap.list_admin_user_discriminators()
+    assert found == []
+
+
+@pytest.mark.asyncio
+async def test_clear_admin_user_discriminators(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    the_async_session.add(authz_schema.AdminUser(json_path=JSON_PATH))
+    the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
+    await the_async_session.commit()
+
+    await ap.clear_admin_user_discriminators()
+
+    found = await ap.list_admin_user_discriminators()
+    assert found == []
+
+
+@pytest.mark.asyncio
+async def test_clear_admin_user_discriminators_empty(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    await ap.clear_admin_user_discriminators()
+
+    found = await ap.list_admin_user_discriminators()
+    assert found == []
+
+
+@pytest.mark.asyncio
 async def test_authorizationpolicy_crud_admin_user(the_async_session):
+    # The deprecated 'email'-keyed aliases delegate to the
+    # '*_discriminator' methods, storing the canonical email JSONPath.
     ap = authz_persistence.AuthorizationPolicy(the_async_session)
 
     found = await ap.list_admin_users()
@@ -55,7 +158,7 @@ async def test_authorizationpolicy_crud_admin_user(the_async_session):
     await the_async_session.commit()
 
     found = await ap.list_admin_users()
-    assert found == [EMAIL]
+    assert found == [JSON_PATH]
     await the_async_session.commit()
 
     with pytest.raises(authz_persistence.AdminUserExists):
@@ -69,7 +172,7 @@ async def test_authorizationpolicy_crud_admin_user(the_async_session):
     await the_async_session.commit()
 
     found = await ap.list_admin_users()
-    assert found == [EMAIL]
+    assert found == [JSON_PATH]
     await the_async_session.commit()
 
     await ap.remove_admin_user(email=EMAIL)

--- a/tests/unit/views/test_authz_views.py
+++ b/tests/unit/views/test_authz_views.py
@@ -10,6 +10,8 @@ from soliplex import models
 from soliplex.views import authz as authz_views
 
 ADMIN_EMAIL = "admin@example.com"
+ADMIN_EMAIL_JSON_PATH = f'$[?$.email == "{ADMIN_EMAIL}"]'
+ADMIN_OTHER_JSON_PATH = '$[?$.group == "test.admin.group"]'
 THE_USER_CLAIMS = {"email": ADMIN_EMAIL}
 
 ROOM_ID = "test_room"
@@ -217,27 +219,30 @@ async def test_delete_room_authz(w_existing, w_admin_access):
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("w_admin_access", [False, True])
-@pytest.mark.parametrize("w_admin_user", [None, ADMIN_EMAIL])
+@pytest.mark.parametrize(
+    "w_admin_user_discrims",
+    [
+        [],
+        [ADMIN_EMAIL_JSON_PATH],
+        [ADMIN_OTHER_JSON_PATH],
+        [ADMIN_EMAIL_JSON_PATH, ADMIN_OTHER_JSON_PATH],
+    ],
+)
 @pytest.mark.parametrize("w_room_policy", [None, ROOM_POLICY])
 async def test_get_installation_authz(
     w_room_policy,
-    w_admin_user,
+    w_admin_user_discrims,
     w_admin_access,
 ):
     the_installation = mock.create_autospec(installation.Installation)
     the_installation.get_room_configs.return_value = {ROOM_ID: object()}
     the_authz_policy = mock.create_autospec(authz_package.AuthorizationPolicy)
     the_authz_policy.check_admin_access.return_value = w_admin_access
-    the_authz_logger = mock.create_autospec(loggers.LogWrapper)
-
-    if w_admin_user is not None:
-        exp_admin_emails = [ADMIN_EMAIL]
-    else:
-        exp_admin_emails = []
-
-    the_authz_policy.list_admin_users.return_value = exp_admin_emails
-
     the_authz_policy.get_room_policy.return_value = w_room_policy
+    the_authz_policy.list_admin_user_discriminators.return_value = (
+        w_admin_user_discrims
+    )
+    the_authz_logger = mock.create_autospec(loggers.LogWrapper)
 
     if not w_admin_access:
         with pytest.raises(fastapi.HTTPException) as exc:
@@ -256,11 +261,11 @@ async def test_get_installation_authz(
         )
 
         the_authz_policy.get_room_policy.assert_not_awaited()
-        the_authz_policy.list_admin_users.assert_not_awaited()
+        the_authz_policy.list_admin_user_discriminators.assert_not_awaited()
 
     else:
         expected = models.InstallationAuthorization(
-            admin_user_emails=exp_admin_emails,
+            admin_user_discriminators=w_admin_user_discrims,
             room_policies={
                 ROOM_ID: w_room_policy,
             },
@@ -279,7 +284,7 @@ async def test_get_installation_authz(
             room_id=ROOM_ID,
             user_token=THE_USER_CLAIMS,
         )
-        the_authz_policy.list_admin_users.assert_awaited_once_with()
+        the_authz_policy.list_admin_user_discriminators.assert_awaited_once_with()
         the_installation.get_room_configs.assert_awaited_once_with(
             user=THE_USER_CLAIMS,
             the_authz_policy=the_authz_policy,


### PR DESCRIPTION
Prefer use of JSONPath discriminators over email addresses.

Existing method taking 'email' argments are now deprecated shims.

Toward #1080.