### PR TITLE
refactor: drop 'user_token' parm

### DIFF
--- a/src/soliplex/authz/__init__.py
+++ b/src/soliplex/authz/__init__.py
@@ -226,7 +226,6 @@ class AuthorizationPolicy(abc.ABC):
     async def get_room_policy(
         self,
         room_id: str,
-        user_token: UserToken,
     ) -> models.RoomPolicy | None:  # noqa: F821
         """Return the authorization policy for the room"""
 
@@ -235,7 +234,6 @@ class AuthorizationPolicy(abc.ABC):
         self,
         room_id: str,
         room_policy: models.RoomPolicy,  # noqa: F821
-        user_token: UserToken,
     ) -> None:
         """Update the authorization policy for the room"""
 
@@ -243,7 +241,6 @@ class AuthorizationPolicy(abc.ABC):
     async def delete_room_policy(
         self,
         room_id: str,
-        user_token: UserToken,
     ) -> None:
         """Delete the authorization policy for the room"""
 

--- a/src/soliplex/authz/persistence.py
+++ b/src/soliplex/authz/persistence.py
@@ -26,12 +26,6 @@ class AdminUserExists(ValueError):
         )
 
 
-class NotAdminUser(ValueError):
-    def __init__(self, email):
-        self.email = email
-        super().__init__(f"Non-admin user, email: {email}")
-
-
 async def _find_admin_user_by_json_path(
     json_path: str,
     session,
@@ -207,13 +201,9 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
     async def get_room_policy(
         self,
         room_id: str,
-        user_token: authz_package.UserToken,
     ) -> models.RoomPolicy | None:
         """Return the authorization policy for the room"""
         async with self.session as session:
-            if not await _user_is_admin(user_token, session):
-                raise NotAdminUser(user_token["email"])
-
             policy = await _find_room_policy(room_id, session)
 
         if policy is not None:
@@ -226,13 +216,9 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
         self,
         room_id: str,
         room_policy: models.RoomPolicy,
-        user_token: authz_package.UserToken,
     ) -> None:
         """Update the authorization policy for the room"""
         async with self.session as session:
-            if not await _user_is_admin(user_token, session):
-                raise NotAdminUser(user_token["email"])
-
             policy = await _find_room_policy(room_id, session)
 
             if policy is not None:
@@ -251,13 +237,9 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
     async def delete_room_policy(
         self,
         room_id: str,
-        user_token: authz_package.UserToken,
     ) -> None:
         """Delete any existing authorization policy for the room"""
         async with self.session as session:
-            if not await _user_is_admin(user_token, session):
-                raise NotAdminUser(user_token["email"])
-
             policy = await _find_room_policy(room_id, session)
 
             if policy is not None:

--- a/src/soliplex/views/authz.py
+++ b/src/soliplex/views/authz.py
@@ -50,7 +50,6 @@ async def get_room_authz(
 
     room_policy = await the_authz_policy.get_room_policy(
         room_id=room_id,
-        user_token=the_user_claims,
     )
 
     return room_policy
@@ -81,7 +80,6 @@ async def post_room_authz(
     await the_authz_policy.update_room_policy(
         room_id=room_id,
         room_policy=room_policy,
-        user_token=the_user_claims,
     )
 
     return fastapi.Response(status_code=204)
@@ -110,7 +108,6 @@ async def delete_room_authz(
 
     await the_authz_policy.delete_room_policy(
         room_id=room_id,
-        user_token=the_user_claims,
     )
 
     return fastapi.Response(status_code=204)
@@ -141,7 +138,6 @@ async def get_installation_authz(
     room_policies = {
         room_id: await the_authz_policy.get_room_policy(
             room_id=room_id,
-            user_token=the_user_claims,
         )
         for room_id in await the_installation.get_room_configs(
             user=the_user_claims,

--- a/tests/unit/authz/test_authz_persistence.py
+++ b/tests/unit/authz/test_authz_persistence.py
@@ -282,39 +282,11 @@ async def test_authorizationpolicy_filter_room_ids(the_async_session):
 
 
 @pytest.mark.asyncio
-async def test_authorizationpolicy_room_policy_crud_not_admin(
-    the_async_session,
-):
-    ap = authz_persistence.AuthorizationPolicy(the_async_session)
-
-    with pytest.raises(authz_persistence.NotAdminUser):
-        await ap.get_room_policy(ROOM_ID, USER_TOKEN)
-
-    acl_entry_model = models.ACLEntry(
-        allow_deny=authz_package.AllowDeny.ALLOW,
-        everyone=True,
-    )
-    policy_model = models.RoomPolicy(
-        room_id=ROOM_ID,
-        acl_entries=[acl_entry_model],
-    )
-
-    with pytest.raises(authz_persistence.NotAdminUser):
-        await ap.update_room_policy(ROOM_ID, policy_model, USER_TOKEN)
-
-    with pytest.raises(authz_persistence.NotAdminUser):
-        await ap.delete_room_policy(ROOM_ID, USER_TOKEN)
-
-
-@pytest.mark.asyncio
 async def test_authorizationpolicy_room_policy_crud(the_async_session):
     ap = authz_persistence.AuthorizationPolicy(the_async_session)
 
-    await ap.add_admin_user(email=EMAIL)
-    await the_async_session.commit()
-
     # No policy -> public room
-    policy = await ap.get_room_policy(ROOM_ID, USER_TOKEN)
+    policy = await ap.get_room_policy(ROOM_ID)
     assert policy is None
 
     acl_entry_model = models.ACLEntry(
@@ -325,10 +297,10 @@ async def test_authorizationpolicy_room_policy_crud(the_async_session):
         room_id=ROOM_ID,
         acl_entries=[acl_entry_model],
     )
-    await ap.update_room_policy(ROOM_ID, policy_model, USER_TOKEN)
+    await ap.update_room_policy(ROOM_ID, policy_model)
     await the_async_session.commit()
 
-    after = await ap.get_room_policy(ROOM_ID, USER_TOKEN)
+    after = await ap.get_room_policy(ROOM_ID)
     assert after == policy_model
     await the_async_session.commit()
 
@@ -339,19 +311,19 @@ async def test_authorizationpolicy_room_policy_crud(the_async_session):
     new_policy_model = policy_model.model_copy(
         update={"acl_entries": [new_acl_entry_model]},
     )
-    await ap.update_room_policy(ROOM_ID, new_policy_model, USER_TOKEN)
+    await ap.update_room_policy(ROOM_ID, new_policy_model)
     await the_async_session.commit()
 
-    policy = await ap.get_room_policy(ROOM_ID, USER_TOKEN)
+    policy = await ap.get_room_policy(ROOM_ID)
     assert policy == new_policy_model
     await the_async_session.commit()
 
-    await ap.delete_room_policy(ROOM_ID, USER_TOKEN)
+    await ap.delete_room_policy(ROOM_ID)
     await the_async_session.commit()
 
-    gone = await ap.get_room_policy(ROOM_ID, USER_TOKEN)
+    gone = await ap.get_room_policy(ROOM_ID)
     assert gone is None
     await the_async_session.commit()
 
-    await ap.delete_room_policy(ROOM_ID, USER_TOKEN)
+    await ap.delete_room_policy(ROOM_ID)
     await the_async_session.commit()

--- a/tests/unit/views/test_authz_views.py
+++ b/tests/unit/views/test_authz_views.py
@@ -86,7 +86,6 @@ async def test_get_room_authz(w_policy, w_admin_access):
 
         the_authz_policy.get_room_policy.assert_awaited_once_with(
             room_id=ROOM_ID,
-            user_token=THE_USER_CLAIMS,
         )
 
     the_authz_logger.debug.assert_called_once_with(
@@ -147,7 +146,6 @@ async def test_post_room_authz(w_existing, w_admin_access):
         the_authz_policy.update_room_policy.assert_awaited_once_with(
             room_id=ROOM_ID,
             room_policy=NEW_ROOM_POLICY,
-            user_token=THE_USER_CLAIMS,
         )
 
     the_authz_logger.debug.assert_called_once_with(
@@ -205,7 +203,6 @@ async def test_delete_room_authz(w_existing, w_admin_access):
 
         the_authz_policy.delete_room_policy.assert_awaited_once_with(
             room_id=ROOM_ID,
-            user_token=THE_USER_CLAIMS,
         )
 
     the_authz_logger.debug.assert_called_once_with(
@@ -282,7 +279,6 @@ async def test_get_installation_authz(
 
         the_authz_policy.get_room_policy.assert_awaited_once_with(
             room_id=ROOM_ID,
-            user_token=THE_USER_CLAIMS,
         )
         the_authz_policy.list_admin_user_discriminators.assert_awaited_once_with()
         the_installation.get_room_configs.assert_awaited_once_with(


### PR DESCRIPTION
  ... from 'authz.AuthorizationPolicy.{get,update,delete}_room_policy'

  Callers (in 'views.authz' already make explicit calls to
  'AuthorizationPolicy.check_admin_access' before calling these methods.

Toward #1081.