### PR TITLE
fix: CLI 'room-authz' commands use 'authz.AuthorizationPolicy'

### DIFF
--- a/src/soliplex/authz/__init__.py
+++ b/src/soliplex/authz/__init__.py
@@ -85,6 +85,40 @@ class ExactlyOneDiscriminator(ValueError):
         )
 
 
+class NoSuchAdminUser(ValueError):
+    """Raised when no admin user matches a given JSONPath discriminator."""
+
+    def __init__(self, json_path):
+        self.json_path = json_path
+        super().__init__(f"No admin user exists with json_path: {json_path}")
+
+
+class AdminUserExists(ValueError):
+    """Raised when an admin user already exists for a discriminator."""
+
+    def __init__(self, json_path):
+        self.json_path = json_path
+        super().__init__(
+            f"Admin user already exists with json_path: {json_path}"
+        )
+
+
+class NoSuchRoomPolicy(ValueError):
+    """Raised when no authorization policy exists for a room."""
+
+    def __init__(self, room_id):
+        self.room_id = room_id
+        super().__init__(f"No policy exists for room: {room_id}")
+
+
+class NoSuchACLEntry(ValueError):
+    """Raised when no stored ACL entry matches a room operation."""
+
+    def __init__(self, room_id):
+        self.room_id = room_id
+        super().__init__(f"No matching ACL entry in room: {room_id}")
+
+
 def validate_json_path(value: str | None) -> str | None:
     """Validate a JSONPath query string.
 
@@ -243,6 +277,46 @@ class AuthorizationPolicy(abc.ABC):
         room_id: str,
     ) -> None:
         """Delete the authorization policy for the room"""
+
+    @abc.abstractmethod
+    async def get_room_policy_unchecked(
+        self,
+        room_id: str,
+    ) -> models.RoomPolicyUnchecked | None:  # noqa: F821
+        """Return the room policy, tolerating non-compiling 'json_path's."""
+
+    @abc.abstractmethod
+    async def clear_room_acl(self, room_id: str) -> None:
+        """Remove all ACL entries from the room's policy.
+
+        The policy row and its 'default_allow_deny' are preserved.
+        """
+
+    @abc.abstractmethod
+    async def add_acl_entry(
+        self,
+        room_id: str,
+        entry: models.ACLEntry,  # noqa: F821
+    ) -> None:
+        """Add an ACL entry to the room's policy, replacing any entry with
+        the same discriminator."""
+
+    @abc.abstractmethod
+    async def remove_acl_entry(
+        self,
+        room_id: str,
+        entry: models.ACLEntryUnchecked,  # noqa: F821
+    ) -> None:
+        """Remove the matching ACL entry from the room's policy."""
+
+    @abc.abstractmethod
+    async def set_room_default(
+        self,
+        room_id: str,
+        allow_deny: AllowDeny,
+    ) -> None:
+        """Set the room policy's 'default_allow_deny', creating an empty
+        policy if none exists."""
 
 
 async def get_the_authz_policy(

--- a/src/soliplex/authz/persistence.py
+++ b/src/soliplex/authz/persistence.py
@@ -12,18 +12,25 @@ from soliplex import models
 from soliplex.authz import schema as authz_schema
 
 
-class NoSuchAdminUser(ValueError):
-    def __init__(self, json_path):
-        self.json_path = json_path
-        super().__init__(f"No admin user exists with json_path: {json_path}")
+def _entry_discriminator(
+    entry: models.ACLEntryUnchecked,
+) -> tuple[bool, bool, str | None]:
+    """Resolve an ACL-entry model's discriminator without compiling.
 
-
-class AdminUserExists(ValueError):
-    def __init__(self, json_path):
-        self.json_path = json_path
-        super().__init__(
-            f"Admin user already exists with json_path: {json_path}"
+    Collapses the 'preferred_username' / 'email' claim shortcuts to the
+    equivalent stored 'json_path' string (highest priority first, matching
+    'authz_schema.ACLEntry.from_model'), so a possibly-stale 'json_path'
+    can be matched against stored rows by string equality. Returns the
+    '(everyone, authenticated, json_path)' triple.
+    """
+    json_path = entry.json_path
+    if entry.preferred_username is not None:
+        json_path = authz_package.token_field_json_path(
+            "preferred_username", entry.preferred_username
         )
+    elif entry.email is not None:
+        json_path = authz_package.token_field_json_path("email", entry.email)
+    return entry.everyone, entry.authenticated, json_path
 
 
 async def _find_admin_user_by_json_path(
@@ -94,7 +101,7 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
             user = await _find_admin_user_by_json_path(json_path, session)
 
             if user is not None:
-                raise AdminUserExists(json_path=json_path)
+                raise authz_package.AdminUserExists(json_path=json_path)
 
             user = authz_schema.AdminUser(json_path=json_path)
             session.add(user)
@@ -110,7 +117,7 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
             user = await _find_admin_user_by_json_path(json_path, session)
 
             if user is None:
-                raise NoSuchAdminUser(json_path=json_path)
+                raise authz_package.NoSuchAdminUser(json_path=json_path)
 
             await session.delete(user)
 
@@ -166,12 +173,12 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
         async with self.session as session:
             policy = await _find_room_policy(room_id, session)
 
-        if policy is not None:
-            await policy.awaitable_attrs.acl_entries
-            allow_deny = policy.check_token(user_token)
-            return allow_deny == authz_package.AllowDeny.ALLOW
-        else:
-            return True
+            if policy is not None:
+                await policy.awaitable_attrs.acl_entries
+                allow_deny = policy.check_token(user_token)
+                return allow_deny == authz_package.AllowDeny.ALLOW
+            else:
+                return True
 
     async def filter_room_ids(
         self,
@@ -206,9 +213,29 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
         async with self.session as session:
             policy = await _find_room_policy(room_id, session)
 
-        if policy is not None:
-            await policy.awaitable_attrs.acl_entries
-            return policy.as_model
+            if policy is not None:
+                await policy.awaitable_attrs.acl_entries
+                return policy.as_model
+
+        return None
+
+    async def get_room_policy_unchecked(
+        self,
+        room_id: str,
+    ) -> models.RoomPolicyUnchecked | None:
+        """Return the room policy, tolerating non-compiling 'json_path's.
+
+        The analogue of 'get_room_policy' for callers (e.g. the CLI) that
+        must inspect a policy even when a stored ACL entry's 'json_path'
+        no longer compiles. Returns the unchecked model, which carries
+        such a 'json_path' without raising.
+        """
+        async with self.session as session:
+            policy = await _find_room_policy(room_id, session)
+
+            if policy is not None:
+                await policy.awaitable_attrs.acl_entries
+                return policy.as_unchecked_model
 
         return None
 
@@ -217,7 +244,11 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
         room_id: str,
         room_policy: models.RoomPolicy,
     ) -> None:
-        """Update the authorization policy for the room"""
+        """Update the authorization policy for the room
+
+        'room_id' is authoritative: the stored policy is written for
+        'room_id' regardless of the 'room_id' carried by 'room_policy'.
+        """
         async with self.session as session:
             policy = await _find_room_policy(room_id, session)
 
@@ -228,6 +259,7 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
                     await session.delete(policy)
 
             new_policy = authz_schema.RoomPolicy.from_model(room_policy)
+            new_policy.room_id = room_id
 
             async with session.begin_nested():
                 session.add(new_policy)
@@ -245,3 +277,117 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
             if policy is not None:
                 async with session.begin_nested():
                     await session.delete(policy)
+
+    async def clear_room_acl(self, room_id: str) -> None:
+        """Remove all ACL entries from the room's policy.
+
+        The policy row and its 'default_allow_deny' are preserved. A
+        no-op if the room has no policy.
+        """
+        async with self.session as session:
+            policy = await _find_room_policy(room_id, session)
+
+            if policy is not None:
+                await policy.awaitable_attrs.acl_entries
+                for acl_entry in list(policy.acl_entries):
+                    await session.delete(acl_entry)
+
+    async def add_acl_entry(
+        self,
+        room_id: str,
+        entry: models.ACLEntry,
+    ) -> None:
+        """Add an ACL entry to the room's policy.
+
+        The room must already have a policy ('set_room_default' or a prior
+        'update_room_policy'); otherwise 'NoSuchRoomPolicy' is raised. Any
+        existing entry with the same discriminator is replaced.
+        """
+        new_acl = authz_schema.ACLEntry.from_model(entry)
+
+        async with self.session as session:
+            policy = await _find_room_policy(room_id, session)
+
+            if policy is None:
+                raise authz_package.NoSuchRoomPolicy(room_id=room_id)
+
+            await policy.awaitable_attrs.acl_entries
+            for existing in list(policy.acl_entries):
+                if (
+                    (new_acl.everyone and existing.everyone)
+                    or (new_acl.authenticated and existing.authenticated)
+                    or (
+                        new_acl.json_path is not None
+                        and existing.json_path == new_acl.json_path
+                    )
+                ):
+                    await session.delete(existing)
+
+            new_acl.room_policy = policy
+            session.add(new_acl)
+
+    async def remove_acl_entry(
+        self,
+        room_id: str,
+        entry: models.ACLEntryUnchecked,
+    ) -> None:
+        """Remove the matching ACL entry from the room's policy.
+
+        Matches stored entries by 'allow_deny' and discriminator. 'entry'
+        is the unchecked model so a stored 'json_path' that no longer
+        compiles can still be matched; the entry is not re-validated.
+
+        Raises 'NoSuchRoomPolicy' if the room has no policy, or
+        'NoSuchACLEntry' if no stored entry matches.
+        """
+        everyone, authenticated, json_path = _entry_discriminator(entry)
+
+        async with self.session as session:
+            policy = await _find_room_policy(room_id, session)
+
+            if policy is None:
+                raise authz_package.NoSuchRoomPolicy(room_id=room_id)
+
+            await policy.awaitable_attrs.acl_entries
+            matches = [
+                existing
+                for existing in policy.acl_entries
+                if existing.allow_deny == entry.allow_deny
+                and (
+                    (everyone and existing.everyone)
+                    or (authenticated and existing.authenticated)
+                    or (
+                        json_path is not None
+                        and existing.json_path == json_path
+                    )
+                )
+            ]
+
+            if not matches:
+                raise authz_package.NoSuchACLEntry(room_id=room_id)
+
+            for existing in matches:
+                await session.delete(existing)
+
+    async def set_room_default(
+        self,
+        room_id: str,
+        allow_deny: authz_package.AllowDeny,
+    ) -> None:
+        """Set the room policy's 'default_allow_deny'.
+
+        Existing ACL entries are preserved. If the room has no policy, an
+        empty one is created with the given default.
+        """
+        async with self.session as session:
+            policy = await _find_room_policy(room_id, session)
+
+            if policy is None:
+                session.add(
+                    authz_schema.RoomPolicy(
+                        room_id=room_id,
+                        default_allow_deny=allow_deny,
+                    )
+                )
+            else:
+                policy.default_allow_deny = allow_deny

--- a/src/soliplex/authz/persistence.py
+++ b/src/soliplex/authz/persistence.py
@@ -275,6 +275,14 @@ class AuthorizationPolicy(authz_package.AuthorizationPolicy):
             policy = await _find_room_policy(room_id, session)
 
             if policy is not None:
+                # Load the ACL entries so the ORM 'delete' cascade removes
+                # them along with the policy. Without this they are only
+                # cleaned up by the DB-level 'ON DELETE CASCADE', which the
+                # async SQLite engine does not enforce -- leaving orphans
+                # that SQLite's primary-key reuse can re-attach to the next
+                # policy created for the same room.
+                await policy.awaitable_attrs.acl_entries
+
                 async with session.begin_nested():
                     await session.delete(policy)
 

--- a/src/soliplex/authz/schema.py
+++ b/src/soliplex/authz/schema.py
@@ -140,6 +140,19 @@ class RoomPolicy(Base):
             acl_entries=acl_entries,
         )
 
+    @property
+    def as_unchecked_model(self) -> models.RoomPolicyUnchecked:
+        # Like 'as_model' but builds the unchecked model, so a stored ACL
+        # entry whose 'json_path' no longer compiles does not raise.
+        acl_entries = [
+            acl_entry.as_unchecked_model for acl_entry in self.acl_entries
+        ]
+        return models.RoomPolicyUnchecked(
+            room_id=self.room_id,
+            default_allow_deny=self.default_allow_deny,
+            acl_entries=acl_entries,
+        )
+
     def check_token(
         self,
         user_token: authz_package.UserToken | None,
@@ -213,8 +226,7 @@ class ACLEntry(Base):
             json_path=json_path,
         )
 
-    @property
-    def as_model(self) -> models.ACLEntry:
+    def _model_kwargs(self) -> dict[str, str]:
         # Surface a stored 'preferred_username' / 'email' query back as
         # the matching public model field; leave general-purpose
         # queries as 'json_path'.
@@ -228,11 +240,26 @@ class ACLEntry(Base):
                 kwargs[parsed[0]] = parsed[1]
             else:
                 kwargs["json_path"] = self.json_path
+        return kwargs
+
+    @property
+    def as_model(self) -> models.ACLEntry:
         return models.ACLEntry(
             allow_deny=self.allow_deny,
             everyone=self.everyone,
             authenticated=self.authenticated,
-            **kwargs,
+            **self._model_kwargs(),
+        )
+
+    @property
+    def as_unchecked_model(self) -> models.ACLEntryUnchecked:
+        # Like 'as_model' but builds the unchecked model, so a stored
+        # 'json_path' that no longer compiles does not raise.
+        return models.ACLEntryUnchecked(
+            allow_deny=self.allow_deny,
+            everyone=self.everyone,
+            authenticated=self.authenticated,
+            **self._model_kwargs(),
         )
 
     def check_token(

--- a/src/soliplex/cli/admin_users.py
+++ b/src/soliplex/cli/admin_users.py
@@ -10,7 +10,6 @@ import typer
 import yaml
 
 from soliplex import authz as authz_package
-from soliplex.authz import persistence as authz_persistence
 from soliplex.cli import cli_util
 from soliplex.cli import types
 
@@ -361,7 +360,7 @@ def add_admin_user(
 
     try:
         discriminators = asyncio.run(_add_discriminator(dburi, resolved))
-    except authz_persistence.AdminUserExists:
+    except authz_package.AdminUserExists:
         the_console.rule(f"{_describe_admin(resolved)} is already an admin")
         the_console.print("Nothing to do.")
         raise typer.Exit(1) from None
@@ -428,7 +427,7 @@ def delete_admin_user(
 
     try:
         discriminators = asyncio.run(_remove_discriminator(dburi, resolved))
-    except authz_persistence.NoSuchAdminUser:
+    except authz_package.NoSuchAdminUser:
         the_console.rule(f"{_describe_admin(resolved)} is not an admin")
         the_console.print("Nothing to do.")
         raise typer.Exit(1) from None

--- a/src/soliplex/cli/cli_util.py
+++ b/src/soliplex/cli/cli_util.py
@@ -52,37 +52,23 @@ def _check_ram_dburi(dburi: str, command: str):
         raise typer.Exit(1)
 
 
-@contextlib.contextmanager
-def _authz_session(dburi):
-    """Yield a sync authz session, disposing its engine on exit.
-
-    'authz_schema.get_session' builds a fresh engine (and connection
-    pool) per call. Disposing it when the caller finishes -- on both the
-    success and 'typer.Exit' paths -- closes the underlying SQLite
-    connection deterministically instead of leaking it until garbage
-    collection.
-    """
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-    try:
-        yield session
-    finally:
-        session.get_bind().dispose()
-
-
 @contextlib.asynccontextmanager
 async def _authz_policy(dburi):
     """Yield an async 'AuthorizationPolicy', disposing its engine on exit.
 
-    The async analogue of '_authz_session': builds a fresh async engine
-    (creating the schema if needed) bound to a one-shot 'AuthorizationPolicy',
-    and disposes the engine on exit so the underlying SQLite connection is
-    released deterministically.
+    Builds a fresh async engine per call via
+    'installation._create_async_engine' -- the same factory the app's
+    lifespan uses -- so the CLI inherits its file-based-SQLite tuning,
+    notably 'PRAGMA foreign_keys=ON' (which enables the 'ON DELETE
+    CASCADE' behind room policy / ACL deletes). The schema is created if
+    needed, and the engine is disposed on exit -- on both the success and
+    'typer.Exit' paths -- so the underlying SQLite connection is released
+    deterministically instead of leaking it until garbage collection.
     """
-    engine = await authz_schema.get_async_engine(
-        engine_url=dburi,
-        init_schema=True,
-    )
+    engine = installation._create_async_engine(dburi)
     try:
+        async with engine.begin() as connection:
+            await connection.run_sync(authz_schema.Base.metadata.create_all)
         async with sqla_asyncio.AsyncSession(bind=engine) as session:
             yield authz_persistence.AuthorizationPolicy(session)
     finally:

--- a/src/soliplex/cli/room_authz.py
+++ b/src/soliplex/cli/room_authz.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import pathlib
 import sys
 import typing
+import warnings
 
 import typer
 import yaml
 
 from soliplex import authz as authz_package
 from soliplex import models
-from soliplex.authz import schema as authz_schema
 from soliplex.cli import cli_util
 from soliplex.cli import types
 
@@ -81,101 +82,79 @@ def _describe_discriminator(entry):
         return "everyone"
     if entry.authenticated:
         return "authenticated"
+    if entry.preferred_username is not None:
+        return f"preferred_username={entry.preferred_username}"
+    if entry.email is not None:
+        return f"email={entry.email}"
     if entry.json_path is not None:
-        parsed = authz_package.parse_token_field_json_path(entry.json_path)
-        if parsed is not None:
-            field, value = parsed
-            return f"{field}={value}"
         return f"json_path={entry.json_path}"
     return "(invalid: no discriminator set)"
 
 
-def _human_dump_room_policy(session, room_id):  # pragma NO COVER UI ONLY
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
-            )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
+def _human_dump_room_policy(room_id, policy):  # pragma NO COVER UI ONLY
+    the_console.rule(f"Room policy: {room_id}")
+
+    if policy is None:
+        the_console.print(
+            "No policy row exists. Room is in default public "
+            "state (all authenticated users allowed).",
+        )
+        return
+
+    if policy.default_allow_deny == authz_package.AllowDeny.DENY:
+        the_console.print(
+            "Default: DENY (private -- denies callers that don't "
+            "match an ALLOW entry).",
+        )
+    else:
+        the_console.print(
+            "Default: ALLOW (public-by-policy -- admits callers "
+            "that don't match a DENY entry).",
         )
 
-        the_console.rule(f"Room policy: {room_id}")
+    if not policy.acl_entries:
+        the_console.print("ACL entries: (none)")
+        return
 
-        if policy is None:
-            the_console.print(
-                "No policy row exists. Room is in default public "
-                "state (all authenticated users allowed).",
-            )
-            return
-
-        if policy.default_allow_deny == authz_package.AllowDeny.DENY:
-            the_console.print(
-                "Default: DENY (private -- denies callers that don't "
-                "match an ALLOW entry).",
-            )
-        else:
-            the_console.print(
-                "Default: ALLOW (public-by-policy -- admits callers "
-                "that don't match a DENY entry).",
-            )
-
-        if not policy.acl_entries:
-            the_console.print("ACL entries: (none)")
-            return
-
-        the_console.print(f"ACL entries ({len(policy.acl_entries)}):")
-        for index, entry in enumerate(policy.acl_entries, 1):
-            flag = entry.allow_deny.name
-            discriminator = _describe_discriminator(entry)
-            the_console.print(f"  {index}. {flag:<5}  {discriminator}")
+    the_console.print(f"ACL entries ({len(policy.acl_entries)}):")
+    for index, entry in enumerate(policy.acl_entries, 1):
+        flag = entry.allow_deny.name
+        discriminator = _describe_discriminator(entry)
+        the_console.print(f"  {index}. {flag:<5}  {discriminator}")
 
 
-def _dump(ctx, session, room_id):
+def _dump_room_policy(policy):  # pragma NO COVER UI ONLY
+    print(json.dumps(_room_policy_as_jsonable(policy)))
+
+
+def _dump(ctx, room_id, policy):
     if ctx.obj and ctx.obj.get("verbose"):
-        _human_dump_room_policy(session, room_id)
+        _human_dump_room_policy(room_id, policy)
     else:
-        _dump_room_policy(session, room_id)
+        _dump_room_policy(policy)
 
 
 def _acl_entry_as_jsonable(entry) -> dict:
-    """JSON-serializable view of an ACL row, tolerant of invalid paths.
+    """JSON-serializable view of an ACL entry.
 
-    Mirrors the shape of 'authz_schema.ACLEntry.as_model' (and hence
-    the public 'models.ACLEntry') but bypasses pydantic validation, so
-    a row whose stored 'json_path' no longer compiles (e.g. it
-    references a meta-config filter function that's no longer
-    registered) still renders cleanly.
+    'entry' is a 'models.ACLEntryUnchecked' (as returned by
+    'AuthorizationPolicy.get_room_policy_unchecked'), which already
+    surfaces the canonical 'preferred_username' / 'email' query as the
+    matching shortcut field and tolerates a stored 'json_path' that no
+    longer compiles. 'AllowDeny' is emitted as its member name.
     """
-    preferred_username = None
-    email = None
-    json_path = None
-    if entry.json_path is not None:
-        parsed = authz_package.parse_token_field_json_path(entry.json_path)
-        if parsed is not None and parsed[0] == "preferred_username":
-            preferred_username = parsed[1]
-        elif parsed is not None and parsed[0] == "email":
-            email = parsed[1]
-        else:
-            json_path = entry.json_path
     return {
         "allow_deny": entry.allow_deny.name,
         "everyone": entry.everyone,
         "authenticated": entry.authenticated,
-        "preferred_username": preferred_username,
-        "email": email,
-        "json_path": json_path,
+        "preferred_username": entry.preferred_username,
+        "email": entry.email,
+        "json_path": entry.json_path,
     }
 
 
 def _room_policy_as_jsonable(policy):
-    """Render a RoomPolicy (or None) as a JSON-serializable dict.
-
-    Built directly from the ORM rows rather than via 'policy.as_model'
-    so an entry whose stored 'json_path' no longer compiles does not
-    raise when dumping (the round-trip pydantic model would reject it).
+    """Render a 'RoomPolicyUnchecked' (or None) as a JSON-serializable dict.
 
     AllowDeny values are emitted as their member names ('ALLOW' /
     'DENY') rather than the default 'AllowDeny.ALLOW' /
@@ -193,7 +172,7 @@ def _room_policy_as_jsonable(policy):
 
 
 def _room_policy_as_yaml(policy) -> str:
-    """Render a RoomPolicy (or None) as a YAML document.
+    """Render a 'RoomPolicyUnchecked' (or None) as a YAML document.
 
     Uses the same JSON-serializable shape as the JSON dump, so the
     'AllowDeny' values are emitted as their member names.
@@ -236,20 +215,43 @@ def _effective_room_id(room_id, model) -> str | None:
     return None
 
 
-def _dump_room_policy(session, room_id):  # pragma NO COVER UI ONLY
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
-            )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
-        )
-        to_dump = _room_policy_as_jsonable(policy)
+async def _get_policy(dburi, room_id):
+    async with cli_util._authz_policy(dburi) as policy:
+        return await policy.get_room_policy_unchecked(room_id)
 
-    print(json.dumps(to_dump))
+
+async def _update_policy(dburi, room_id, model):
+    async with cli_util._authz_policy(dburi) as policy:
+        await policy.update_room_policy(room_id, model)
+
+
+async def _delete_policy(dburi, room_id):
+    async with cli_util._authz_policy(dburi) as policy:
+        await policy.delete_room_policy(room_id)
+
+
+async def _set_default(dburi, room_id, allow_deny):
+    async with cli_util._authz_policy(dburi) as policy:
+        await policy.set_room_default(room_id, allow_deny)
+        return await policy.get_room_policy_unchecked(room_id)
+
+
+async def _clear_acl(dburi, room_id):
+    async with cli_util._authz_policy(dburi) as policy:
+        await policy.clear_room_acl(room_id)
+        return await policy.get_room_policy_unchecked(room_id)
+
+
+async def _add_acl_entry(dburi, room_id, entry):
+    async with cli_util._authz_policy(dburi) as policy:
+        await policy.add_acl_entry(room_id, entry)
+        return await policy.get_room_policy_unchecked(room_id)
+
+
+async def _remove_acl_entry(dburi, room_id, entry):
+    async with cli_util._authz_policy(dburi) as policy:
+        await policy.remove_acl_entry(room_id, entry)
+        return await policy.get_room_policy_unchecked(room_id)
 
 
 @app.command("show")
@@ -268,14 +270,14 @@ def show_room_authz(
 ):
     """Show room ACL entries defined in the installation's authz database."""
     the_installation = cli_util.get_installation(installation_path)
-    dburi = the_installation.authorization_dburi_sync
+    dburi = the_installation.authorization_dburi_async
 
     cli_util._check_ram_dburi(dburi, "room-authz show")
     if not allow_stale:
         _check_room_id(the_installation, room_id)
 
-    with cli_util._authz_session(dburi) as session:
-        _dump(ctx, session, room_id)
+    policy = asyncio.run(_get_policy(dburi, room_id))
+    _dump(ctx, room_id, policy)
 
 
 @app.command("as-yaml")
@@ -311,24 +313,14 @@ def room_authz_as_yaml(
     A room with no RoomPolicy row dumps as 'null'.
     """
     the_installation = cli_util.get_installation(installation_path)
-    dburi = the_installation.authorization_dburi_sync
+    dburi = the_installation.authorization_dburi_async
 
     cli_util._check_ram_dburi(dburi, "room-authz as-yaml")
     if not allow_stale:
         _check_room_id(the_installation, room_id)
 
-    with cli_util._authz_session(dburi) as session:
-        with session:
-            policy = (
-                session.query(
-                    authz_schema.RoomPolicy,
-                )
-                .where(
-                    authz_schema.RoomPolicy.room_id == room_id,
-                )
-                .first()
-            )
-            yaml_text = _room_policy_as_yaml(policy)
+    policy = asyncio.run(_get_policy(dburi, room_id))
+    yaml_text = _room_policy_as_yaml(policy)
 
     if output is not None:
         output.write_text(yaml_text)
@@ -373,7 +365,7 @@ def room_authz_from_yaml(
     removes the target room's policy entirely.
     """
     the_installation = cli_util.get_installation(installation_path)
-    dburi = the_installation.authorization_dburi_sync
+    dburi = the_installation.authorization_dburi_async
 
     cli_util._check_ram_dburi(dburi, "room-authz from-yaml")
 
@@ -395,26 +387,10 @@ def room_authz_from_yaml(
 
     _check_room_id(the_installation, room_id)
 
-    with cli_util._authz_session(dburi) as session:
-        with session:
-            existing = (
-                session.query(
-                    authz_schema.RoomPolicy,
-                )
-                .where(
-                    authz_schema.RoomPolicy.room_id == room_id,
-                )
-                .first()
-            )
-            if existing is not None:
-                session.delete(existing)
-                session.commit()
-
-            if model is not None:
-                new_policy = authz_schema.RoomPolicy.from_model(model)
-                new_policy.room_id = room_id
-                session.add(new_policy)
-                session.commit()
+    if model is None:
+        asyncio.run(_delete_policy(dburi, room_id))
+    else:
+        asyncio.run(_update_policy(dburi, room_id, model))
 
 
 @app.command("make-private")
@@ -449,42 +425,33 @@ def make_room_private(
     policy is updated in place to DENY (ACL entries still preserved).
     """
     the_installation = cli_util.get_installation(installation_path)
-    dburi = the_installation.authorization_dburi_sync
+    dburi = the_installation.authorization_dburi_async
 
     cli_util._check_ram_dburi(dburi, "room-authz make-private")
     _check_room_id(the_installation, room_id)
 
-    with cli_util._authz_session(dburi) as session:
-        with session:
-            policy = (
-                session.query(
-                    authz_schema.RoomPolicy,
-                )
-                .where(
-                    authz_schema.RoomPolicy.room_id == room_id,
-                )
-                .first()
+    policy = asyncio.run(_get_policy(dburi, room_id))
+
+    if policy is None:
+        policy = asyncio.run(
+            _set_default(dburi, room_id, authz_package.AllowDeny.DENY)
+        )
+    elif policy.default_allow_deny == authz_package.AllowDeny.ALLOW:
+        if not update:
+            the_console.rule(
+                "Room policy already exists with default ALLOW",
             )
+            the_console.print(
+                f"Room '{room_id}' has an existing policy with "
+                "default_allow_deny=ALLOW; pass '--update' to "
+                "flip it to DENY.",
+            )
+            raise typer.Exit(1)
+        policy = asyncio.run(
+            _set_default(dburi, room_id, authz_package.AllowDeny.DENY)
+        )
 
-            if policy is None:
-                policy = authz_schema.RoomPolicy(room_id=room_id)
-                session.add(policy)
-                session.commit()
-            elif policy.default_allow_deny == authz_package.AllowDeny.ALLOW:
-                if not update:
-                    the_console.rule(
-                        "Room policy already exists with default ALLOW",
-                    )
-                    the_console.print(
-                        f"Room '{room_id}' has an existing policy with "
-                        "default_allow_deny=ALLOW; pass '--update' to "
-                        "flip it to DENY.",
-                    )
-                    raise typer.Exit(1)
-                policy.default_allow_deny = authz_package.AllowDeny.DENY
-                session.commit()
-
-        _dump(ctx, session, room_id)
+    _dump(ctx, room_id, policy)
 
 
 @app.command("make-public")
@@ -518,40 +485,31 @@ def make_room_public(
     policy is updated in place to ALLOW (ACL entries still preserved).
     """
     the_installation = cli_util.get_installation(installation_path)
-    dburi = the_installation.authorization_dburi_sync
+    dburi = the_installation.authorization_dburi_async
 
     cli_util._check_ram_dburi(dburi, "room-authz make-public")
     _check_room_id(the_installation, room_id)
 
-    with cli_util._authz_session(dburi) as session:
-        with session:
-            policy = (
-                session.query(
-                    authz_schema.RoomPolicy,
-                )
-                .where(
-                    authz_schema.RoomPolicy.room_id == room_id,
-                )
-                .first()
+    policy = asyncio.run(_get_policy(dburi, room_id))
+
+    if policy is not None and (
+        policy.default_allow_deny == authz_package.AllowDeny.DENY
+    ):
+        if not update:
+            the_console.rule(
+                "Room policy already exists with default DENY",
             )
+            the_console.print(
+                f"Room '{room_id}' has an existing policy with "
+                "default_allow_deny=DENY; pass '--update' to "
+                "flip it to ALLOW.",
+            )
+            raise typer.Exit(1)
+        policy = asyncio.run(
+            _set_default(dburi, room_id, authz_package.AllowDeny.ALLOW)
+        )
 
-            if policy is not None and (
-                policy.default_allow_deny == authz_package.AllowDeny.DENY
-            ):
-                if not update:
-                    the_console.rule(
-                        "Room policy already exists with default DENY",
-                    )
-                    the_console.print(
-                        f"Room '{room_id}' has an existing policy with "
-                        "default_allow_deny=DENY; pass '--update' to "
-                        "flip it to ALLOW.",
-                    )
-                    raise typer.Exit(1)
-                policy.default_allow_deny = authz_package.AllowDeny.ALLOW
-                session.commit()
-
-        _dump(ctx, session, room_id)
+    _dump(ctx, room_id, policy)
 
 
 @app.command("clear-acl")
@@ -571,29 +529,13 @@ def clear_room_acl(
     If no RoomPolicy exists for the room, the command is a no-op.
     """
     the_installation = cli_util.get_installation(installation_path)
-    dburi = the_installation.authorization_dburi_sync
+    dburi = the_installation.authorization_dburi_async
 
     cli_util._check_ram_dburi(dburi, "room-authz clear-acl")
     _check_room_id(the_installation, room_id)
 
-    with cli_util._authz_session(dburi) as session:
-        with session:
-            policy = (
-                session.query(
-                    authz_schema.RoomPolicy,
-                )
-                .where(
-                    authz_schema.RoomPolicy.room_id == room_id,
-                )
-                .first()
-            )
-
-            if policy is not None:
-                for acl_entry in policy.acl_entries:
-                    session.delete(acl_entry)
-                session.commit()
-
-        _dump(ctx, session, room_id)
+    policy = asyncio.run(_clear_acl(dburi, room_id))
+    _dump(ctx, room_id, policy)
 
 
 def _resolve_allow_deny(allow: bool, deny: bool) -> authz_package.AllowDeny:
@@ -674,7 +616,7 @@ def _check_acl_entry_args(
         allow_invalid=allow_invalid_json_path,
     )
 
-    dburi = the_installation.authorization_dburi_sync
+    dburi = the_installation.authorization_dburi_async
     cli_util._check_ram_dburi(dburi, command)
 
     return dburi, allow_deny, json_path
@@ -754,47 +696,25 @@ def add_acl_entry(
         "room-authz add-acl-entry",
     )
 
-    with cli_util._authz_session(dburi) as session:
-        with session:
-            policy = (
-                session.query(
-                    authz_schema.RoomPolicy,
-                )
-                .where(
-                    authz_schema.RoomPolicy.room_id == room_id,
-                )
-                .first()
-            )
+    entry = models.ACLEntry(
+        allow_deny=allow_deny,
+        everyone=everyone,
+        authenticated=authenticated,
+        json_path=json_path,
+    )
 
-            if policy is None:
-                the_console.rule(f"No policy exists for room '{room_id}'")
-                the_console.print(
-                    f"Run 'room-authz make-private' or "
-                    "'room-authz make-public' to establish a policy "
-                    f"for '{room_id}' before adding ACL entries.",
-                )
-                raise typer.Exit(1)
+    try:
+        policy = asyncio.run(_add_acl_entry(dburi, room_id, entry))
+    except authz_package.NoSuchRoomPolicy:
+        the_console.rule(f"No policy exists for room '{room_id}'")
+        the_console.print(
+            f"Run 'room-authz make-private' or "
+            "'room-authz make-public' to establish a policy "
+            f"for '{room_id}' before adding ACL entries.",
+        )
+        raise typer.Exit(1) from None
 
-            for entry in list(policy.acl_entries):
-                if everyone and entry.everyone:
-                    session.delete(entry)
-                elif authenticated and entry.authenticated:
-                    session.delete(entry)
-                elif json_path is not None and entry.json_path == json_path:
-                    session.delete(entry)
-            session.commit()
-
-            new_acl = authz_schema.ACLEntry(
-                room_policy=policy,
-                allow_deny=allow_deny,
-                everyone=everyone,
-                authenticated=authenticated,
-                json_path=json_path,
-            )
-            session.add(new_acl)
-            session.commit()
-
-        _dump(ctx, session, room_id)
+    _dump(ctx, room_id, policy)
 
 
 @app.command("delete-acl-entry")
@@ -877,52 +797,47 @@ def delete_acl_entry(
         allow_invalid_json_path=allow_invalid_json_path,
     )
 
-    with cli_util._authz_session(dburi) as session:
-        with session:
-            policy = (
-                session.query(
-                    authz_schema.RoomPolicy,
-                )
-                .where(
-                    authz_schema.RoomPolicy.room_id == room_id,
-                )
-                .first()
-            )
+    entry = models.ACLEntryUnchecked(
+        allow_deny=allow_deny,
+        everyone=everyone,
+        authenticated=authenticated,
+        json_path=json_path,
+    )
 
-            if policy is None:
-                the_console.rule(f"No policy exists for room '{room_id}'")
-                the_console.print(
-                    f"Room '{room_id}' has no RoomPolicy; nothing to delete.",
-                )
-                raise typer.Exit(1)
+    try:
+        policy = asyncio.run(_remove_acl_entry(dburi, room_id, entry))
+    except authz_package.NoSuchRoomPolicy:
+        the_console.rule(f"No policy exists for room '{room_id}'")
+        the_console.print(
+            f"Room '{room_id}' has no RoomPolicy; nothing to delete.",
+        )
+        raise typer.Exit(1) from None
+    except authz_package.NoSuchACLEntry:
+        the_console.rule("No matching ACL entry found")
+        the_console.print(
+            f"Room '{room_id}' has no ACL entry matching the "
+            "supplied --allow/--deny and discriminator.",
+        )
+        raise typer.Exit(1) from None
 
-            matches = []
-            for entry in policy.acl_entries:
-                if entry.allow_deny != allow_deny:
-                    continue
-                if everyone and entry.everyone:
-                    matches.append(entry)
-                elif authenticated and entry.authenticated:
-                    matches.append(entry)
-                elif json_path is not None and entry.json_path == json_path:
-                    matches.append(entry)
-
-            if not matches:
-                the_console.rule("No matching ACL entry found")
-                the_console.print(
-                    f"Room '{room_id}' has no ACL entry matching the "
-                    "supplied --allow/--deny and discriminator.",
-                )
-                raise typer.Exit(1)
-
-            for entry in matches:
-                session.delete(entry)
-            session.commit()
-
-        _dump(ctx, session, room_id)
+    _dump(ctx, room_id, policy)
 
 
 # Deprecated and hidden BBB commands.
+
+ADD_COMMAND_DEPRECATION = """\
+Deprecated: to be removed after `v0.71'.  Use 'add-acl-entry' instead.
+"""
+
+
+async def _add_user(dburi, room_id, entry):
+    async with cli_util._authz_policy(dburi) as policy:
+        if await policy.get_room_policy_unchecked(room_id) is None:
+            await policy.set_room_default(
+                room_id, authz_package.AllowDeny.DENY
+            )
+        await policy.add_acl_entry(room_id, entry)
+        return await policy.get_room_policy_unchecked(room_id)
 
 
 @app.command("add-user", hidden=True, deprecated=True)
@@ -931,51 +846,42 @@ def add_room_user(
     installation_path: types.installation_path_type,
     room_id: str,
     user_email: str,
-):  # pragma NO COVER command
+):
     """Add a user to the ACL for a room."""
+    warnings.warn(
+        ADD_COMMAND_DEPRECATION,
+        DeprecationWarning,
+        stacklevel=2,
+    )
     the_installation = cli_util.get_installation(installation_path)
-    dburi = the_installation.authorization_dburi_sync
+    dburi = the_installation.authorization_dburi_async
 
     cli_util._check_ram_dburi(dburi, "room-authz add-user")
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
+    json_path = authz_package.token_field_json_path("email", user_email)
+    entry = models.ACLEntry(
+        allow_deny=authz_package.AllowDeny.ALLOW,
+        json_path=json_path,
+    )
 
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
+    policy = asyncio.run(_add_user(dburi, room_id, entry))
+    _dump(ctx, room_id, policy)
+
+
+CLEAR_COMMAND_DEPRECATION = """\
+Deprecated: to be removed after `v0.71'.
+Use 'clear' plus either 'make-public' or 'make-private' instead.
+"""
+
+
+async def _clear(dburi, room_id, make_room_private):
+    async with cli_util._authz_policy(dburi) as policy:
+        await policy.delete_room_policy(room_id)
+        if make_room_private:
+            await policy.set_room_default(
+                room_id, authz_package.AllowDeny.DENY
             )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
-        )
-
-        if policy is None:
-            policy = authz_schema.RoomPolicy(room_id=room_id)
-            session.add(policy)
-            session.commit()
-
-        json_path = authz_package.token_field_json_path("email", user_email)
-
-        existing_acls = [
-            acl_entry
-            for acl_entry in policy.acl_entries
-            if acl_entry.json_path == json_path
-        ]
-        for to_remove in existing_acls:
-            session.delete(to_remove)
-        session.commit()
-
-        new_acl = authz_schema.ACLEntry(
-            room_policy=policy,
-            allow_deny=authz_package.AllowDeny.ALLOW,
-            json_path=json_path,
-        )
-        session.add(new_acl)
-        session.commit()
-
-    _dump_room_policy(session, room_id)
+        return await policy.get_room_policy_unchecked(room_id)
 
 
 @app.command("clear", hidden=True, deprecated=True)
@@ -988,7 +894,7 @@ def clear_room_authz(
         "--make-room-private",
         help="Make room private",
     ),
-):  # pragma NO COVER command
+):
     """Clear room ACL entries from the installation's authz database
 
     Unless '--make-room-private' is passed, the room will be in its
@@ -997,41 +903,15 @@ def clear_room_authz(
     If '--make-room-private' is passed, the room policy will be set to
     private (default_allow_deny of DENY), with no users.
     """
+    warnings.warn(
+        CLEAR_COMMAND_DEPRECATION,
+        DeprecationWarning,
+        stacklevel=2,
+    )
     the_installation = cli_util.get_installation(installation_path)
-    dburi = the_installation.authorization_dburi_sync
+    dburi = the_installation.authorization_dburi_async
 
     cli_util._check_ram_dburi(dburi, "room-authz clear")
 
-    session = authz_schema.get_session(engine_url=dburi, init_schema=True)
-
-    with session:
-        policy = (
-            session.query(
-                authz_schema.RoomPolicy,
-            )
-            .where(
-                authz_schema.RoomPolicy.room_id == room_id,
-            )
-            .first()
-        )
-
-        before_entries = len(session.query(authz_schema.ACLEntry).all())
-
-        should_remove = 0
-        if policy is not None:
-            # for acl_entry in policy.acl_entries:
-            #    session.delete(acl_entry)
-            should_remove = len(policy.acl_entries)
-
-            session.delete(policy)
-            session.commit()
-
-        after_entries = len(session.query(authz_schema.ACLEntry).all())
-        assert after_entries == before_entries - should_remove
-
-        if make_room_private:
-            policy = authz_schema.RoomPolicy(room_id=room_id)
-            session.add(policy)
-            session.commit()
-
-    _dump_room_policy(session, room_id)
+    policy = asyncio.run(_clear(dburi, room_id, make_room_private))
+    _dump(ctx, room_id, policy)

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -857,7 +857,7 @@ class AGUI_Threads(pydantic.BaseModel):
 # ----------------------------------------------------------------------------
 
 
-class ACLEntry(pydantic.BaseModel):
+class ACLEntryUnchecked(pydantic.BaseModel):
     allow_deny: authz_package.AllowDeny = authz_package.AllowDeny.DENY
     everyone: bool = False
     authenticated: bool = False
@@ -865,6 +865,8 @@ class ACLEntry(pydantic.BaseModel):
     email: str | None = None
     json_path: str | None = None
 
+
+class ACLEntry(ACLEntryUnchecked):
     @pydantic.field_validator("json_path")
     @classmethod
     def _check_json_path(cls, value: str | None) -> str | None:
@@ -888,9 +890,13 @@ class ACLEntry(pydantic.BaseModel):
         return self
 
 
-class RoomPolicy(pydantic.BaseModel):
+class RoomPolicyUnchecked(pydantic.BaseModel):
     room_id: str
     default_allow_deny: authz_package.AllowDeny = authz_package.AllowDeny.DENY
+    acl_entries: list[ACLEntryUnchecked] = pydantic.Field(default_factory=list)
+
+
+class RoomPolicy(RoomPolicyUnchecked):
     acl_entries: list[ACLEntry] = pydantic.Field(default_factory=list)
 
 

--- a/tests/functional/test_cli_smoketest.py
+++ b/tests/functional/test_cli_smoketest.py
@@ -33,6 +33,9 @@ _OLLAMA_ENV_RE = re.compile(r'^  - "OLLAMA_BASE_URL"$', re.MULTILINE)
 
 ALICE = "alice@example.com"
 ROLE_JP = '$[?$.role == "admin"]'
+# A room configured in 'example/minimal.yaml' whose agent needs no LLM, so
+# loading the installation for a 'room-authz' command requires no provider.
+ROOM = "faux"
 
 
 @pytest.fixture
@@ -61,20 +64,33 @@ def scratch_installation(tmp_path):
     return config_path
 
 
-def _cli(config_path, subcommand, *rest):
-    """Run 'admin-users <subcommand> <config> ...' via the real CLI binary."""
+def _run(config_path, group, subcommand, *rest, input_text=None):
+    """Run '<group> <subcommand> <config> ...' via the real CLI binary."""
     return subprocess.run(
         [
             sys.executable,
             "-m",
             "soliplex.cli.main",
-            "admin-users",
+            group,
             subcommand,
             str(config_path),
             *rest,
         ],
         capture_output=True,
         text=True,
+        input=input_text,
+    )
+
+
+def _cli(config_path, subcommand, *rest):
+    """Run an 'admin-users' subcommand via the real CLI binary."""
+    return _run(config_path, "admin-users", subcommand, *rest)
+
+
+def _room(config_path, subcommand, *rest, input_text=None):
+    """Run a 'room-authz' subcommand via the real CLI binary."""
+    return _run(
+        config_path, "room-authz", subcommand, *rest, input_text=input_text
     )
 
 
@@ -82,6 +98,12 @@ def _listed(result):
     """Parse the JSON 'admin_users' dump from the last line of stdout."""
     last = [line for line in result.stdout.splitlines() if line.strip()][-1]
     return json.loads(last)["admin_users"]
+
+
+def _policy(result):
+    """Parse the JSON room-policy dump from the last line of stdout."""
+    last = [line for line in result.stdout.splitlines() if line.strip()][-1]
+    return json.loads(last)
 
 
 def test_admin_users_smoketest(scratch_installation):
@@ -121,3 +143,69 @@ def test_admin_users_smoketest(scratch_installation):
     deleted = _cli(scratch_installation, "delete", ALICE)
     assert deleted.returncode == 0, deleted.stderr
     assert _listed(deleted) == [ROLE_JP]
+
+
+def test_room_authz_smoketest(scratch_installation):
+    # A faithful end-to-end run of the 'room-authz' subcommands against the
+    # real binary, ending with a delete-then-recreate that proves the async
+    # engine's 'PRAGMA foreign_keys=ON' cascades ACL rows (so no orphan
+    # re-attaches to the new policy via SQLite primary-key reuse). This is
+    # deliberately a single multi-step sequence (a smoke test), not a set of
+    # one-act unit tests.
+    private = _room(scratch_installation, "make-private", ROOM)
+    assert private.returncode == 0, private.stderr
+    assert _policy(private) == {
+        "room_id": ROOM,
+        "default_allow_deny": "DENY",
+        "acl_entries": [],
+    }
+
+    added = _room(
+        scratch_installation,
+        "add-acl-entry",
+        ROOM,
+        "--allow",
+        "--email",
+        ALICE,
+    )
+    assert added.returncode == 0, added.stderr
+    assert _policy(added)["acl_entries"] == [
+        {
+            "allow_deny": "ALLOW",
+            "everyone": False,
+            "authenticated": False,
+            "preferred_username": None,
+            "email": ALICE,
+            "json_path": None,
+        },
+    ]
+
+    shown = _room(scratch_installation, "show", ROOM)
+    assert shown.returncode == 0, shown.stderr
+    assert _policy(shown)["acl_entries"][0]["email"] == ALICE
+
+    dumped = _room(scratch_installation, "as-yaml", ROOM)
+    assert dumped.returncode == 0, dumped.stderr
+    assert yaml.safe_load(dumped.stdout)["acl_entries"][0]["email"] == ALICE
+
+    missing = _room(
+        scratch_installation,
+        "delete-acl-entry",
+        ROOM,
+        "--allow",
+        "--email",
+        "nobody@example.com",
+    )
+    assert missing.returncode == 1
+    assert "No matching ACL entry" in missing.stdout
+
+    # Drop the whole policy (with its ALLOW entry) via a 'null' from-yaml ...
+    dropped = _room(
+        scratch_installation, "from-yaml", ROOM, input_text="null\n"
+    )
+    assert dropped.returncode == 0, dropped.stderr
+
+    # ... then recreate it: the ALLOW entry must not resurface.
+    recreated = _room(scratch_installation, "make-private", ROOM)
+    assert recreated.returncode == 0, recreated.stderr
+    assert _policy(recreated)["acl_entries"] == []

--- a/tests/unit/authz/test_authz_persistence.py
+++ b/tests/unit/authz/test_authz_persistence.py
@@ -70,7 +70,7 @@ async def test_add_admin_user_discriminator_already_exists(the_async_session):
     the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
     await the_async_session.commit()
 
-    with pytest.raises(authz_persistence.AdminUserExists):
+    with pytest.raises(authz_package.AdminUserExists):
         await ap.add_admin_user_discriminator(ROLE_JSON_PATH)
 
 
@@ -90,7 +90,7 @@ async def test_remove_admin_user_discriminator(the_async_session):
 async def test_remove_admin_user_discriminator_absent(the_async_session):
     ap = authz_persistence.AuthorizationPolicy(the_async_session)
 
-    with pytest.raises(authz_persistence.NoSuchAdminUser):
+    with pytest.raises(authz_package.NoSuchAdminUser):
         await ap.remove_admin_user_discriminator(ROLE_JSON_PATH)
 
 
@@ -161,7 +161,7 @@ async def test_authorizationpolicy_crud_admin_user(the_async_session):
     assert found == [JSON_PATH]
     await the_async_session.commit()
 
-    with pytest.raises(authz_persistence.AdminUserExists):
+    with pytest.raises(authz_package.AdminUserExists):
         await ap.add_admin_user(email=EMAIL)
 
     no_dupe = await authz_persistence._find_admin_user_by_json_path(
@@ -187,7 +187,7 @@ async def test_authorizationpolicy_crud_admin_user(the_async_session):
     assert found == []
     await the_async_session.commit()
 
-    with pytest.raises(authz_persistence.NoSuchAdminUser):
+    with pytest.raises(authz_package.NoSuchAdminUser):
         await ap.remove_admin_user(email=EMAIL)
 
 
@@ -327,3 +327,304 @@ async def test_authorizationpolicy_room_policy_crud(the_async_session):
 
     await ap.delete_room_policy(ROOM_ID)
     await the_async_session.commit()
+
+
+ALLOW = authz_package.AllowDeny.ALLOW
+DENY = authz_package.AllowDeny.DENY
+STALE_JSON_PATH = "$[?stale_filter_func($.email)]"
+
+
+def _orm_entry(
+    allow_deny, *, everyone=False, authenticated=False, json_path=None
+):
+    return authz_schema.ACLEntry(
+        allow_deny=allow_deny,
+        everyone=everyone,
+        authenticated=authenticated,
+        json_path=json_path,
+    )
+
+
+async def _seed_policy(session, *, default=DENY, entries=()):
+    policy = authz_schema.RoomPolicy(
+        room_id=ROOM_ID, default_allow_deny=default
+    )
+    session.add(policy)
+    for entry in entries:
+        entry.room_policy = policy
+        session.add(entry)
+    await session.commit()
+    return policy
+
+
+async def _seed_stale_entry(session, *, allow_deny=ALLOW):
+    await _seed_policy(
+        session,
+        default=DENY,
+        entries=[_orm_entry(allow_deny, json_path=JSON_PATH)],
+    )
+    await session.execute(
+        sqla_sql.text(
+            "UPDATE room_acl_entries SET json_path = :stale "
+            "WHERE json_path = :placeholder"
+        ),
+        {"stale": STALE_JSON_PATH, "placeholder": JSON_PATH},
+    )
+    await session.commit()
+    session.expire_all()
+
+
+@pytest.mark.asyncio
+async def test_get_room_policy_unchecked_absent(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    found = await ap.get_room_policy_unchecked(ROOM_ID)
+
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_get_room_policy_unchecked_tolerates_stale_json_path(
+    the_async_session,
+):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_stale_entry(the_async_session)
+
+    found = await ap.get_room_policy_unchecked(ROOM_ID)
+
+    assert isinstance(found, models.RoomPolicyUnchecked)
+    assert [entry.json_path for entry in found.acl_entries] == [
+        STALE_JSON_PATH
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_room_policy_room_id_is_authoritative(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    policy_model = models.RoomPolicy(
+        room_id="some-other-room",
+        acl_entries=[models.ACLEntry(allow_deny=ALLOW, everyone=True)],
+    )
+
+    await ap.update_room_policy(ROOM_ID, policy_model)
+    await the_async_session.commit()
+
+    stored = await ap.get_room_policy(ROOM_ID)
+    assert stored is not None
+    assert stored.room_id == ROOM_ID
+    assert await ap.get_room_policy("some-other-room") is None
+
+
+@pytest.mark.asyncio
+async def test_clear_room_acl(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_policy(
+        the_async_session,
+        default=DENY,
+        entries=[
+            _orm_entry(ALLOW, everyone=True),
+            _orm_entry(DENY, authenticated=True),
+        ],
+    )
+
+    await ap.clear_room_acl(ROOM_ID)
+    await the_async_session.commit()
+
+    after = await ap.get_room_policy(ROOM_ID)
+    assert after.acl_entries == []
+    assert after.default_allow_deny == DENY
+
+
+@pytest.mark.asyncio
+async def test_clear_room_acl_no_policy(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    await ap.clear_room_acl(ROOM_ID)
+
+    assert await ap.get_room_policy(ROOM_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_add_acl_entry_to_policy(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_policy(the_async_session, default=DENY, entries=[])
+
+    await ap.add_acl_entry(
+        ROOM_ID, models.ACLEntry(allow_deny=ALLOW, everyone=True)
+    )
+    await the_async_session.commit()
+
+    after = await ap.get_room_policy(ROOM_ID)
+    assert [(e.allow_deny, e.everyone) for e in after.acl_entries] == [
+        (ALLOW, True)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_add_acl_entry_no_policy_raises(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    with pytest.raises(authz_package.NoSuchRoomPolicy):
+        await ap.add_acl_entry(
+            ROOM_ID, models.ACLEntry(allow_deny=ALLOW, everyone=True)
+        )
+
+
+@pytest.mark.parametrize(
+    "discriminator_kwargs",
+    [
+        {"everyone": True},
+        {"authenticated": True},
+        {"json_path": ROLE_JSON_PATH},
+    ],
+)
+@pytest.mark.asyncio
+async def test_add_acl_entry_replaces_same_discriminator(
+    the_async_session, discriminator_kwargs
+):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_policy(
+        the_async_session,
+        default=DENY,
+        entries=[_orm_entry(ALLOW, **discriminator_kwargs)],
+    )
+
+    await ap.add_acl_entry(
+        ROOM_ID, models.ACLEntry(allow_deny=DENY, **discriminator_kwargs)
+    )
+    await the_async_session.commit()
+
+    after = await ap.get_room_policy(ROOM_ID)
+    assert len(after.acl_entries) == 1
+    assert after.acl_entries[0].allow_deny == DENY
+
+
+@pytest.mark.asyncio
+async def test_add_acl_entry_keeps_other_discriminator(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_policy(
+        the_async_session,
+        default=DENY,
+        entries=[_orm_entry(ALLOW, everyone=True)],
+    )
+
+    await ap.add_acl_entry(
+        ROOM_ID, models.ACLEntry(allow_deny=DENY, json_path=ROLE_JSON_PATH)
+    )
+    await the_async_session.commit()
+
+    after = await ap.get_room_policy(ROOM_ID)
+    assert len(after.acl_entries) == 2
+
+
+@pytest.mark.parametrize(
+    "seed_kwargs, remove_kwargs",
+    [
+        ({"everyone": True}, {"everyone": True}),
+        ({"authenticated": True}, {"authenticated": True}),
+        ({"json_path": ROLE_JSON_PATH}, {"json_path": ROLE_JSON_PATH}),
+        (
+            {
+                "json_path": authz_package.token_field_json_path(
+                    "preferred_username", "phreddy"
+                )
+            },
+            {"preferred_username": "phreddy"},
+        ),
+        ({"json_path": JSON_PATH}, {"email": EMAIL}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_remove_acl_entry_matches_discriminator(
+    the_async_session, seed_kwargs, remove_kwargs
+):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_policy(
+        the_async_session,
+        default=DENY,
+        entries=[_orm_entry(ALLOW, **seed_kwargs)],
+    )
+
+    await ap.remove_acl_entry(
+        ROOM_ID, models.ACLEntryUnchecked(allow_deny=ALLOW, **remove_kwargs)
+    )
+    await the_async_session.commit()
+
+    after = await ap.get_room_policy(ROOM_ID)
+    assert after.acl_entries == []
+
+
+@pytest.mark.asyncio
+async def test_remove_acl_entry_no_match_raises(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_policy(
+        the_async_session,
+        default=DENY,
+        entries=[
+            _orm_entry(ALLOW, everyone=True),
+            _orm_entry(DENY, json_path=ROLE_JSON_PATH),
+        ],
+    )
+
+    with pytest.raises(authz_package.NoSuchACLEntry):
+        await ap.remove_acl_entry(
+            ROOM_ID,
+            models.ACLEntryUnchecked(
+                allow_deny=ALLOW, json_path=ROLE_JSON_PATH
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_remove_acl_entry_no_policy_raises(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    with pytest.raises(authz_package.NoSuchRoomPolicy):
+        await ap.remove_acl_entry(
+            ROOM_ID, models.ACLEntryUnchecked(allow_deny=ALLOW, everyone=True)
+        )
+
+
+@pytest.mark.asyncio
+async def test_remove_acl_entry_stale_json_path(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_stale_entry(the_async_session, allow_deny=ALLOW)
+
+    await ap.remove_acl_entry(
+        ROOM_ID,
+        models.ACLEntryUnchecked(allow_deny=ALLOW, json_path=STALE_JSON_PATH),
+    )
+    await the_async_session.commit()
+
+    after = await ap.get_room_policy(ROOM_ID)
+    assert after.acl_entries == []
+
+
+@pytest.mark.asyncio
+async def test_set_room_default_creates_when_missing(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+
+    await ap.set_room_default(ROOM_ID, ALLOW)
+    await the_async_session.commit()
+
+    after = await ap.get_room_policy(ROOM_ID)
+    assert after is not None
+    assert after.default_allow_deny == ALLOW
+    assert after.acl_entries == []
+
+
+@pytest.mark.asyncio
+async def test_set_room_default_updates_existing(the_async_session):
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_policy(
+        the_async_session,
+        default=DENY,
+        entries=[_orm_entry(ALLOW, everyone=True)],
+    )
+
+    await ap.set_room_default(ROOM_ID, ALLOW)
+    await the_async_session.commit()
+
+    after = await ap.get_room_policy(ROOM_ID)
+    assert after.default_allow_deny == ALLOW
+    assert len(after.acl_entries) == 1

--- a/tests/unit/authz/test_authz_persistence.py
+++ b/tests/unit/authz/test_authz_persistence.py
@@ -416,6 +416,28 @@ async def test_update_room_policy_room_id_is_authoritative(the_async_session):
 
 
 @pytest.mark.asyncio
+async def test_delete_room_policy_removes_acl_entries(the_async_session):
+    # Regression: the delete must cascade to the ACL entries. The async
+    # SQLite engine does not enforce the DB-level 'ON DELETE CASCADE', so
+    # an orphaned row would survive and -- via SQLite primary-key reuse --
+    # re-attach to the next policy created for the same room.
+    ap = authz_persistence.AuthorizationPolicy(the_async_session)
+    await _seed_policy(
+        the_async_session,
+        default=DENY,
+        entries=[_orm_entry(ALLOW, everyone=True)],
+    )
+
+    await ap.delete_room_policy(ROOM_ID)
+    await the_async_session.commit()
+
+    remaining = (
+        await the_async_session.scalars(sqla_sql.select(authz_schema.ACLEntry))
+    ).all()
+    assert remaining == []
+
+
+@pytest.mark.asyncio
 async def test_clear_room_acl(the_async_session):
     ap = authz_persistence.AuthorizationPolicy(the_async_session)
     await _seed_policy(

--- a/tests/unit/authz/test_authz_schema.py
+++ b/tests/unit/authz/test_authz_schema.py
@@ -1,7 +1,9 @@
 import datetime
 from unittest import mock
 
+import pydantic
 import pytest
+import sqlalchemy
 from sqlalchemy import orm as sqla_orm
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
@@ -144,6 +146,43 @@ def test_roompolicy_from_model(model_kwargs):
         assert f_entry.as_model == e_entry
 
 
+def test_roompolicy_as_unchecked_model(the_session):
+    policy = authz_schema.RoomPolicy(
+        room_id=ROOM_ID,
+        default_allow_deny=authz_package.AllowDeny.ALLOW,
+    )
+    authz_schema.ACLEntry(
+        room_policy=policy,
+        allow_deny=authz_package.AllowDeny.DENY,
+        everyone=True,
+    )
+    authz_schema.ACLEntry(
+        room_policy=policy,
+        allow_deny=authz_package.AllowDeny.ALLOW,
+        json_path=JSON_PATH,
+    )
+    the_session.add(policy)
+    the_session.commit()
+
+    unchecked = policy.as_unchecked_model
+
+    assert unchecked.room_id == ROOM_ID
+    assert unchecked.default_allow_deny == authz_package.AllowDeny.ALLOW
+    assert len(unchecked.acl_entries) == 2
+    assert (
+        models.ACLEntryUnchecked(
+            allow_deny=authz_package.AllowDeny.DENY, everyone=True
+        )
+        in unchecked.acl_entries
+    )
+    assert (
+        models.ACLEntryUnchecked(
+            allow_deny=authz_package.AllowDeny.ALLOW, email=EMAIL
+        )
+        in unchecked.acl_entries
+    )
+
+
 @pytest.mark.parametrize("token", [None, {}, {"foo": "bar"}])
 @pytest.mark.parametrize(
     "default_allow_deny",
@@ -256,6 +295,93 @@ def test_aclentry_from_model(the_session, the_room_policy, model_kwargs):
     the_session.commit()
 
     assert found.as_model == model
+
+
+STALE_JSON_PATH = "$[?stale_filter_func($.email)]"
+
+
+def _seed_stale_aclentry(the_session, the_room_policy):
+    """Plant an ACL entry whose stored 'json_path' no longer compiles.
+
+    The ORM's 'json_path' validator rejects a non-compiling query on
+    insert, so seed a valid placeholder query, then rewrite it to the
+    non-compiling value with a raw UPDATE (which skips '@validates') and
+    refresh the instance from the row.
+    """
+    entry = authz_schema.ACLEntry(
+        room_policy=the_room_policy,
+        allow_deny=authz_package.AllowDeny.ALLOW,
+        json_path=JSON_PATH,
+    )
+    the_session.add(the_room_policy)
+    the_session.add(entry)
+    the_session.commit()
+    the_session.execute(
+        sqlalchemy.text(
+            "UPDATE room_acl_entries SET json_path = :stale "
+            "WHERE json_path = :placeholder"
+        ),
+        {"stale": STALE_JSON_PATH, "placeholder": JSON_PATH},
+    )
+    the_session.commit()
+    the_session.refresh(entry)
+    return entry
+
+
+def test_aclentry_as_model_rejects_stale_json_path(
+    the_session, the_room_policy
+):
+    entry = _seed_stale_aclentry(the_session, the_room_policy)
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = entry.as_model
+
+
+@pytest.mark.parametrize(
+    "model_kwargs",
+    [
+        {"everyone": True, "allow_deny": authz_package.AllowDeny.DENY},
+        {"authenticated": True, "allow_deny": authz_package.AllowDeny.ALLOW},
+        {
+            "preferred_username": "phreddy",
+            "allow_deny": authz_package.AllowDeny.ALLOW,
+        },
+        {
+            "email": "phreddy@example.com",
+            "allow_deny": authz_package.AllowDeny.ALLOW,
+        },
+        {
+            "json_path": "$[?match($.foo, 'b.*z')]",
+            "allow_deny": authz_package.AllowDeny.ALLOW,
+        },
+    ],
+)
+def test_aclentry_as_unchecked_model(
+    the_session, the_room_policy, model_kwargs
+):
+    found = authz_schema.ACLEntry.from_model(
+        models.ACLEntry(**(ACL_ENTRY_DEFAULTS | model_kwargs))
+    )
+    found.room_policy = the_room_policy
+    the_session.add(the_room_policy)
+    the_session.add(found)
+    the_session.commit()
+
+    unchecked = found.as_unchecked_model
+
+    assert unchecked == models.ACLEntryUnchecked(
+        **(ACL_ENTRY_DEFAULTS | model_kwargs)
+    )
+
+
+def test_aclentry_as_unchecked_model_tolerates_stale_json_path(
+    the_session, the_room_policy
+):
+    entry = _seed_stale_aclentry(the_session, the_room_policy)
+
+    unchecked = entry.as_unchecked_model
+
+    assert unchecked.json_path == STALE_JSON_PATH
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli/test_cli_room_authz.py
+++ b/tests/unit/cli/test_cli_room_authz.py
@@ -116,75 +116,32 @@ def test__check_room_id(
 
 
 @pytest.mark.parametrize(
-    "w_attrs, exp_text",
+    "w_kwargs, exp_text",
     [
         # 'everyone' wins outright.
-        (
-            {
-                "everyone": True,
-                "authenticated": False,
-                "json_path": None,
-            },
-            "everyone",
-        ),
+        ({"everyone": True}, "everyone"),
         # ... even when other discriminators are also set.
         (
-            {
-                "everyone": True,
-                "authenticated": True,
-                "json_path": "$.foo",
-            },
+            {"everyone": True, "authenticated": True, "json_path": "$.foo"},
             "everyone",
         ),
         # 'authenticated' is the second priority.
-        (
-            {
-                "everyone": False,
-                "authenticated": True,
-                "json_path": None,
-            },
-            "authenticated",
-        ),
+        ({"authenticated": True}, "authenticated"),
+        # A 'preferred_username' entry (the model surfaces it directly).
+        ({"preferred_username": "alice"}, "preferred_username=alice"),
+        # An 'email' entry.
+        ({"email": "alice@example.com"}, "email=alice@example.com"),
         # A general-purpose query is shown verbatim.
         (
-            {
-                "everyone": False,
-                "authenticated": False,
-                "json_path": "$[?match($.foo, 'b.*z')]",
-            },
+            {"json_path": "$[?match($.foo, 'b.*z')]"},
             "json_path=$[?match($.foo, 'b.*z')]",
         ),
-        # A converted 'preferred_username' query is humanized back.
-        (
-            {
-                "everyone": False,
-                "authenticated": False,
-                "json_path": '$[?$.preferred_username == "alice"]',
-            },
-            "preferred_username=alice",
-        ),
-        # A converted 'email' query is humanized back.
-        (
-            {
-                "everyone": False,
-                "authenticated": False,
-                "json_path": '$[?$.email == "alice@example.com"]',
-            },
-            "email=alice@example.com",
-        ),
         # No discriminator set is treated as invalid (defensive).
-        (
-            {
-                "everyone": False,
-                "authenticated": False,
-                "json_path": None,
-            },
-            "(invalid: no discriminator set)",
-        ),
+        ({}, "(invalid: no discriminator set)"),
     ],
 )
-def test__describe_discriminator(w_attrs, exp_text):
-    entry = mock.Mock(**w_attrs)
+def test__describe_discriminator(w_kwargs, exp_text):
+    entry = models.ACLEntryUnchecked(**w_kwargs)
 
     found = cli_room_authz._describe_discriminator(entry)
 
@@ -214,15 +171,15 @@ def test__dump(
     exp_human,
 ):
     ctx.obj = w_obj
-    session = mock.Mock()
+    policy = mock.Mock()
 
-    cli_room_authz._dump(ctx, session, "room-1")
+    cli_room_authz._dump(ctx, "room-1", policy)
 
     if exp_human:
-        _human_dump_room_policy.assert_called_once_with(session, "room-1")
+        _human_dump_room_policy.assert_called_once_with("room-1", policy)
         _dump_room_policy.assert_not_called()
     else:
-        _dump_room_policy.assert_called_once_with(session, "room-1")
+        _dump_room_policy.assert_called_once_with(policy)
         _human_dump_room_policy.assert_not_called()
 
 
@@ -231,12 +188,16 @@ def _mock_acl_entry(
     allow_deny=authz_package.AllowDeny.DENY,
     everyone=False,
     authenticated=False,
+    preferred_username=None,
+    email=None,
     json_path=None,
 ):
-    return mock.Mock(
+    return models.ACLEntryUnchecked(
         allow_deny=allow_deny,
         everyone=everyone,
         authenticated=authenticated,
+        preferred_username=preferred_username,
+        email=email,
         json_path=json_path,
     )
 
@@ -271,11 +232,11 @@ def _mock_acl_entry(
                 "json_path": None,
             },
         ),
-        # Stored canonical 'preferred_username' query -> surfaced back.
+        # A 'preferred_username' entry (the model surfaces it directly).
         (
             {
                 "allow_deny": authz_package.AllowDeny.ALLOW,
-                "json_path": '$[?$.preferred_username == "alice"]',
+                "preferred_username": "alice",
             },
             {
                 "allow_deny": "ALLOW",
@@ -286,11 +247,11 @@ def _mock_acl_entry(
                 "json_path": None,
             },
         ),
-        # Stored canonical 'email' query -> surfaced back.
+        # An 'email' entry.
         (
             {
                 "allow_deny": authz_package.AllowDeny.ALLOW,
-                "json_path": '$[?$.email == "alice@example.com"]',
+                "email": "alice@example.com",
             },
             {
                 "allow_deny": "ALLOW",
@@ -301,7 +262,7 @@ def _mock_acl_entry(
                 "json_path": None,
             },
         ),
-        # General-purpose JSONPath: surface as 'json_path' verbatim.
+        # General-purpose JSONPath: passed through verbatim.
         (
             {
                 "allow_deny": authz_package.AllowDeny.DENY,
@@ -316,22 +277,8 @@ def _mock_acl_entry(
                 "json_path": "$[?match($.foo, 'b.*z')]",
             },
         ),
-        # Canonical-form-but-for-some-other-field: surface as 'json_path'.
-        (
-            {
-                "allow_deny": authz_package.AllowDeny.ALLOW,
-                "json_path": '$[?$.sub == "abc"]',
-            },
-            {
-                "allow_deny": "ALLOW",
-                "everyone": False,
-                "authenticated": False,
-                "preferred_username": None,
-                "email": None,
-                "json_path": '$[?$.sub == "abc"]',
-            },
-        ),
-        # Invalid stored 'json_path': dumped verbatim, no validation.
+        # A stored 'json_path' that no longer compiles: passed through
+        # (the unchecked model carries it without validation).
         (
             {
                 "allow_deny": authz_package.AllowDeny.DENY,
@@ -361,7 +308,7 @@ def test__room_policy_as_jsonable_none():
 
 
 def test__room_policy_as_jsonable_empty():
-    policy = mock.Mock(
+    policy = models.RoomPolicyUnchecked(
         room_id="chat",
         default_allow_deny=authz_package.AllowDeny.DENY,
         acl_entries=[],
@@ -378,14 +325,14 @@ def test__room_policy_as_jsonable_empty():
 
 def test__room_policy_as_jsonable_populated_w_invalid_json_path():
     # The middle entry's 'json_path' would fail compilation today;
-    # dumping must still succeed.
-    policy = mock.Mock(
+    # dumping must still succeed (the unchecked model carries it).
+    policy = models.RoomPolicyUnchecked(
         room_id="chat",
         default_allow_deny=authz_package.AllowDeny.ALLOW,
         acl_entries=[
             _mock_acl_entry(
                 allow_deny=authz_package.AllowDeny.ALLOW,
-                json_path='$[?$.email == "alice@example.com"]',
+                email="alice@example.com",
             ),
             _mock_acl_entry(
                 allow_deny=authz_package.AllowDeny.DENY,
@@ -437,13 +384,13 @@ def test__room_policy_as_yaml_none():
 
 
 def test__room_policy_as_yaml_populated():
-    policy = mock.Mock(
+    policy = models.RoomPolicyUnchecked(
         room_id="chat",
         default_allow_deny=authz_package.AllowDeny.ALLOW,
         acl_entries=[
             _mock_acl_entry(
                 allow_deny=authz_package.AllowDeny.ALLOW,
-                json_path='$[?$.email == "alice@example.com"]',
+                email="alice@example.com",
             ),
         ],
     )
@@ -598,7 +545,7 @@ def test__resolve_allow_deny_mutex_violation(
 def test__check_acl_entry_args(get_installation, _check_ram_dburi):
     the_installation = get_installation.return_value
     the_installation._config.room_configs = {"chat": mock.Mock()}
-    the_installation.authorization_dburi_sync = "sqlite:///fake.sqlite"
+    the_installation.authorization_dburi_async = "sqlite:///fake.sqlite"
 
     found = cli_room_authz._check_acl_entry_args(
         mock.sentinel.installation_path,
@@ -634,7 +581,7 @@ def test__check_acl_entry_args_allow_invalid_json_path(
 ):
     the_installation = get_installation.return_value
     the_installation._config.room_configs = {"chat": mock.Mock()}
-    the_installation.authorization_dburi_sync = "sqlite:///fake.sqlite"
+    the_installation.authorization_dburi_async = "sqlite:///fake.sqlite"
 
     bogus = "$[?stale_filter_func($.email)]"
 
@@ -665,11 +612,10 @@ def test__check_acl_entry_args_allow_invalid_json_path(
 # These drive the actual 'room-authz' subcommands through a Typer
 # 'CliRunner' against a throwaway copy of 'example/minimal.yaml' backed by
 # a scratch authorization database (see the 'scratch_installation' and
-# 'cli_runner' fixtures in 'tests/unit/cli/conftest.py'). Every active
-# command body is now exercised here rather than coverage-excluded; the
-# two '_*_dump_room_policy' helpers stay '# pragma NO COVER UI ONLY', and
-# the deprecated/hidden 'add-user' / 'clear' commands keep their
-# '# pragma NO COVER command'.
+# 'cli_runner' fixtures in 'tests/unit/cli/conftest.py'). Every command
+# body -- including the deprecated/hidden 'add-user' / 'clear' commands --
+# is now exercised here rather than coverage-excluded; only the two
+# '_*_dump_room_policy' helpers stay '# pragma NO COVER UI ONLY'.
 # ---------------------------------------------------------------------------
 
 ALLOW = authz_package.AllowDeny.ALLOW
@@ -1377,3 +1323,99 @@ def test_from_yaml_null_without_room_id_errors(
     )
 
     assert result.exit_code == 1
+
+
+# -- deprecated: add-user / clear -------------------------------------------
+
+
+def test_add_user_creates_policy_when_missing(
+    scratch_installation,
+    cli_runner,
+):
+    # No policy yet: 'add-user' creates an empty DENY policy, then adds an
+    # ALLOW entry for the email.
+    with pytest.warns(DeprecationWarning, match="Deprecated"):
+        result = _invoke(
+            cli_runner,
+            scratch_installation,
+            "add-user",
+            "chat",
+            ALICE_EMAIL,
+        )
+
+    assert result.exit_code == 0
+    assert _read_policy(scratch_installation, "chat") == {
+        "default": DENY,
+        "entries": {(ALLOW, False, False, ALICE_EMAIL_JP)},
+    }
+
+
+def test_add_user_existing_policy_preserves_default(
+    scratch_installation,
+    cli_runner,
+):
+    # An existing policy's default is left intact; the new ALLOW entry is
+    # added alongside the existing (different-discriminator) entry.
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        ALLOW,
+        [_entry(DENY, everyone=True)],
+    )
+
+    with pytest.warns(DeprecationWarning, match="Deprecated"):
+        result = _invoke(
+            cli_runner,
+            scratch_installation,
+            "add-user",
+            "chat",
+            ALICE_EMAIL,
+        )
+
+    assert result.exit_code == 0
+    assert _read_policy(scratch_installation, "chat") == {
+        "default": ALLOW,
+        "entries": {
+            (DENY, True, False, None),
+            (ALLOW, False, False, ALICE_EMAIL_JP),
+        },
+    }
+
+
+def test_clear_removes_policy(scratch_installation, cli_runner):
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        DENY,
+        [_entry(ALLOW, everyone=True)],
+    )
+
+    with pytest.warns(DeprecationWarning, match="Deprecated"):
+        result = _invoke(cli_runner, scratch_installation, "clear", "chat")
+
+    assert result.exit_code == 0
+    assert _read_policy(scratch_installation, "chat") is None
+
+
+def test_clear_make_room_private(scratch_installation, cli_runner):
+    _seed_policy(
+        scratch_installation,
+        "chat",
+        ALLOW,
+        [_entry(ALLOW, everyone=True)],
+    )
+
+    with pytest.warns(DeprecationWarning, match="Deprecated"):
+        result = _invoke(
+            cli_runner,
+            scratch_installation,
+            "clear",
+            "chat",
+            "--make-room-private",
+        )
+
+    assert result.exit_code == 0
+    assert _read_policy(scratch_installation, "chat") == {
+        "default": DENY,
+        "entries": set(),
+    }


### PR DESCRIPTION
refactor: hoist `models.{ACLEntry,RoomPolicy}Unchecked` as bases for `models.{ACLEntry,RoomPolicy`

   ... the new bases do not enforce that 'json_path' expressions can be validated, to permit
  examining / remediating entries after a software change.

feat: update 'authz.AuthorizationPolicy' to support finer-grained operations needed by CLI.

Closes #1081.