### PR TITLE
feat: audit-scoped log wrappers

### DIFF
--- a/src/soliplex/authz/__init__.py
+++ b/src/soliplex/authz/__init__.py
@@ -6,9 +6,7 @@ import json
 import re
 import typing
 
-import fastapi
 import jsonpath
-from sqlalchemy.ext import asyncio as sqla_asyncio
 
 # Avoid circular import when only used for typing
 # from soliplex import models
@@ -334,27 +332,3 @@ class RoomAuthorizationPolicy(abc.ABC):
     ) -> None:
         """Set the room policy's 'default_allow_deny', creating an empty
         policy if none exists."""
-
-
-async def get_the_admin_user_policy(
-    request: fastapi.Request,
-) -> AdminUserPolicy:
-    from . import persistence
-
-    engine = request.state.authorization_engine
-    async with sqla_asyncio.AsyncSession(bind=engine) as session:
-        yield persistence.AdminUserPolicy(session)
-
-
-async def get_the_room_authz_policy(
-    request: fastapi.Request,
-) -> RoomAuthorizationPolicy:
-    from . import persistence
-
-    engine = request.state.authorization_engine
-    async with sqla_asyncio.AsyncSession(bind=engine) as session:
-        yield persistence.RoomAuthorizationPolicy(session)
-
-
-depend_the_admin_user_policy = fastapi.Depends(get_the_admin_user_policy)
-depend_the_room_authz_policy = fastapi.Depends(get_the_room_authz_policy)

--- a/src/soliplex/authz/persistence.py
+++ b/src/soliplex/authz/persistence.py
@@ -6,11 +6,13 @@ Implements 'authz.AdminUserPolicy' and 'authz.RoomAuthorizationPolicy'.
 from __future__ import annotations
 
 import contextlib
+import typing
 
 from sqlalchemy import sql as sqla_sql
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import authz
+from soliplex import loggers
 from soliplex import models
 from soliplex.authz import schema as authz_schema
 
@@ -83,6 +85,14 @@ class _SessionPolicy:
 
 
 class AdminUserPolicy(_SessionPolicy, authz.AdminUserPolicy):
+    def __init__(
+        self,
+        session: sqla_asyncio.AsyncSession,
+        claims: dict[str, typing.Any],
+    ):
+        super().__init__(session)
+        self._audit = loggers.AdminUsersAuditLog(claims=claims)
+
     async def list_admin_user_discriminators(self) -> list[str]:
         """List JSONPath discriminators which identify admin users.
 
@@ -92,10 +102,12 @@ class AdminUserPolicy(_SessionPolicy, authz.AdminUserPolicy):
         """
         query = sqla_sql.select(authz_schema.AdminUser)
         async with self.session as session:
-            return [
+            discriminators = [
                 admin_user.json_path
                 for admin_user in await session.scalars(query)
             ]
+        self._audit.admin_users_listed()
+        return discriminators
 
     async def add_admin_user_discriminator(self, json_path: str):
         """Add a user discriminator to the admin users table.
@@ -108,10 +120,13 @@ class AdminUserPolicy(_SessionPolicy, authz.AdminUserPolicy):
             user = await _find_admin_user_by_json_path(json_path, session)
 
             if user is not None:
-                raise authz.AdminUserExists(json_path=json_path)
+                exc = authz.AdminUserExists(json_path=json_path)
+                self._audit.admin_user_add_failed(json_path, reason=str(exc))
+                raise exc
 
             user = authz_schema.AdminUser(json_path=json_path)
             session.add(user)
+        self._audit.admin_user_added(json_path)
 
     async def remove_admin_user_discriminator(self, json_path: str):
         """Remove a user discriminator from the admin users table.
@@ -124,9 +139,14 @@ class AdminUserPolicy(_SessionPolicy, authz.AdminUserPolicy):
             user = await _find_admin_user_by_json_path(json_path, session)
 
             if user is None:
-                raise authz.NoSuchAdminUser(json_path=json_path)
+                exc = authz.NoSuchAdminUser(json_path=json_path)
+                self._audit.admin_user_remove_failed(
+                    json_path, reason=str(exc)
+                )
+                raise exc
 
             await session.delete(user)
+        self._audit.admin_user_removed(json_path)
 
     async def clear_admin_user_discriminators(self):
         """Remove all admin user discriminators from the admin users table."""
@@ -134,6 +154,7 @@ class AdminUserPolicy(_SessionPolicy, authz.AdminUserPolicy):
         async with self.session as session:
             for admin_user in await session.scalars(query):
                 await session.delete(admin_user)
+        self._audit.admin_users_cleared()
 
     async def list_admin_users(self) -> list[str]:
         """Deprecated alias for 'list_admin_user_discriminators'."""
@@ -163,10 +184,23 @@ class AdminUserPolicy(_SessionPolicy, authz.AdminUserPolicy):
     ) -> bool:
         """Is the user represented by 'user_token' an admin user?"""
         async with self.session as session:
-            return await _user_is_admin(user_token, session)
+            is_admin = await _user_is_admin(user_token, session)
+        if is_admin:
+            self._audit.admin_access_allowed()
+        else:
+            self._audit.admin_access_denied()
+        return is_admin
 
 
 class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
+    def __init__(
+        self,
+        session: sqla_asyncio.AsyncSession,
+        claims: dict[str, typing.Any],
+    ):
+        super().__init__(session)
+        self._audit = loggers.RoomAuthzAuditLog(claims=claims)
+
     async def check_room_access(
         self,
         room_id: str,
@@ -224,9 +258,11 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
 
             if policy is not None:
                 await policy.awaitable_attrs.acl_entries
-                return policy.as_model
-
-        return None
+                result = policy.as_model
+            else:
+                result = None
+        self._audit.room_policy_read(room_id)
+        return result
 
     async def get_room_policy_unchecked(
         self,
@@ -244,9 +280,11 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
 
             if policy is not None:
                 await policy.awaitable_attrs.acl_entries
-                return policy.as_unchecked_model
-
-        return None
+                result = policy.as_unchecked_model
+            else:
+                result = None
+        self._audit.room_policy_read(room_id)
+        return result
 
     async def list_room_policies(
         self,
@@ -263,7 +301,9 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
             policies = list(await session.scalars(query))
             for policy in policies:
                 await policy.awaitable_attrs.acl_entries
-            return [policy.as_unchecked_model for policy in policies]
+            result = [policy.as_unchecked_model for policy in policies]
+        self._audit.room_policies_listed()
+        return result
 
     async def update_room_policy(
         self,
@@ -290,6 +330,7 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
             async with session.begin_nested():
                 session.add(new_policy)
 
+        self._audit.room_policy_updated(room_id)
         return None
 
     async def delete_room_policy(
@@ -312,6 +353,8 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
                 async with session.begin_nested():
                     await session.delete(policy)
 
+        self._audit.room_policy_deleted(room_id)
+
     async def clear_room_acl(self, room_id: str) -> None:
         """Remove all ACL entries from the room's policy.
 
@@ -325,6 +368,7 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
                 await policy.awaitable_attrs.acl_entries
                 for acl_entry in list(policy.acl_entries):
                     await session.delete(acl_entry)
+        self._audit.acl_cleared(room_id)
 
     async def add_acl_entry(
         self,
@@ -343,7 +387,11 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
             policy = await _find_room_policy(room_id, session)
 
             if policy is None:
-                raise authz.NoSuchRoomPolicy(room_id=room_id)
+                exc = authz.NoSuchRoomPolicy(room_id=room_id)
+                self._audit.acl_entry_add_failed(
+                    room_id, entry, reason=str(exc)
+                )
+                raise exc
 
             await policy.awaitable_attrs.acl_entries
             for existing in list(policy.acl_entries):
@@ -359,6 +407,7 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
 
             new_acl.room_policy = policy
             session.add(new_acl)
+        self._audit.acl_entry_added(room_id, entry)
 
     async def remove_acl_entry(
         self,
@@ -380,7 +429,11 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
             policy = await _find_room_policy(room_id, session)
 
             if policy is None:
-                raise authz.NoSuchRoomPolicy(room_id=room_id)
+                exc = authz.NoSuchRoomPolicy(room_id=room_id)
+                self._audit.acl_entry_remove_failed(
+                    room_id, entry, reason=str(exc)
+                )
+                raise exc
 
             await policy.awaitable_attrs.acl_entries
             matches = [
@@ -398,10 +451,15 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
             ]
 
             if not matches:
-                raise authz.NoSuchACLEntry(room_id=room_id)
+                exc = authz.NoSuchACLEntry(room_id=room_id)
+                self._audit.acl_entry_remove_failed(
+                    room_id, entry, reason=str(exc)
+                )
+                raise exc
 
             for existing in matches:
                 await session.delete(existing)
+        self._audit.acl_entry_removed(room_id, entry)
 
     async def set_room_default(
         self,
@@ -425,3 +483,4 @@ class RoomAuthorizationPolicy(_SessionPolicy, authz.RoomAuthorizationPolicy):
                 )
             else:
                 policy.default_allow_deny = allow_deny
+        self._audit.room_default_set(room_id, allow_deny)

--- a/src/soliplex/cli/cli_util.py
+++ b/src/soliplex/cli/cli_util.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import contextlib
+import getpass
+import os
 import pathlib
 
 import typer
@@ -75,18 +77,34 @@ async def _authz_session(dburi):
         await engine.dispose()
 
 
+def _audit_claims() -> dict[str, str]:
+    """Audit-log actor claims for CLI operations.
+
+    The CLI has no OIDC principal, so the actor is the operator running
+    'soliplex-cli': 'SOLIPLEX_AUDIT_ACTOR' if set, else the OS login name.
+    The policy objects fold these claims into every audit record they emit,
+    so CLI and REST mutations land in the same durable audit log.
+    """
+    return {
+        "source": "cli",
+        "actor": os.environ.get("SOLIPLEX_AUDIT_ACTOR", getpass.getuser()),
+    }
+
+
 @contextlib.asynccontextmanager
 async def _admin_user_policy(dburi):
     """Yield an async 'AdminUserPolicy' (see '_authz_session')."""
     async with _authz_session(dburi) as session:
-        yield authz_persistence.AdminUserPolicy(session)
+        yield authz_persistence.AdminUserPolicy(session, _audit_claims())
 
 
 @contextlib.asynccontextmanager
 async def _room_authz_policy(dburi):
     """Yield an async 'RoomAuthorizationPolicy' (see '_authz_session')."""
     async with _authz_session(dburi) as session:
-        yield authz_persistence.RoomAuthorizationPolicy(session)
+        yield authz_persistence.RoomAuthorizationPolicy(
+            session, _audit_claims()
+        )
 
 
 def _check_exactly_one_discriminator(

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -575,6 +575,10 @@ async def lifespan(
 
     apply_logfire_configuration(app, the_installation, disable_logfire_console)
 
+    # Logging is now configured, so the audit log reaches its handlers.
+    audit_log = loggers.ProcessLifetimeAuditLog()
+    audit_log.server_starting()
+
     agui_engine = _create_async_engine(
         the_installation.thread_persistence_dburi_async,
         json_serializer=util.serialize_sqla_json,
@@ -633,7 +637,11 @@ async def lifespan(
             await stack.enter_async_context(mcp_lifespan)
             app.mount(f"/mcp/{mcp_name}", mcp_app, name=f"mcp_{mcp_name}")
 
+        audit_log.server_started()
+
         yield context
+
+        audit_log.server_stopping()
 
     await agui_engine.dispose()
     await authz_engine.dispose()

--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import enum
 import logging
+import typing
+
+# from soliplex import authn
 
 SOLIPLEX_LOGGER_NAME = "soliplex"
 
@@ -82,23 +86,52 @@ ROOM_UNKNOWN_CHUNK_ID = "unknown chunk id"
 STATS_GET_ROOMS_STATS = "get rooms stats"
 STATS_GET_ROOM_STATS = "get room stats"
 
+SOLIPLEX_AUDIT_LOGGER_NAME = "soliplex-audit"
+SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA = "audit-scope"
+SOLIPLEX_AUDIT_LOGGER_OUTCOME_EXTRA = "outcome"
 
-class LogWrapper(logging.LoggerAdapter):
-    """Context wrapper for capturing extra logging values"""
+# Outcome values folded into every audit record's 'outcome' field, so a
+# reviewer can split successful operations from denied / failed ones.
+AUDIT_OUTCOME_SUCCESS = "success"
+AUDIT_OUTCOME_DENIED = "denied"
+AUDIT_OUTCOME_ERROR = "error"
+
+# admin-users audit events
+AUDIT_ADMIN_ACCESS = "admin access"
+AUDIT_ADMIN_USERS_LISTED = "admin users listed"
+AUDIT_ADMIN_USER_ADDED = "admin user added"
+AUDIT_ADMIN_USER_REMOVED = "admin user removed"
+AUDIT_ADMIN_USERS_CLEARED = "admin users cleared"
+
+# room-authz audit events
+AUDIT_ROOM_POLICY_READ = "room policy read"
+AUDIT_ROOM_POLICIES_LISTED = "room policies listed"
+AUDIT_ROOM_POLICY_UPDATED = "room policy updated"
+AUDIT_ROOM_POLICY_DELETED = "room policy deleted"
+AUDIT_ROOM_ACL_ENTRY_ADDED = "room acl entry added"
+AUDIT_ROOM_ACL_ENTRY_REMOVED = "room acl entry removed"
+AUDIT_ROOM_ACL_CLEARED = "room acl cleared"
+AUDIT_ROOM_DEFAULT_SET = "room default set"
+
+# installation-config audit events
+AUDIT_INSTALLATION_READ = "installation read"
+AUDIT_INSTALLATION_VERSIONS_READ = "installation versions read"
+AUDIT_INSTALLATION_PROVIDERS_READ = "installation providers read"
+AUDIT_INSTALLATION_GIT_METADATA_READ = "installation git metadata read"
+
+# server-lifecycle audit events
+AUDIT_SERVER_STARTING = "server starting"
+AUDIT_SERVER_STARTED = "server started"
+AUDIT_SERVER_STOPPING = "server stopping"
+
+
+class _StructuredFieldsAdapter(logging.LoggerAdapter):
+    """LoggerAdapter that folds caller keyword fields into 'extra'."""
 
     # Keyword arguments the stdlib logging machinery consumes itself; any
     # other keyword passed to a log call is a structured field destined for
     # the record's 'extra' rather than the logger.
     _LOG_KWARGS = frozenset({"exc_info", "stack_info", "stacklevel", "extra"})
-
-    def __init__(self, logger_name, the_installation, **extra):
-        self.logger_name = logger_name
-        self.installation = the_installation
-        logger = logging.getLogger(logger_name)
-        try:
-            super().__init__(logger, extra=extra, merge_extra=True)
-        except TypeError:  # pragma: NO COVER Python < 3.13
-            super().__init__(logger, extra=extra)
 
     def process(self, msg, kwargs):
         """Fold caller-supplied keyword fields into the record's 'extra'.
@@ -118,6 +151,19 @@ class LogWrapper(logging.LoggerAdapter):
         }
         kwargs["extra"] = {**self.extra, **kwargs.get("extra", {}), **fields}
         return msg, kwargs
+
+
+class LogWrapper(_StructuredFieldsAdapter):
+    """Context wrapper for capturing extra logging values"""
+
+    def __init__(self, logger_name, the_installation, **extra):
+        self.logger_name = logger_name
+        self.installation = the_installation
+        logger = logging.getLogger(logger_name)
+        try:
+            super().__init__(logger, extra=extra, merge_extra=True)
+        except TypeError:  # pragma: NO COVER Python < 3.13
+            super().__init__(logger, extra=extra)
 
     def bind(self, logger_name=None, **extra) -> LogWrapper:
         if logger_name is None:
@@ -194,3 +240,189 @@ class UpdateLevels(logging.Filter):
             log_record.levelname = logging.getLevelName(after)
 
         return log_record
+
+
+class AuditLogScopes(enum.StrEnum):
+    PROCESS_LIFETIME = "process-lifetime"
+    ROOM_AUTHZ = "room-authz"
+    ADMIN_USERS = "admin-users"
+    INSTALLATION_CONFIG = "installation-config"
+    RAG_ACCESS = "rag-access"
+
+
+class AuditLogWrapper(_StructuredFieldsAdapter):
+    """Context wrapper for capturing audit-related logging values.
+
+    Subclasses bind a fixed 'AuditLogScopes' and expose one named method per
+    auditable action (the API that "spells out required / optional values").
+    Each action records its 'outcome' so a reviewer can split successful
+    operations from denied (authorization refused) or failed (validation /
+    not-found) ones. Successes log at INFO; denials and failures at ERROR.
+    """
+
+    def __init__(self, *, scope: AuditLogScopes | None = None, **extra):
+        extra_w_scope = {
+            SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA: scope,
+        } | extra
+
+        logger = logging.getLogger(SOLIPLEX_AUDIT_LOGGER_NAME)
+        try:
+            super().__init__(logger, extra=extra_w_scope, merge_extra=True)
+        except TypeError:  # pragma: NO COVER Python < 3.13
+            super().__init__(logger, extra=extra_w_scope)
+
+    def _succeeded(self, message: str, **fields):
+        self.info(message, outcome=AUDIT_OUTCOME_SUCCESS, **fields)
+
+    def _denied(self, message: str, **fields):
+        self.error(message, outcome=AUDIT_OUTCOME_DENIED, **fields)
+
+    def _failed(self, message: str, **fields):
+        self.error(message, outcome=AUDIT_OUTCOME_ERROR, **fields)
+
+
+class ProcessLifetimeAuditLog(AuditLogWrapper):
+    def __init__(self, **extra):
+        super().__init__(scope=AuditLogScopes.PROCESS_LIFETIME, **extra)
+
+    def server_starting(self):
+        self._succeeded(AUDIT_SERVER_STARTING)
+
+    def server_started(self):
+        self._succeeded(AUDIT_SERVER_STARTED)
+
+    def server_stopping(self):
+        self._succeeded(AUDIT_SERVER_STOPPING)
+
+
+class RoomAuthzAuditLog(AuditLogWrapper):
+    def __init__(self, claims: dict[str, typing.Any], **extra):
+        extra_with_claims = {"claims": claims} | extra
+        super().__init__(scope=AuditLogScopes.ROOM_AUTHZ, **extra_with_claims)
+
+    # security-object reads
+    def room_policy_read(self, room_id: str):
+        self._succeeded(AUDIT_ROOM_POLICY_READ, room_id=room_id)
+
+    def room_policies_listed(self):
+        self._succeeded(AUDIT_ROOM_POLICIES_LISTED)
+
+    # policy modification
+    def room_policy_updated(self, room_id: str):
+        self._succeeded(AUDIT_ROOM_POLICY_UPDATED, room_id=room_id)
+
+    def room_policy_update_failed(self, room_id: str, reason: str):
+        self._failed(AUDIT_ROOM_POLICY_UPDATED, room_id=room_id, reason=reason)
+
+    def room_default_set(self, room_id: str, allow_deny: str):
+        self._succeeded(
+            AUDIT_ROOM_DEFAULT_SET, room_id=room_id, allow_deny=allow_deny
+        )
+
+    # policy / security-object deletion
+    def room_policy_deleted(self, room_id: str):
+        self._succeeded(AUDIT_ROOM_POLICY_DELETED, room_id=room_id)
+
+    def room_policy_delete_failed(self, room_id: str, reason: str):
+        self._failed(AUDIT_ROOM_POLICY_DELETED, room_id=room_id, reason=reason)
+
+    # room-access grant
+    def acl_entry_added(self, room_id: str, entry: str):
+        self._succeeded(
+            AUDIT_ROOM_ACL_ENTRY_ADDED, room_id=room_id, entry=entry
+        )
+
+    def acl_entry_add_failed(self, room_id: str, entry: str, reason: str):
+        self._failed(
+            AUDIT_ROOM_ACL_ENTRY_ADDED,
+            room_id=room_id,
+            entry=entry,
+            reason=reason,
+        )
+
+    # room-access revoke
+    def acl_entry_removed(self, room_id: str, entry: str):
+        self._succeeded(
+            AUDIT_ROOM_ACL_ENTRY_REMOVED, room_id=room_id, entry=entry
+        )
+
+    def acl_entry_remove_failed(self, room_id: str, entry: str, reason: str):
+        self._failed(
+            AUDIT_ROOM_ACL_ENTRY_REMOVED,
+            room_id=room_id,
+            entry=entry,
+            reason=reason,
+        )
+
+    def acl_cleared(self, room_id: str):
+        self._succeeded(AUDIT_ROOM_ACL_CLEARED, room_id=room_id)
+
+
+class AdminUsersAuditLog(AuditLogWrapper):
+    def __init__(self, claims: dict[str, typing.Any], **extra):
+        extra_with_claims = {"claims": claims} | extra
+        super().__init__(scope=AuditLogScopes.ADMIN_USERS, **extra_with_claims)
+
+    # privilege gate
+    def admin_access_allowed(self):
+        self._succeeded(AUDIT_ADMIN_ACCESS)
+
+    def admin_access_denied(self):
+        self._denied(AUDIT_ADMIN_ACCESS)
+
+    # security-object read
+    def admin_users_listed(self):
+        self._succeeded(AUDIT_ADMIN_USERS_LISTED)
+
+    # privilege grant
+    def admin_user_added(self, discriminator: str):
+        self._succeeded(AUDIT_ADMIN_USER_ADDED, discriminator=discriminator)
+
+    def admin_user_add_failed(self, discriminator: str, reason: str):
+        self._failed(
+            AUDIT_ADMIN_USER_ADDED, discriminator=discriminator, reason=reason
+        )
+
+    # privilege revoke
+    def admin_user_removed(self, discriminator: str):
+        self._succeeded(AUDIT_ADMIN_USER_REMOVED, discriminator=discriminator)
+
+    def admin_user_remove_failed(self, discriminator: str, reason: str):
+        self._failed(
+            AUDIT_ADMIN_USER_REMOVED,
+            discriminator=discriminator,
+            reason=reason,
+        )
+
+    def admin_users_cleared(self):
+        self._succeeded(AUDIT_ADMIN_USERS_CLEARED)
+
+
+class InstallationConfigAuditLog(AuditLogWrapper):
+    def __init__(self, claims: dict[str, typing.Any], **extra):
+        extra_with_claims = {"claims": claims} | extra
+        super().__init__(
+            scope=AuditLogScopes.INSTALLATION_CONFIG, **extra_with_claims
+        )
+
+    # privileged-config reads
+    def installation_read(self):
+        self._succeeded(AUDIT_INSTALLATION_READ)
+
+    def installation_versions_read(self):
+        self._succeeded(AUDIT_INSTALLATION_VERSIONS_READ)
+
+    def installation_providers_read(self):
+        self._succeeded(AUDIT_INSTALLATION_PROVIDERS_READ)
+
+    def installation_git_metadata_read(self):
+        self._succeeded(AUDIT_INSTALLATION_GIT_METADATA_READ)
+
+
+class RAGAccessAuditLog(AuditLogWrapper):
+    # Deferred (rag-access out of scope pending the haiku-rag approach); the
+    # scope and class exist so the audit vocabulary is complete, but no events
+    # are wired yet.
+    def __init__(self, claims: dict[str, typing.Any], **extra):
+        extra_with_claims = {"claims": claims} | extra
+        super().__init__(scope=AuditLogScopes.RAG_ACCESS, **extra_with_claims)

--- a/src/soliplex/views/__init__.py
+++ b/src/soliplex/views/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import fastapi
 from fastapi import responses
 from fastapi import security
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import authn as authn_module
 from soliplex import installation as installation_module
@@ -80,6 +81,37 @@ async def get_the_logger(
 
 
 depend_the_logger = fastapi.Depends(get_the_logger)
+
+
+async def get_the_admin_user_policy(
+    request: fastapi.Request,
+    the_user_claims: authn_module.UserClaims = depend_the_user_claims,
+):
+    # Imported lazily: 'authz.persistence' pulls in 'authz', which imports
+    # nothing from 'views', but the lazy form mirrors the engine's other
+    # policy construction and keeps module import order robust.
+    from soliplex.authz import persistence
+
+    engine = request.state.authorization_engine
+    async with sqla_asyncio.AsyncSession(bind=engine) as session:
+        yield persistence.AdminUserPolicy(session, the_user_claims)
+
+
+depend_the_admin_user_policy = fastapi.Depends(get_the_admin_user_policy)
+
+
+async def get_the_room_authz_policy(
+    request: fastapi.Request,
+    the_user_claims: authn_module.UserClaims = depend_the_user_claims,
+):
+    from soliplex.authz import persistence
+
+    engine = request.state.authorization_engine
+    async with sqla_asyncio.AsyncSession(bind=engine) as session:
+        yield persistence.RoomAuthorizationPolicy(session, the_user_claims)
+
+
+depend_the_room_authz_policy = fastapi.Depends(get_the_room_authz_policy)
 
 
 #   'process_control' canary

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -33,7 +33,7 @@ router = fastapi.APIRouter(tags=["rooms"])
 
 depend_the_installation = installation.depend_the_installation
 depend_the_threads = agui_package.depend_the_threads
-depend_the_room_authz = authz.depend_the_room_authz_policy
+depend_the_room_authz = views.depend_the_room_authz_policy
 depend_the_user_claims = views.depend_the_user_claims
 depend_the_logger = views.depend_the_logger
 

--- a/src/soliplex/views/authz.py
+++ b/src/soliplex/views/authz.py
@@ -13,8 +13,8 @@ from soliplex import views
 router = fastapi.APIRouter(tags=["authorization"])
 
 depend_the_installation = installation.depend_the_installation
-depend_the_admin_users = authz.depend_the_admin_user_policy
-depend_the_room_authz = authz.depend_the_room_authz_policy
+depend_the_admin_users = views.depend_the_admin_user_policy
+depend_the_room_authz = views.depend_the_room_authz_policy
 depend_the_user_claims = views.depend_the_user_claims
 depend_the_logger = views.depend_the_logger
 

--- a/src/soliplex/views/file_uploads.py
+++ b/src/soliplex/views/file_uploads.py
@@ -10,7 +10,7 @@ from soliplex import authz
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
-from soliplex import views as views_package
+from soliplex import views
 from soliplex.views import agui as soliplex_views_agui
 from soliplex.views import authz as soliplex_views_authz
 from soliplex.views import util as soliplex_views_util
@@ -19,10 +19,10 @@ router = fastapi.APIRouter(tags=["uploads"])
 
 depend_the_installation = installation.depend_the_installation
 depend_the_threads = agui_package.depend_the_threads
-depend_the_admin_users = authz.depend_the_admin_user_policy
-depend_the_room_authz = authz.depend_the_room_authz_policy
-depend_the_user_claims = views_package.depend_the_user_claims
-depend_the_logger = views_package.depend_the_logger
+depend_the_admin_users = views.depend_the_admin_user_policy
+depend_the_room_authz = views.depend_the_room_authz_policy
+depend_the_user_claims = views.depend_the_user_claims
+depend_the_logger = views.depend_the_logger
 depend_the_authz_logger = soliplex_views_authz.depend_the_authz_logger
 
 

--- a/src/soliplex/views/installation.py
+++ b/src/soliplex/views/installation.py
@@ -15,9 +15,20 @@ from soliplex import views
 router = fastapi.APIRouter(tags=["installation"])
 
 depend_the_installation = installation.depend_the_installation
-depend_the_admin_users = authz.depend_the_admin_user_policy
+depend_the_admin_users = views.depend_the_admin_user_policy
 depend_the_user_claims = views.depend_the_user_claims
 depend_the_logger = views.depend_the_logger
+
+ConfigAuditLog = loggers.InstallationConfigAuditLog
+
+
+def get_the_config_audit_log(
+    the_user_claims: authn.UserClaims = depend_the_user_claims,
+) -> ConfigAuditLog:
+    return ConfigAuditLog(claims=the_user_claims)
+
+
+depend_the_config_audit_log = fastapi.Depends(get_the_config_audit_log)
 
 
 @util.logfire_span("GET /v1/installation")
@@ -27,6 +38,7 @@ async def get_installation(
     the_admin_users: authz.AdminUserPolicy = depend_the_admin_users,
     the_user_claims: authn.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
+    the_audit: ConfigAuditLog = depend_the_config_audit_log,
 ) -> models.Installation:
     """Return the installation's top-level configuration"""
     bound_logger = the_logger.bind(loggers.AUTHZ_LOGGER_NAME)
@@ -39,6 +51,7 @@ async def get_installation(
             detail=loggers.AUTHZ_ADMIN_ACCESS_REQUIRED,
         ) from None
 
+    the_audit.installation_read()
     return models.Installation.from_config(the_installation._config)
 
 
@@ -49,6 +62,7 @@ async def get_installation_versions(
     the_admin_users: authz.AdminUserPolicy = depend_the_admin_users,
     the_user_claims: authn.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
+    the_audit: ConfigAuditLog = depend_the_config_audit_log,
 ) -> models.InstalledPackages:
     """Return the installation's Python project versions manimest"""
     bound_logger = the_logger.bind(loggers.AUTHZ_LOGGER_NAME)
@@ -61,6 +75,7 @@ async def get_installation_versions(
             detail=loggers.AUTHZ_ADMIN_ACCESS_REQUIRED,
         ) from None
 
+    the_audit.installation_versions_read()
     try:
         found = (
             subprocess.check_output(
@@ -89,6 +104,7 @@ async def get_installation_providers(
     the_admin_users: authz.AdminUserPolicy = depend_the_admin_users,
     the_user_claims: authn.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
+    the_audit: ConfigAuditLog = depend_the_config_audit_log,
 ) -> installation.ProviderInfoMap:
     """Return the installation's LLM providers"""
     bound_logger = the_logger.bind(loggers.AUTHZ_LOGGER_NAME)
@@ -101,6 +117,7 @@ async def get_installation_providers(
             detail=loggers.AUTHZ_ADMIN_ACCESS_REQUIRED,
         ) from None
 
+    the_audit.installation_providers_read()
     return the_installation.all_provider_info
 
 
@@ -111,6 +128,7 @@ async def get_installation_git_metadata(
     the_admin_users: authz.AdminUserPolicy = depend_the_admin_users,
     the_user_claims: authn.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
+    the_audit: ConfigAuditLog = depend_the_config_audit_log,
 ) -> models.GitMetadata:
     """Return the installation's Git metadata"""
     bound_logger = the_logger.bind(loggers.AUTHZ_LOGGER_NAME)
@@ -125,6 +143,7 @@ async def get_installation_git_metadata(
 
     git_metadata = util.GitMetadata(pathlib.Path.cwd())
 
+    the_audit.installation_git_metadata_read()
     return models.GitMetadata(
         git_hash=git_metadata.git_hash,
         git_branch=git_metadata.git_branch,

--- a/src/soliplex/views/quizzes.py
+++ b/src/soliplex/views/quizzes.py
@@ -11,7 +11,7 @@ from soliplex import views
 router = fastapi.APIRouter(tags=["quizzes"])
 
 depend_the_installation = installation.depend_the_installation
-depend_the_room_authz = authz.depend_the_room_authz_policy
+depend_the_room_authz = views.depend_the_room_authz_policy
 depend_the_user_claims = views.depend_the_user_claims
 depend_the_logger = views.depend_the_logger
 

--- a/src/soliplex/views/rooms.py
+++ b/src/soliplex/views/rooms.py
@@ -18,7 +18,7 @@ from soliplex import views
 router = fastapi.APIRouter(tags=["rooms"])
 
 depend_the_installation = installation.depend_the_installation
-depend_the_room_authz = authz.depend_the_room_authz_policy
+depend_the_room_authz = views.depend_the_room_authz_policy
 depend_the_user_claims = views.depend_the_user_claims
 depend_the_logger = views.depend_the_logger
 

--- a/src/soliplex/views/stats.py
+++ b/src/soliplex/views/stats.py
@@ -12,7 +12,7 @@ from soliplex import views
 router = fastapi.APIRouter(tags=["stats"])
 
 depend_the_installation = installation.depend_the_installation
-depend_the_room_authz = authz.depend_the_room_authz_policy
+depend_the_room_authz = views.depend_the_room_authz_policy
 depend_the_threads = agui_package.depend_the_threads
 depend_the_user_claims = views.depend_the_user_claims
 depend_the_logger = views.depend_the_logger

--- a/tests/unit/authz/test_authz_package.py
+++ b/tests/unit/authz/test_authz_package.py
@@ -1,6 +1,3 @@
-from unittest import mock
-
-import fastapi
 import pytest
 
 from soliplex import authz
@@ -137,47 +134,3 @@ def test_parse_token_field_json_path_roundtrip(field, value):
 )
 def test_parse_token_field_json_path_non_field_query(value):
     assert authz.parse_token_field_json_path(value) is None
-
-
-@pytest.mark.anyio
-@mock.patch("soliplex.authz.persistence.AdminUserPolicy")
-@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
-async def test_get_the_admin_user_policy(as_klass, ap_klass):
-    engine = object()
-    request = fastapi.Request(scope={"type": "http"})
-    request.state.authorization_engine = engine
-
-    counter = 0
-
-    async for policy in authz.get_the_admin_user_policy(request):
-        assert policy is ap_klass.return_value
-        counter += 1
-
-    assert counter == 1
-
-    ap_klass.assert_called_once_with(
-        as_klass.return_value.__aenter__.return_value,
-    )
-    as_klass.assert_called_once_with(bind=engine)
-
-
-@pytest.mark.anyio
-@mock.patch("soliplex.authz.persistence.RoomAuthorizationPolicy")
-@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
-async def test_get_the_room_authz_policy(as_klass, ap_klass):
-    engine = object()
-    request = fastapi.Request(scope={"type": "http"})
-    request.state.authorization_engine = engine
-
-    counter = 0
-
-    async for policy in authz.get_the_room_authz_policy(request):
-        assert policy is ap_klass.return_value
-        counter += 1
-
-    assert counter == 1
-
-    ap_klass.assert_called_once_with(
-        as_klass.return_value.__aenter__.return_value,
-    )
-    as_klass.assert_called_once_with(bind=engine)

--- a/tests/unit/authz/test_authz_persistence.py
+++ b/tests/unit/authz/test_authz_persistence.py
@@ -6,6 +6,7 @@ from sqlalchemy import sql as sqla_sql
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import authz
+from soliplex import loggers
 from soliplex import models
 from soliplex.authz import persistence as authz_persistence
 from soliplex.authz import schema as authz_schema
@@ -18,6 +19,7 @@ USER_TOKEN = {
     "email": EMAIL,
 }
 ROOM_ID = "test-room"
+CLAIMS = {"source": "test", "actor": EMAIL}
 
 
 @pytest.fixture
@@ -27,9 +29,23 @@ def faux_sqlaa_session():
     )
 
 
+def _admin_user_policy(session):
+    """An 'AdminUserPolicy' whose '_audit' is a mock, for emit assertions."""
+    policy = authz_persistence.AdminUserPolicy(session, CLAIMS)
+    policy._audit = mock.create_autospec(loggers.AdminUsersAuditLog)
+    return policy
+
+
+def _room_authz_policy(session):
+    """A 'RoomAuthorizationPolicy' whose '_audit' is a mock."""
+    policy = authz_persistence.RoomAuthorizationPolicy(session, CLAIMS)
+    policy._audit = mock.create_autospec(loggers.RoomAuthzAuditLog)
+    return policy
+
+
 @pytest.mark.anyio
 async def test_admin_user_session(faux_sqlaa_session):
-    aup = authz_persistence.AdminUserPolicy(faux_sqlaa_session)
+    aup = authz_persistence.AdminUserPolicy(faux_sqlaa_session, CLAIMS)
     begin = faux_sqlaa_session.begin
 
     async with aup.session as session:
@@ -42,9 +58,16 @@ async def test_admin_user_session(faux_sqlaa_session):
     begin.return_value.__aenter__.assert_called_once_with()
 
 
+def test_admin_user_policy_builds_audit_log():
+    policy = authz_persistence.AdminUserPolicy(object(), CLAIMS)
+
+    assert isinstance(policy._audit, loggers.AdminUsersAuditLog)
+    assert policy._audit.extra["claims"] == CLAIMS
+
+
 @pytest.mark.asyncio
 async def test_list_admin_user_discriminators(the_async_session):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
     the_async_session.add(authz_schema.AdminUser(json_path=JSON_PATH))
     the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
     await the_async_session.commit()
@@ -52,53 +75,70 @@ async def test_list_admin_user_discriminators(the_async_session):
     found = await aup.list_admin_user_discriminators()
 
     assert found == [JSON_PATH, ROLE_JSON_PATH]
+    aup._audit.admin_users_listed.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_add_admin_user_discriminator(the_async_session):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
 
     await aup.add_admin_user_discriminator(ROLE_JSON_PATH)
 
+    aup._audit.admin_user_added.assert_called_once_with(ROLE_JSON_PATH)
     found = await aup.list_admin_user_discriminators()
     assert found == [ROLE_JSON_PATH]
 
 
 @pytest.mark.asyncio
 async def test_add_admin_user_discriminator_already_exists(the_async_session):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
     the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
     await the_async_session.commit()
 
     with pytest.raises(authz.AdminUserExists):
         await aup.add_admin_user_discriminator(ROLE_JSON_PATH)
 
+    ((args, kwargs),) = aup._audit.admin_user_add_failed.call_args_list
+    (arg,) = args
+    assert arg == ROLE_JSON_PATH
+    assert list(kwargs) == ["reason"]
+    msg = kwargs["reason"]
+    assert msg.startswith("Admin user already exists with json_path")
+
 
 @pytest.mark.asyncio
 async def test_remove_admin_user_discriminator(the_async_session):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
     the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
     await the_async_session.commit()
 
     await aup.remove_admin_user_discriminator(ROLE_JSON_PATH)
 
+    aup._audit.admin_user_removed.assert_called_once_with(ROLE_JSON_PATH)
     found = await aup.list_admin_user_discriminators()
     assert found == []
 
 
 @pytest.mark.asyncio
 async def test_remove_admin_user_discriminator_absent(the_async_session):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
 
     with pytest.raises(authz.NoSuchAdminUser):
         await aup.remove_admin_user_discriminator(ROLE_JSON_PATH)
+
+    ((args, kwargs),) = aup._audit.admin_user_remove_failed.call_args_list
+    (arg,) = args
+    assert arg == ROLE_JSON_PATH
+    assert list(kwargs) == ["reason"]
+    msg = kwargs["reason"]
+    assert msg.startswith("No admin user exists with json_path")
 
 
 @pytest.mark.asyncio
 async def test_remove_admin_user_discriminator_invalid_json_path(
     the_async_session,
 ):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
     # Seed via a core INSERT so the stored value bypasses the ORM
     # '@validates' hook -- mimicking an entry whose 'json_path' no
     # longer compiles (e.g. a removed meta-config filter function).
@@ -112,29 +152,32 @@ async def test_remove_admin_user_discriminator_invalid_json_path(
 
     await aup.remove_admin_user_discriminator(INVALID_JSON_PATH)
 
+    aup._audit.admin_user_removed.assert_called_once_with(INVALID_JSON_PATH)
     found = await aup.list_admin_user_discriminators()
     assert found == []
 
 
 @pytest.mark.asyncio
 async def test_clear_admin_user_discriminators(the_async_session):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
     the_async_session.add(authz_schema.AdminUser(json_path=JSON_PATH))
     the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
     await the_async_session.commit()
 
     await aup.clear_admin_user_discriminators()
 
+    aup._audit.admin_users_cleared.assert_called_once_with()
     found = await aup.list_admin_user_discriminators()
     assert found == []
 
 
 @pytest.mark.asyncio
 async def test_clear_admin_user_discriminators_empty(the_async_session):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
 
     await aup.clear_admin_user_discriminators()
 
+    aup._audit.admin_users_cleared.assert_called_once_with()
     found = await aup.list_admin_user_discriminators()
     assert found == []
 
@@ -143,9 +186,12 @@ async def test_clear_admin_user_discriminators_empty(the_async_session):
 async def test_admin_user_crud(the_async_session):
     # The deprecated 'email'-keyed aliases delegate to the
     # '*_discriminator' methods, storing the canonical email JSONPath.
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
 
     found = await aup.list_admin_users()
+
+    aup._audit.admin_users_listed.assert_called_once_with()
+    aup._audit.admin_users_listed.reset_mock()
 
     assert found == []
 
@@ -157,9 +203,15 @@ async def test_admin_user_crud(the_async_session):
     assert user is not None
     await the_async_session.commit()
 
+    aup._audit.admin_user_added.assert_called_once_with(JSON_PATH)
+    aup._audit.admin_user_added.reset_mock()
+
     found = await aup.list_admin_users()
     assert found == [JSON_PATH]
     await the_async_session.commit()
+
+    aup._audit.admin_users_listed.assert_called_once_with()
+    aup._audit.admin_users_listed.reset_mock()
 
     with pytest.raises(authz.AdminUserExists):
         await aup.add_admin_user(email=EMAIL)
@@ -171,9 +223,20 @@ async def test_admin_user_crud(the_async_session):
     assert no_dupe is user
     await the_async_session.commit()
 
+    ((args, kwargs),) = aup._audit.admin_user_add_failed.call_args_list
+    (arg,) = args
+    assert arg == JSON_PATH
+    assert list(kwargs) == ["reason"]
+    msg = kwargs["reason"]
+    assert msg.startswith("Admin user already exists with json_path")
+    aup._audit.admin_user_add_failed.reset_mock()
+
     found = await aup.list_admin_users()
     assert found == [JSON_PATH]
     await the_async_session.commit()
+
+    aup._audit.admin_users_listed.assert_called_once_with()
+    aup._audit.admin_users_listed.reset_mock()
 
     await aup.remove_admin_user(email=EMAIL)
     gone = await authz_persistence._find_admin_user_by_json_path(
@@ -183,34 +246,63 @@ async def test_admin_user_crud(the_async_session):
     assert gone is None
     await the_async_session.commit()
 
+    aup._audit.admin_user_removed.assert_called_once_with(JSON_PATH)
+    aup._audit.admin_user_removed.reset_mock()
+
     found = await aup.list_admin_users()
     assert found == []
     await the_async_session.commit()
 
+    aup._audit.admin_users_listed.assert_called_once_with()
+    aup._audit.admin_users_listed.reset_mock()
+
     with pytest.raises(authz.NoSuchAdminUser):
         await aup.remove_admin_user(email=EMAIL)
+
+    ((args, kwargs),) = aup._audit.admin_user_remove_failed.call_args_list
+    (arg,) = args
+    assert arg == JSON_PATH
+    assert list(kwargs) == ["reason"]
+    msg = kwargs["reason"]
+    assert msg.startswith("No admin user exists with json_path")
+    aup._audit.admin_user_remove_failed.reset_mock()
 
 
 @pytest.mark.asyncio
 async def test_admin_user_check_admin_access(the_async_session):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
 
     assert not await aup.check_admin_access(USER_TOKEN)
+
+    aup._audit.admin_access_denied.assert_called_once_with()
+    aup._audit.admin_access_denied.reset_mock()
 
     await aup.add_admin_user(email=EMAIL)
 
+    aup._audit.admin_user_added.assert_called_once_with(JSON_PATH)
+    aup._audit.admin_user_added.reset_mock()
+
     assert await aup.check_admin_access(USER_TOKEN)
+
+    aup._audit.admin_access_allowed.assert_called_once_with()
+    aup._audit.admin_access_allowed.reset_mock()
 
     await aup.remove_admin_user(email=EMAIL)
 
+    aup._audit.admin_user_removed.assert_called_once_with(JSON_PATH)
+    aup._audit.admin_user_removed.reset_mock()
+
     assert not await aup.check_admin_access(USER_TOKEN)
+
+    aup._audit.admin_access_denied.assert_called_once_with()
+    aup._audit.admin_access_denied.reset_mock()
 
 
 @pytest.mark.asyncio
 async def test_admin_user_check_admin_access_json_path(
     the_async_session,
 ):
-    aup = authz_persistence.AdminUserPolicy(the_async_session)
+    aup = _admin_user_policy(the_async_session)
 
     # An admin keyed by a non-email JSONPath query (e.g. a role claim),
     # as produced by 'admin-users add --json-path'.
@@ -220,18 +312,39 @@ async def test_admin_user_check_admin_access_json_path(
     await the_async_session.commit()
 
     assert await aup.check_admin_access({"role": "admin"})
+
+    aup._audit.admin_access_allowed.assert_called_once_with()
+    aup._audit.admin_access_allowed.reset_mock()
+
     assert not await aup.check_admin_access({"role": "user"})
+
+    aup._audit.admin_access_denied.assert_called_once_with()
+    aup._audit.admin_access_denied.reset_mock()
+
     # A role-keyed admin is not matched by an unrelated email token.
     assert not await aup.check_admin_access(USER_TOKEN)
+
+    aup._audit.admin_access_denied.assert_called_once_with()
+    aup._audit.admin_access_denied.reset_mock()
 
     # A non-email admin surfaces as its raw JSONPath query, not an email.
     listed = await aup.list_admin_users()
     assert listed == ['$[?$.role == "admin"]']
 
+    aup._audit.admin_users_listed.assert_called_once_with()
+    aup._audit.admin_users_listed.reset_mock()
+
+
+def test_room_authz_policy_builds_audit_log():
+    policy = authz_persistence.RoomAuthorizationPolicy(object(), CLAIMS)
+
+    assert isinstance(policy._audit, loggers.RoomAuthzAuditLog)
+    assert policy._audit.extra["claims"] == CLAIMS
+
 
 @pytest.mark.asyncio
 async def test_room_authz_check_room_access(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
 
     # No policy -> public room
     assert await rap.check_room_access(ROOM_ID, None)
@@ -253,10 +366,13 @@ async def test_room_authz_check_room_access(the_async_session):
 
     assert await rap.check_room_access(ROOM_ID, None)
 
+    # The hot end-user access path is deliberately not audited.
+    assert rap._audit.method_calls == []
+
 
 @pytest.mark.asyncio
 async def test_room_authz_filter_room_ids(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
 
     room_ids = [ROOM_ID]
 
@@ -280,14 +396,20 @@ async def test_room_authz_filter_room_ids(the_async_session):
 
     assert await rap.filter_room_ids(room_ids, None) == room_ids
 
+    # The hot end-user access path is deliberately not audited.
+    assert rap._audit.method_calls == []
+
 
 @pytest.mark.asyncio
 async def test_room_authz_policy_crud(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
 
     # No policy -> public room
     policy = await rap.get_room_policy(ROOM_ID)
     assert policy is None
+
+    rap._audit.room_policy_read.assert_called_once_with(ROOM_ID)
+    rap._audit.room_policy_read.reset_mock()
 
     acl_entry_model = models.ACLEntry(
         allow_deny=authz.AllowDeny.ALLOW,
@@ -300,9 +422,15 @@ async def test_room_authz_policy_crud(the_async_session):
     await rap.update_room_policy(ROOM_ID, policy_model)
     await the_async_session.commit()
 
+    rap._audit.room_policy_updated.assert_called_once_with(ROOM_ID)
+    rap._audit.room_policy_updated.reset_mock()
+
     after = await rap.get_room_policy(ROOM_ID)
     assert after == policy_model
     await the_async_session.commit()
+
+    rap._audit.room_policy_read.assert_called_once_with(ROOM_ID)
+    rap._audit.room_policy_read.reset_mock()
 
     new_acl_entry_model = models.ACLEntry(
         allow_deny=authz.AllowDeny.ALLOW,
@@ -314,19 +442,34 @@ async def test_room_authz_policy_crud(the_async_session):
     await rap.update_room_policy(ROOM_ID, new_policy_model)
     await the_async_session.commit()
 
+    rap._audit.room_policy_updated.assert_called_once_with(ROOM_ID)
+    rap._audit.room_policy_updated.reset_mock()
+
     policy = await rap.get_room_policy(ROOM_ID)
     assert policy == new_policy_model
     await the_async_session.commit()
 
+    rap._audit.room_policy_read.assert_called_once_with(ROOM_ID)
+    rap._audit.room_policy_read.reset_mock()
+
     await rap.delete_room_policy(ROOM_ID)
     await the_async_session.commit()
+
+    rap._audit.room_policy_deleted.assert_called_once_with(ROOM_ID)
+    rap._audit.room_policy_deleted.reset_mock()
 
     gone = await rap.get_room_policy(ROOM_ID)
     assert gone is None
     await the_async_session.commit()
 
+    rap._audit.room_policy_read.assert_called_once_with(ROOM_ID)
+    rap._audit.room_policy_read.reset_mock()
+
     await rap.delete_room_policy(ROOM_ID)
     await the_async_session.commit()
+
+    rap._audit.room_policy_deleted.assert_called_once_with(ROOM_ID)
+    rap._audit.room_policy_deleted.reset_mock()
 
 
 ALLOW = authz.AllowDeny.ALLOW
@@ -376,18 +519,19 @@ async def _seed_stale_entry(session, *, allow_deny=ALLOW):
 
 @pytest.mark.asyncio
 async def test_get_room_policy_unchecked_absent(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
 
     found = await rap.get_room_policy_unchecked(ROOM_ID)
 
     assert found is None
+    rap._audit.room_policy_read.assert_called_once_with(ROOM_ID)
 
 
 @pytest.mark.asyncio
 async def test_get_room_policy_unchecked_tolerates_stale_json_path(
     the_async_session,
 ):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_stale_entry(the_async_session)
 
     found = await rap.get_room_policy_unchecked(ROOM_ID)
@@ -396,20 +540,22 @@ async def test_get_room_policy_unchecked_tolerates_stale_json_path(
     assert [entry.json_path for entry in found.acl_entries] == [
         STALE_JSON_PATH
     ]
+    rap._audit.room_policy_read.assert_called_once_with(ROOM_ID)
 
 
 @pytest.mark.asyncio
 async def test_list_room_policies_empty(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
 
     found = await rap.list_room_policies()
 
     assert found == []
+    rap._audit.room_policies_listed.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_list_room_policies(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     the_async_session.add(
         authz_schema.RoomPolicy(room_id="alpha", default_allow_deny=ALLOW)
     )
@@ -427,13 +573,14 @@ async def test_list_room_policies(the_async_session):
         "alpha": ALLOW,
         "beta": DENY,
     }
+    rap._audit.room_policies_listed.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_list_room_policies_tolerates_stale_json_path(
     the_async_session,
 ):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_stale_entry(the_async_session)
 
     found = await rap.list_room_policies()
@@ -442,11 +589,12 @@ async def test_list_room_policies_tolerates_stale_json_path(
     assert [entry.json_path for entry in found[0].acl_entries] == [
         STALE_JSON_PATH
     ]
+    rap._audit.room_policies_listed.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_update_room_policy_room_id_is_authoritative(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     policy_model = models.RoomPolicy(
         room_id="some-other-room",
         acl_entries=[models.ACLEntry(allow_deny=ALLOW, everyone=True)],
@@ -455,6 +603,7 @@ async def test_update_room_policy_room_id_is_authoritative(the_async_session):
     await rap.update_room_policy(ROOM_ID, policy_model)
     await the_async_session.commit()
 
+    rap._audit.room_policy_updated.assert_called_once_with(ROOM_ID)
     stored = await rap.get_room_policy(ROOM_ID)
     assert stored is not None
     assert stored.room_id == ROOM_ID
@@ -467,7 +616,7 @@ async def test_delete_room_policy_removes_acl_entries(the_async_session):
     # SQLite engine does not enforce the DB-level 'ON DELETE CASCADE', so
     # an orphaned row would survive and -- via SQLite primary-key reuse --
     # re-attach to the next policy created for the same room.
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_policy(
         the_async_session,
         default=DENY,
@@ -481,11 +630,12 @@ async def test_delete_room_policy_removes_acl_entries(the_async_session):
         await the_async_session.scalars(sqla_sql.select(authz_schema.ACLEntry))
     ).all()
     assert remaining == []
+    rap._audit.room_policy_deleted.assert_called_once_with(ROOM_ID)
 
 
 @pytest.mark.asyncio
 async def test_clear_room_acl(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_policy(
         the_async_session,
         default=DENY,
@@ -498,6 +648,7 @@ async def test_clear_room_acl(the_async_session):
     await rap.clear_room_acl(ROOM_ID)
     await the_async_session.commit()
 
+    rap._audit.acl_cleared.assert_called_once_with(ROOM_ID)
     after = await rap.get_room_policy(ROOM_ID)
     assert after.acl_entries == []
     assert after.default_allow_deny == DENY
@@ -505,23 +656,24 @@ async def test_clear_room_acl(the_async_session):
 
 @pytest.mark.asyncio
 async def test_clear_room_acl_no_policy(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
 
     await rap.clear_room_acl(ROOM_ID)
 
+    rap._audit.acl_cleared.assert_called_once_with(ROOM_ID)
     assert await rap.get_room_policy(ROOM_ID) is None
 
 
 @pytest.mark.asyncio
 async def test_add_acl_entry_to_policy(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_policy(the_async_session, default=DENY, entries=[])
+    entry = models.ACLEntry(allow_deny=ALLOW, everyone=True)
 
-    await rap.add_acl_entry(
-        ROOM_ID, models.ACLEntry(allow_deny=ALLOW, everyone=True)
-    )
+    await rap.add_acl_entry(ROOM_ID, entry)
     await the_async_session.commit()
 
+    rap._audit.acl_entry_added.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
     assert [(e.allow_deny, e.everyone) for e in after.acl_entries] == [
         (ALLOW, True)
@@ -530,12 +682,19 @@ async def test_add_acl_entry_to_policy(the_async_session):
 
 @pytest.mark.asyncio
 async def test_add_acl_entry_no_policy_raises(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
+    entry = models.ACLEntry(allow_deny=ALLOW, everyone=True)
 
     with pytest.raises(authz.NoSuchRoomPolicy):
-        await rap.add_acl_entry(
-            ROOM_ID, models.ACLEntry(allow_deny=ALLOW, everyone=True)
-        )
+        await rap.add_acl_entry(ROOM_ID, entry)
+
+    ((args, kwargs),) = rap._audit.acl_entry_add_failed.call_args_list
+    room_arg, entry_arg = args
+    assert room_arg == ROOM_ID
+    assert entry_arg == entry
+    assert list(kwargs) == ["reason"]
+    msg = kwargs["reason"]
+    assert msg.startswith("No policy exists for room")
 
 
 @pytest.mark.parametrize(
@@ -550,18 +709,18 @@ async def test_add_acl_entry_no_policy_raises(the_async_session):
 async def test_add_acl_entry_replaces_same_discriminator(
     the_async_session, discriminator_kwargs
 ):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_policy(
         the_async_session,
         default=DENY,
         entries=[_orm_entry(ALLOW, **discriminator_kwargs)],
     )
+    entry = models.ACLEntry(allow_deny=DENY, **discriminator_kwargs)
 
-    await rap.add_acl_entry(
-        ROOM_ID, models.ACLEntry(allow_deny=DENY, **discriminator_kwargs)
-    )
+    await rap.add_acl_entry(ROOM_ID, entry)
     await the_async_session.commit()
 
+    rap._audit.acl_entry_added.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
     assert len(after.acl_entries) == 1
     assert after.acl_entries[0].allow_deny == DENY
@@ -569,18 +728,18 @@ async def test_add_acl_entry_replaces_same_discriminator(
 
 @pytest.mark.asyncio
 async def test_add_acl_entry_keeps_other_discriminator(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_policy(
         the_async_session,
         default=DENY,
         entries=[_orm_entry(ALLOW, everyone=True)],
     )
+    entry = models.ACLEntry(allow_deny=DENY, json_path=ROLE_JSON_PATH)
 
-    await rap.add_acl_entry(
-        ROOM_ID, models.ACLEntry(allow_deny=DENY, json_path=ROLE_JSON_PATH)
-    )
+    await rap.add_acl_entry(ROOM_ID, entry)
     await the_async_session.commit()
 
+    rap._audit.acl_entry_added.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
     assert len(after.acl_entries) == 2
 
@@ -606,25 +765,25 @@ async def test_add_acl_entry_keeps_other_discriminator(the_async_session):
 async def test_remove_acl_entry_matches_discriminator(
     the_async_session, seed_kwargs, remove_kwargs
 ):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_policy(
         the_async_session,
         default=DENY,
         entries=[_orm_entry(ALLOW, **seed_kwargs)],
     )
+    entry = models.ACLEntryUnchecked(allow_deny=ALLOW, **remove_kwargs)
 
-    await rap.remove_acl_entry(
-        ROOM_ID, models.ACLEntryUnchecked(allow_deny=ALLOW, **remove_kwargs)
-    )
+    await rap.remove_acl_entry(ROOM_ID, entry)
     await the_async_session.commit()
 
+    rap._audit.acl_entry_removed.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
     assert after.acl_entries == []
 
 
 @pytest.mark.asyncio
 async def test_remove_acl_entry_no_match_raises(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_policy(
         the_async_session,
         default=DENY,
@@ -634,47 +793,63 @@ async def test_remove_acl_entry_no_match_raises(the_async_session):
         ],
     )
 
+    entry = models.ACLEntryUnchecked(
+        allow_deny=ALLOW, json_path=ROLE_JSON_PATH
+    )
+
     with pytest.raises(authz.NoSuchACLEntry):
-        await rap.remove_acl_entry(
-            ROOM_ID,
-            models.ACLEntryUnchecked(
-                allow_deny=ALLOW, json_path=ROLE_JSON_PATH
-            ),
-        )
+        await rap.remove_acl_entry(ROOM_ID, entry)
+
+    ((args, kwargs),) = rap._audit.acl_entry_remove_failed.call_args_list
+    room_arg, entry_arg = args
+    assert room_arg == ROOM_ID
+    assert entry_arg == entry
+    assert list(kwargs) == ["reason"]
+    msg = kwargs["reason"]
+    assert msg.startswith("No matching ACL entry in room")
 
 
 @pytest.mark.asyncio
 async def test_remove_acl_entry_no_policy_raises(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
+    entry = models.ACLEntryUnchecked(allow_deny=ALLOW, everyone=True)
 
     with pytest.raises(authz.NoSuchRoomPolicy):
-        await rap.remove_acl_entry(
-            ROOM_ID, models.ACLEntryUnchecked(allow_deny=ALLOW, everyone=True)
-        )
+        await rap.remove_acl_entry(ROOM_ID, entry)
+
+    ((args, kwargs),) = rap._audit.acl_entry_remove_failed.call_args_list
+    room_arg, entry_arg = args
+    assert room_arg == ROOM_ID
+    assert entry_arg == entry
+    assert list(kwargs) == ["reason"]
+    msg = kwargs["reason"]
+    assert msg.startswith("No policy exists for room")
 
 
 @pytest.mark.asyncio
 async def test_remove_acl_entry_stale_json_path(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_stale_entry(the_async_session, allow_deny=ALLOW)
-
-    await rap.remove_acl_entry(
-        ROOM_ID,
-        models.ACLEntryUnchecked(allow_deny=ALLOW, json_path=STALE_JSON_PATH),
+    entry = models.ACLEntryUnchecked(
+        allow_deny=ALLOW, json_path=STALE_JSON_PATH
     )
+
+    await rap.remove_acl_entry(ROOM_ID, entry)
     await the_async_session.commit()
 
+    rap._audit.acl_entry_removed.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
     assert after.acl_entries == []
 
 
 @pytest.mark.asyncio
 async def test_set_room_default_creates_when_missing(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
 
     await rap.set_room_default(ROOM_ID, ALLOW)
     await the_async_session.commit()
 
+    rap._audit.room_default_set.assert_called_once_with(ROOM_ID, ALLOW)
     after = await rap.get_room_policy(ROOM_ID)
     assert after is not None
     assert after.default_allow_deny == ALLOW
@@ -683,7 +858,7 @@ async def test_set_room_default_creates_when_missing(the_async_session):
 
 @pytest.mark.asyncio
 async def test_set_room_default_updates_existing(the_async_session):
-    rap = authz_persistence.RoomAuthorizationPolicy(the_async_session)
+    rap = _room_authz_policy(the_async_session)
     await _seed_policy(
         the_async_session,
         default=DENY,
@@ -693,6 +868,7 @@ async def test_set_room_default_updates_existing(the_async_session):
     await rap.set_room_default(ROOM_ID, ALLOW)
     await the_async_session.commit()
 
+    rap._audit.room_default_set.assert_called_once_with(ROOM_ID, ALLOW)
     after = await rap.get_room_policy(ROOM_ID)
     assert after.default_allow_deny == ALLOW
     assert len(after.acl_entries) == 1

--- a/tests/unit/cli/test_cli_util.py
+++ b/tests/unit/cli/test_cli_util.py
@@ -140,6 +140,23 @@ async def test__room_authz_policy(tmp_path):
     assert [p.room_id for p in found] == ["faux"]
 
 
+def test__audit_claims_uses_env_actor(monkeypatch):
+    monkeypatch.setenv("SOLIPLEX_AUDIT_ACTOR", "ops@example.com")
+
+    claims = cli_util._audit_claims()
+
+    assert claims == {"source": "cli", "actor": "ops@example.com"}
+
+
+def test__audit_claims_falls_back_to_os_user(monkeypatch):
+    monkeypatch.delenv("SOLIPLEX_AUDIT_ACTOR", raising=False)
+    monkeypatch.setattr(cli_util.getpass, "getuser", lambda: "phreddy")
+
+    claims = cli_util._audit_claims()
+
+    assert claims == {"source": "cli", "actor": "phreddy"}
+
+
 SUMMARY = "'--a', '--b', or '--c'"
 
 

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -1385,6 +1385,7 @@ def mcp_apps():
         (True, []),
     ],
 )
+@mock.patch("soliplex.loggers.ProcessLifetimeAuditLog")
 @mock.patch("soliplex.installation.add_no_auth_user_as_admin")
 @mock.patch("soliplex.installation.apply_logfire_configuration")
 @mock.patch("soliplex.secrets.resolve_secrets")
@@ -1400,6 +1401,7 @@ async def test_lifespan(
     srs,
     alc,
     anauaa,
+    plal_klass,
     mcp_apps,
     temp_dir,
     w_no_auth_mode,
@@ -1521,6 +1523,12 @@ root:
         url_safe_token_secret=URL_SAFE_TOKEN_SECRET_KEY,
         max_token_age_secs=7200,
     )
+
+    plal_klass.assert_called_once_with()
+    plal = plal_klass.return_value
+    plal.server_starting.assert_called_once_with()
+    plal.server_started.assert_called_once_with()
+    plal.server_stopping.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_loggers.py
+++ b/tests/unit/test_loggers.py
@@ -8,6 +8,12 @@ from soliplex import installation
 from soliplex import loggers
 
 LOGGER_NAME = "test-logger"
+CLAIMS = {"email": "phreddy@example.com"}
+SCOPE_LIFETIME = loggers.AuditLogScopes.PROCESS_LIFETIME
+SCOPE_ROOM_AUTHZ = loggers.AuditLogScopes.ROOM_AUTHZ
+SCOPE_ADMIN_USERS = loggers.AuditLogScopes.ADMIN_USERS
+SCOPE_INSTALLATION_CONFIG = loggers.AuditLogScopes.INSTALLATION_CONFIG
+SCOPE_RAG_ACCESS = loggers.AuditLogScopes.RAG_ACCESS
 
 
 @pytest.fixture
@@ -159,3 +165,514 @@ def test_updatelevels_filter(w_level, exp_level):
     found = update_levels.filter(record)
 
     assert found.levelno == exp_level
+
+
+@pytest.mark.parametrize("scope", loggers.AuditLogScopes)
+def test_auditlogwrapper_ctor(scope):
+    found = loggers.AuditLogWrapper(scope=scope)
+
+    assert found.name == loggers.SOLIPLEX_AUDIT_LOGGER_NAME
+    assert found.extra[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA] == scope
+
+
+@pytest.fixture
+def audit_records():
+    """Capture records emitted to the 'soliplex-audit' logger in a list."""
+    records = []
+    handler = logging.Handler()
+    handler.emit = records.append
+    logger = logging.getLogger(loggers.SOLIPLEX_AUDIT_LOGGER_NAME)
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+
+
+def _assert_audit_record(record, *, message, levelno, outcome, scope, fields):
+    """Shared assertions for a single emitted audit record."""
+    assert record.getMessage() == message
+    assert record.levelno == levelno
+    assert record.outcome == outcome
+    assert record.__dict__[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA] == scope
+    for key, value in fields.items():
+        assert getattr(record, key) == value
+
+
+# --- ProcessLifetimeAuditLog ----------------------------------------------
+
+
+def test_processlifetimeauditlog_ctor():
+    found = loggers.ProcessLifetimeAuditLog()
+
+    assert found.name == loggers.SOLIPLEX_AUDIT_LOGGER_NAME
+    scope = found.extra[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA]
+    assert scope == SCOPE_LIFETIME
+
+
+def test_server_starting(audit_records):
+    wrapper = loggers.ProcessLifetimeAuditLog()
+
+    wrapper.server_starting()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_SERVER_STARTING,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_LIFETIME,
+        fields={},
+    )
+
+
+def test_server_started(audit_records):
+    wrapper = loggers.ProcessLifetimeAuditLog()
+
+    wrapper.server_started()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_SERVER_STARTED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_LIFETIME,
+        fields={},
+    )
+
+
+def test_server_stopping(audit_records):
+    wrapper = loggers.ProcessLifetimeAuditLog()
+
+    wrapper.server_stopping()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_SERVER_STOPPING,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_LIFETIME,
+        fields={},
+    )
+
+
+# --- RoomAuthzAuditLog ----------------------------------------------------
+
+
+@pytest.mark.parametrize("w_claims", [{}, CLAIMS])
+def test_roomauthzauditlog_ctor(w_claims):
+    found = loggers.RoomAuthzAuditLog(claims=w_claims)
+
+    assert found.name == loggers.SOLIPLEX_AUDIT_LOGGER_NAME
+    scope = found.extra[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA]
+    assert scope == SCOPE_ROOM_AUTHZ
+    assert found.extra["claims"] == w_claims
+
+
+def test_room_policy_read(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.room_policy_read("r1")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_POLICY_READ,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS, "room_id": "r1"},
+    )
+
+
+def test_room_policies_listed(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.room_policies_listed()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_POLICIES_LISTED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS},
+    )
+
+
+def test_room_policy_updated(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.room_policy_updated("r1")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_POLICY_UPDATED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS, "room_id": "r1"},
+    )
+
+
+def test_room_policy_update_failed(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.room_policy_update_failed("r1", "boom")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_POLICY_UPDATED,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_ERROR,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS, "room_id": "r1", "reason": "boom"},
+    )
+
+
+def test_room_default_set(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.room_default_set("r1", "DENY")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_DEFAULT_SET,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS, "room_id": "r1", "allow_deny": "DENY"},
+    )
+
+
+def test_room_policy_deleted(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.room_policy_deleted("r1")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_POLICY_DELETED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS, "room_id": "r1"},
+    )
+
+
+def test_room_policy_delete_failed(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.room_policy_delete_failed("r1", "boom")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_POLICY_DELETED,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_ERROR,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS, "room_id": "r1", "reason": "boom"},
+    )
+
+
+def test_acl_entry_added(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.acl_entry_added("r1", "alice")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_ACL_ENTRY_ADDED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS, "room_id": "r1", "entry": "alice"},
+    )
+
+
+def test_acl_entry_add_failed(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.acl_entry_add_failed("r1", "alice", "dup")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_ACL_ENTRY_ADDED,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_ERROR,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={
+            "claims": CLAIMS,
+            "room_id": "r1",
+            "entry": "alice",
+            "reason": "dup",
+        },
+    )
+
+
+def test_acl_entry_removed(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.acl_entry_removed("r1", "alice")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_ACL_ENTRY_REMOVED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS, "room_id": "r1", "entry": "alice"},
+    )
+
+
+def test_acl_entry_remove_failed(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.acl_entry_remove_failed("r1", "alice", "miss")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_ACL_ENTRY_REMOVED,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_ERROR,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={
+            "claims": CLAIMS,
+            "room_id": "r1",
+            "entry": "alice",
+            "reason": "miss",
+        },
+    )
+
+
+def test_acl_cleared(audit_records):
+    wrapper = loggers.RoomAuthzAuditLog(claims=CLAIMS)
+
+    wrapper.acl_cleared("r1")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_ACL_CLEARED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ROOM_AUTHZ,
+        fields={"claims": CLAIMS, "room_id": "r1"},
+    )
+
+
+# --- AdminUsersAuditLog ---------------------------------------------------
+
+
+@pytest.mark.parametrize("w_claims", [{}, CLAIMS])
+def test_adminusersauditlog_ctor(w_claims):
+    found = loggers.AdminUsersAuditLog(claims=w_claims)
+
+    assert found.name == loggers.SOLIPLEX_AUDIT_LOGGER_NAME
+    scope = found.extra[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA]
+    assert scope == SCOPE_ADMIN_USERS
+    assert found.extra["claims"] == w_claims
+
+
+def test_admin_access_allowed(audit_records):
+    wrapper = loggers.AdminUsersAuditLog(claims=CLAIMS)
+
+    wrapper.admin_access_allowed()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ADMIN_ACCESS,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ADMIN_USERS,
+        fields={"claims": CLAIMS},
+    )
+
+
+def test_admin_access_denied(audit_records):
+    wrapper = loggers.AdminUsersAuditLog(claims=CLAIMS)
+
+    wrapper.admin_access_denied()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ADMIN_ACCESS,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_DENIED,
+        scope=SCOPE_ADMIN_USERS,
+        fields={"claims": CLAIMS},
+    )
+
+
+def test_admin_users_listed(audit_records):
+    wrapper = loggers.AdminUsersAuditLog(claims=CLAIMS)
+
+    wrapper.admin_users_listed()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ADMIN_USERS_LISTED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ADMIN_USERS,
+        fields={"claims": CLAIMS},
+    )
+
+
+def test_admin_user_added(audit_records):
+    wrapper = loggers.AdminUsersAuditLog(claims=CLAIMS)
+
+    wrapper.admin_user_added("alice")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ADMIN_USER_ADDED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ADMIN_USERS,
+        fields={"claims": CLAIMS, "discriminator": "alice"},
+    )
+
+
+def test_admin_user_add_failed(audit_records):
+    wrapper = loggers.AdminUsersAuditLog(claims=CLAIMS)
+
+    wrapper.admin_user_add_failed("alice", "dup")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ADMIN_USER_ADDED,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_ERROR,
+        scope=SCOPE_ADMIN_USERS,
+        fields={"claims": CLAIMS, "discriminator": "alice", "reason": "dup"},
+    )
+
+
+def test_admin_user_removed(audit_records):
+    wrapper = loggers.AdminUsersAuditLog(claims=CLAIMS)
+
+    wrapper.admin_user_removed("alice")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ADMIN_USER_REMOVED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ADMIN_USERS,
+        fields={"claims": CLAIMS, "discriminator": "alice"},
+    )
+
+
+def test_admin_user_remove_failed(audit_records):
+    wrapper = loggers.AdminUsersAuditLog(claims=CLAIMS)
+
+    wrapper.admin_user_remove_failed("alice", "miss")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ADMIN_USER_REMOVED,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_ERROR,
+        scope=SCOPE_ADMIN_USERS,
+        fields={"claims": CLAIMS, "discriminator": "alice", "reason": "miss"},
+    )
+
+
+def test_admin_users_cleared(audit_records):
+    wrapper = loggers.AdminUsersAuditLog(claims=CLAIMS)
+
+    wrapper.admin_users_cleared()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ADMIN_USERS_CLEARED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ADMIN_USERS,
+        fields={"claims": CLAIMS},
+    )
+
+
+# --- InstallationConfigAuditLog -------------------------------------------
+
+
+@pytest.mark.parametrize("w_claims", [{}, CLAIMS])
+def test_installationconfigauditlog_ctor(w_claims):
+    found = loggers.InstallationConfigAuditLog(claims=w_claims)
+
+    assert found.name == loggers.SOLIPLEX_AUDIT_LOGGER_NAME
+    scope = found.extra[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA]
+    assert scope == SCOPE_INSTALLATION_CONFIG
+    assert found.extra["claims"] == w_claims
+
+
+def test_installation_read(audit_records):
+    wrapper = loggers.InstallationConfigAuditLog(claims=CLAIMS)
+
+    wrapper.installation_read()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_INSTALLATION_READ,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_INSTALLATION_CONFIG,
+        fields={"claims": CLAIMS},
+    )
+
+
+def test_installation_versions_read(audit_records):
+    wrapper = loggers.InstallationConfigAuditLog(claims=CLAIMS)
+
+    wrapper.installation_versions_read()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_INSTALLATION_VERSIONS_READ,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_INSTALLATION_CONFIG,
+        fields={"claims": CLAIMS},
+    )
+
+
+def test_installation_providers_read(audit_records):
+    wrapper = loggers.InstallationConfigAuditLog(claims=CLAIMS)
+
+    wrapper.installation_providers_read()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_INSTALLATION_PROVIDERS_READ,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_INSTALLATION_CONFIG,
+        fields={"claims": CLAIMS},
+    )
+
+
+def test_installation_git_metadata_read(audit_records):
+    wrapper = loggers.InstallationConfigAuditLog(claims=CLAIMS)
+
+    wrapper.installation_git_metadata_read()
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_INSTALLATION_GIT_METADATA_READ,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_INSTALLATION_CONFIG,
+        fields={"claims": CLAIMS},
+    )
+
+
+# --- RAGAccessAuditLog ---------------------------------------------------
+
+
+@pytest.mark.parametrize("w_claims", [{}, CLAIMS])
+def test_ragaccessauditlog_ctor(w_claims):
+    found = loggers.RAGAccessAuditLog(claims=w_claims)
+
+    assert found.name == loggers.SOLIPLEX_AUDIT_LOGGER_NAME
+    scope = found.extra[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA]
+    assert scope == SCOPE_RAG_ACCESS
+    assert found.extra["claims"] == w_claims

--- a/tests/unit/views/test_file_uploads_http.py
+++ b/tests/unit/views/test_file_uploads_http.py
@@ -8,7 +8,7 @@ from fastapi import testclient
 from soliplex import authz
 from soliplex import installation
 from soliplex import loggers
-from soliplex import views as views_package
+from soliplex import views
 from soliplex.config import rooms as config_rooms
 from soliplex.views import file_uploads as file_uploads_views
 
@@ -54,9 +54,9 @@ def app(the_installation):
         return the_installation
 
     app.dependency_overrides[installation.get_the_installation] = _inst
-    app.dependency_overrides[views_package.get_the_user_claims] = _user_claims
-    app.dependency_overrides[authz.get_the_room_authz_policy] = _authz
-    app.dependency_overrides[views_package.get_the_logger] = _logger
+    app.dependency_overrides[views.get_the_user_claims] = _user_claims
+    app.dependency_overrides[views.get_the_room_authz_policy] = _authz
+    app.dependency_overrides[views.get_the_logger] = _logger
     return app
 
 

--- a/tests/unit/views/test_installation_views.py
+++ b/tests/unit/views/test_installation_views.py
@@ -23,6 +23,14 @@ GIT_TAG = "test-git-tag"
 THE_USER_CLAIMS = {"email": "admin@example.com"}
 
 
+@mock.patch("soliplex.views.installation.ConfigAuditLog")
+def test_get_the_config_audit_log(cal_klass):
+    found = installation_views.get_the_config_audit_log(THE_USER_CLAIMS)
+
+    assert found is cal_klass.return_value
+    cal_klass.assert_called_once_with(claims=THE_USER_CLAIMS)
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize("w_admin_access", [False, True])
 @mock.patch("soliplex.models.Installation.from_config")
@@ -35,6 +43,7 @@ async def test_get_installation(fc, w_admin_access):
     the_admin_users.check_admin_access.return_value = w_admin_access
     the_logger = mock.create_autospec(loggers.LogWrapper)
     bound_logger = the_logger.bind.return_value
+    the_audit = mock.create_autospec(loggers.InstallationConfigAuditLog)
 
     if not w_admin_access:
         with pytest.raises(fastapi.HTTPException) as exc:
@@ -43,6 +52,7 @@ async def test_get_installation(fc, w_admin_access):
                 the_admin_users=the_admin_users,
                 the_user_claims=THE_USER_CLAIMS,
                 the_logger=the_logger,
+                the_audit=the_audit,
             )
 
         assert exc.value.status_code == 403
@@ -50,6 +60,7 @@ async def test_get_installation(fc, w_admin_access):
         bound_logger.error.assert_called_once_with(
             loggers.AUTHZ_ADMIN_ACCESS_REQUIRED,
         )
+        the_audit.installation_read.assert_not_called()
 
     else:
         found = await installation_views.get_installation(
@@ -57,11 +68,13 @@ async def test_get_installation(fc, w_admin_access):
             the_admin_users=the_admin_users,
             the_user_claims=THE_USER_CLAIMS,
             the_logger=the_logger,
+            the_audit=the_audit,
         )
 
         assert found is fc.return_value
 
         fc.assert_called_once_with(i_config)
+        the_audit.installation_read.assert_called_once_with()
 
     the_admin_users.check_admin_access.assert_awaited_once_with(
         THE_USER_CLAIMS
@@ -78,6 +91,7 @@ async def test_get_installation_versions_w_error(sp):
     the_admin_users.check_admin_access.return_value = True
     the_logger = mock.create_autospec(loggers.LogWrapper)
     bound_logger = the_logger.bind.return_value
+    the_audit = mock.create_autospec(loggers.InstallationConfigAuditLog)
 
     def _check(exc):
         return exc.status_code == 500
@@ -88,6 +102,7 @@ async def test_get_installation_versions_w_error(sp):
             the_admin_users=the_admin_users,
             the_user_claims=THE_USER_CLAIMS,
             the_logger=the_logger,
+            the_audit=the_audit,
         )
 
     assert exc.value.detail == loggers.INST_SUBPROCESS_PIP
@@ -96,6 +111,9 @@ async def test_get_installation_versions_w_error(sp):
         THE_USER_CLAIMS,
     )
 
+    # The read is audited once the admin gate passes, before the
+    # subprocess (which here fails with a 500).
+    the_audit.installation_versions_read.assert_called_once_with()
     bound_logger.exception.assert_called_once_with(
         loggers.INST_SUBPROCESS_PIP,
     )
@@ -128,6 +146,7 @@ async def test_get_installation_versions_wo_error(sp, w_admin_access):
     the_admin_users.check_admin_access.return_value = w_admin_access
     the_logger = mock.create_autospec(loggers.LogWrapper)
     bound_logger = the_logger.bind.return_value
+    the_audit = mock.create_autospec(loggers.InstallationConfigAuditLog)
 
     if not w_admin_access:
         with pytest.raises(fastapi.HTTPException) as exc:
@@ -136,6 +155,7 @@ async def test_get_installation_versions_wo_error(sp, w_admin_access):
                 the_admin_users=the_admin_users,
                 the_user_claims=THE_USER_CLAIMS,
                 the_logger=the_logger,
+                the_audit=the_audit,
             )
 
         assert exc.value.status_code == 403
@@ -143,6 +163,7 @@ async def test_get_installation_versions_wo_error(sp, w_admin_access):
         bound_logger.error.assert_called_once_with(
             loggers.AUTHZ_ADMIN_ACCESS_REQUIRED,
         )
+        the_audit.installation_versions_read.assert_not_called()
 
     else:
         found = await installation_views.get_installation_versions(
@@ -150,9 +171,11 @@ async def test_get_installation_versions_wo_error(sp, w_admin_access):
             the_admin_users=the_admin_users,
             the_user_claims=THE_USER_CLAIMS,
             the_logger=the_logger,
+            the_audit=the_audit,
         )
 
         assert found == expected
+        the_audit.installation_versions_read.assert_called_once_with()
 
     the_admin_users.check_admin_access.assert_awaited_once_with(
         THE_USER_CLAIMS,
@@ -178,6 +201,7 @@ async def test_get_installation_providers(w_admin_access):
     the_admin_users.check_admin_access.return_value = w_admin_access
     the_logger = mock.create_autospec(loggers.LogWrapper)
     bound_logger = the_logger.bind.return_value
+    the_audit = mock.create_autospec(loggers.InstallationConfigAuditLog)
 
     if not w_admin_access:
         with pytest.raises(fastapi.HTTPException) as exc:
@@ -186,6 +210,7 @@ async def test_get_installation_providers(w_admin_access):
                 the_admin_users=the_admin_users,
                 the_user_claims=THE_USER_CLAIMS,
                 the_logger=the_logger,
+                the_audit=the_audit,
             )
 
         assert exc.value.status_code == 403
@@ -193,6 +218,7 @@ async def test_get_installation_providers(w_admin_access):
         bound_logger.error.assert_called_once_with(
             loggers.AUTHZ_ADMIN_ACCESS_REQUIRED,
         )
+        the_audit.installation_providers_read.assert_not_called()
 
     else:
         found = await installation_views.get_installation_providers(
@@ -200,9 +226,11 @@ async def test_get_installation_providers(w_admin_access):
             the_admin_users=the_admin_users,
             the_user_claims=THE_USER_CLAIMS,
             the_logger=the_logger,
+            the_audit=the_audit,
         )
 
         assert found == PROVIDER_INFO
+        the_audit.installation_providers_read.assert_called_once_with()
 
     the_admin_users.check_admin_access.assert_awaited_once_with(
         THE_USER_CLAIMS,
@@ -227,6 +255,7 @@ async def test_get_installation_git_metadata(gm_klass, w_admin_access):
     the_admin_users.check_admin_access.return_value = w_admin_access
     the_logger = mock.create_autospec(loggers.LogWrapper)
     bound_logger = the_logger.bind.return_value
+    the_audit = mock.create_autospec(loggers.InstallationConfigAuditLog)
 
     if not w_admin_access:
         with pytest.raises(fastapi.HTTPException) as exc:
@@ -235,6 +264,7 @@ async def test_get_installation_git_metadata(gm_klass, w_admin_access):
                 the_admin_users=the_admin_users,
                 the_user_claims=THE_USER_CLAIMS,
                 the_logger=the_logger,
+                the_audit=the_audit,
             )
 
         assert exc.value.status_code == 403
@@ -242,6 +272,7 @@ async def test_get_installation_git_metadata(gm_klass, w_admin_access):
         bound_logger.error.assert_called_once_with(
             loggers.AUTHZ_ADMIN_ACCESS_REQUIRED,
         )
+        the_audit.installation_git_metadata_read.assert_not_called()
 
     else:
         found = await installation_views.get_installation_git_metadata(
@@ -249,6 +280,7 @@ async def test_get_installation_git_metadata(gm_klass, w_admin_access):
             the_admin_users=the_admin_users,
             the_user_claims=THE_USER_CLAIMS,
             the_logger=the_logger,
+            the_audit=the_audit,
         )
 
         assert found == models.GitMetadata(
@@ -256,6 +288,7 @@ async def test_get_installation_git_metadata(gm_klass, w_admin_access):
             git_branch=GIT_BRANCH,
             git_tag=GIT_TAG,
         )
+        the_audit.installation_git_metadata_read.assert_called_once_with()
 
     bound_logger.debug.assert_called_once_with(
         loggers.INST_GET_INSTALLATION_GIT_METADATA,

--- a/tests/unit/views/test_package.py
+++ b/tests/unit/views/test_package.py
@@ -140,6 +140,56 @@ async def test_get_the_logger(the_installation, w_claims, w_claims_map):
 
 
 @pytest.mark.anyio
+@mock.patch("soliplex.authz.persistence.AdminUserPolicy")
+@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
+async def test_get_the_admin_user_policy(as_klass, ap_klass):
+    engine = object()
+    request = fastapi.Request(scope={"type": "http"})
+    request.state.authorization_engine = engine
+
+    counter = 0
+
+    async for policy in views.get_the_admin_user_policy(
+        request, THE_USER_CLAIMS
+    ):
+        assert policy is ap_klass.return_value
+        counter += 1
+
+    assert counter == 1
+
+    ap_klass.assert_called_once_with(
+        as_klass.return_value.__aenter__.return_value,
+        THE_USER_CLAIMS,
+    )
+    as_klass.assert_called_once_with(bind=engine)
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.authz.persistence.RoomAuthorizationPolicy")
+@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
+async def test_get_the_room_authz_policy(as_klass, rap_klass):
+    engine = object()
+    request = fastapi.Request(scope={"type": "http"})
+    request.state.authorization_engine = engine
+
+    counter = 0
+
+    async for policy in views.get_the_room_authz_policy(
+        request, THE_USER_CLAIMS
+    ):
+        assert policy is rap_klass.return_value
+        counter += 1
+
+    assert counter == 1
+
+    rap_klass.assert_called_once_with(
+        as_klass.return_value.__aenter__.return_value,
+        THE_USER_CLAIMS,
+    )
+    as_klass.assert_called_once_with(bind=engine)
+
+
+@pytest.mark.anyio
 async def test_health_check():
     response = await views.health_check()
 

--- a/tests/unit/views/test_stats_views.py
+++ b/tests/unit/views/test_stats_views.py
@@ -11,7 +11,7 @@ from soliplex import authz
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
-from soliplex import views as views_package
+from soliplex import views
 from soliplex.views import stats as stats_views
 
 ROOM_ID = "test-room"
@@ -228,10 +228,10 @@ def the_app(the_threads):
         return mock.create_autospec(loggers.LogWrapper)
 
     app.dependency_overrides[installation.get_the_installation] = _inst
-    app.dependency_overrides[authz.get_the_room_authz_policy] = _authz
+    app.dependency_overrides[views.get_the_room_authz_policy] = _authz
     app.dependency_overrides[agui_package.get_the_threads] = _threads
-    app.dependency_overrides[views_package.get_the_user_claims] = _user_claims
-    app.dependency_overrides[views_package.get_the_logger] = _logger
+    app.dependency_overrides[views.get_the_user_claims] = _user_claims
+    app.dependency_overrides[views.get_the_logger] = _logger
     return app
 
 


### PR DESCRIPTION
- 'loggers.ProcessLifetimeAuditLog' emits audit records for server proces start / stop.  This logger is owned by the 'soliplex.installation.lifetime' function, which is responsible for emitting its log records.

- 'loggers.RoomAuthzAuditLog' emits audit records for qyer / update of room authorization policies and their associated ACL entries. This logger is owned by 'authz.persistence.RoomAuthorizationPolicy', which is responsible for emitting its log records.

- 'loggers.AdminUsersAuditLog' emits audit records for query / update of admin users.  This logger is owned by 'authz.persistence.RoomAuthorizationPolicy', which is responsible for emitting its log records.

- 'loggers.InstallationConfigAuditLog' emits audit records for queries against potentially-sensitive installation configuration.  This logger is owned by the `views.installation` module:  its view functions are responsible for emitting its log records.

- 'loggers.RAGAccessAuditLog' is a stub for future implementation.

Toward #1092.