### PR TITLE
feat: opt-in CLI audit logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,16 @@
 # LOGFIRE_TOKEN=pylf...
 
 # -----------------------------------------------------------------------------
+# CLI audit logging
+# -----------------------------------------------------------------------------
+# Path to a Python logging-config YAML enabling audit logging for privileged
+# 'soliplex-cli' commands ('admin-users' / 'room-authz'), e.g. routing the
+# 'soliplex-audit' logger to a file. If unset, CLI audit records are
+# suppressed so they don't intermingle with command output. Equivalent to the
+# '--cli-log-config' group option. See docs/config/logging.md.
+# SOLIPLEX_CLI_LOG_CONFIG=/path/to/cli-audit-logging.yaml
+
+# -----------------------------------------------------------------------------
 # OpenAI
 # -----------------------------------------------------------------------------
 # Your OpenAI API key (required only if one or more agents are configured

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,10 @@ See `.env.example` for the full reference. Key variables:
 - `SOLIPLEX_URL_SAFE_TOKEN_SECRET` -- MCP token secret (auto-generated if
   unset)
 - `LOGFIRE_TOKEN` -- Pydantic Logfire token (optional)
+- `SOLIPLEX_CLI_LOG_CONFIG` -- path to a Python logging-config YAML enabling
+  audit logging for privileged CLI commands (also the `--cli-log-config`
+  group option on `admin-users` / `room-authz` / `audit`); unset means CLI
+  audit records are suppressed (see `docs/config/logging.md`)
 
 ## Documentation
 

--- a/docs/config/logging.md
+++ b/docs/config/logging.md
@@ -62,6 +62,59 @@ soliplex-cli serve example/minimal.yaml --log-config example/logging.yaml
 2026-02-09T18:16:40|INFO|uvicorn.error|Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 ```
 
+## CLI Audit Logging
+
+Privileged `soliplex-cli` operations (the `admin-users` and `room-authz`
+mutations and security-object reads) emit audit records to the dedicated
+`soliplex-audit` logger, the same way the REST API does. By default the CLI
+**suppresses** these records so they do not intermingle with normal command
+output during interactive use — the installation's own `logging_config_file`
+(which typically targets `sys.stdout`, for the *server*) is deliberately
+**not** applied to the CLI.
+
+To capture the CLI audit trail, pass a dedicated
+Python logging-config YAML — one that routes the `soliplex-audit`
+logger to the appropriate sink — via the `--cli-log-config` option
+(or set the `SOLIPLEX_CLI_LOG_CONFIG` environment variable).
+
+The option is a **group-level** option on the `admin-users`, `room-authz`,
+and `audit` command groups, so it must appear **before** the subcommand name:
+
+```bash
+# via the option (before the subcommand):
+soliplex-cli room-authz --cli-log-config cli-audit-logging.yaml \
+    make-private example/minimal.yaml faux
+
+# or via the environment variable:
+SOLIPLEX_CLI_LOG_CONFIG=cli-audit-logging.yaml \
+    soliplex-cli admin-users add example/minimal.yaml alice@example.com
+```
+
+Example audit log config:
+
+```yaml
+# cli-audit-logging.yaml
+version: 1
+disable_existing_loggers: false
+formatters:
+  audit:
+    format: "%(asctime)s|%(levelname)s|%(outcome)s|%(message)s"
+handlers:
+  audit_file:
+    class: "logging.FileHandler"
+    filename: "/var/log/soliplex/audit.log"
+    formatter: "audit"
+loggers:
+  soliplex-audit:
+    level: "INFO"
+    handlers: ["audit_file"]
+    propagate: false
+```
+
+Each record carries an `outcome` field (`success`, `denied`, or `error`)
+and an `audit-scope` field, so failed and denied operations are audited
+alongside successful ones.
+
 ## Configure Logging `extra` Values from Request Headers
 
 Request header values may be useful in logging:  for instance, if a proxy

--- a/docs/server/cli.md
+++ b/docs/server/cli.md
@@ -158,6 +158,15 @@ example/minimal.yaml`.
   run, the errors are emitted as a single JSON document on stdout
   (suitable for piping into `jq` or a CI log parser); each subcommand
   documents its own JSON shape under "Exit Status".
+- `--cli-log-config PATH` — apply the named Python logging-config YAML
+  for CLI audit logging (also read from the `SOLIPLEX_CLI_LOG_CONFIG`
+  environment variable); without it, audit records are suppressed. The
+  `audit` subcommands do not mutate state, but
+  [`audit admin-users`](#audit-admin-users) and
+  [`audit room-authz`](#audit-room-authz) read security objects through
+  the authorization policies and so emit security-object-read audit
+  records, which this option captures. See
+  [CLI Audit Logging](../config/logging.md#cli-audit-logging).
 
 ### Default Subcommand
 
@@ -1347,6 +1356,13 @@ All six commands share the following conventions:
     2. bob@example.com
   ```
 
+- The group-level `--cli-log-config PATH` option (also read from the
+  `SOLIPLEX_CLI_LOG_CONFIG` environment variable) enables CLI audit
+  logging by applying the named Python logging-config YAML; without it,
+  the audit records these commands emit are suppressed so they don't
+  intermingle with the JSON / human output. See
+  [CLI Audit Logging](../config/logging.md#cli-audit-logging).
+
 - Exit status is `0` on success, or `1` when the RAM-DB guard fires
   or any per-command precondition fails: for
   [`admin-users add`](#admin-users-add), when the discriminator
@@ -1761,6 +1777,13 @@ All eight commands share the following:
     1. ALLOW  email=alice@example.com
     2. DENY   everyone
   ```
+
+- The group-level `--cli-log-config PATH` option (also read from the
+  `SOLIPLEX_CLI_LOG_CONFIG` environment variable) enables CLI audit
+  logging by applying the named Python logging-config YAML; without it,
+  the audit records these commands emit are suppressed so they don't
+  intermingle with the JSON / human output. See
+  [CLI Audit Logging](../config/logging.md#cli-audit-logging).
 
 - Exit status is `0` on success (including when no policy row exists
   for the room), or `1` when the RAM-DB guard fires or `ROOM_ID`

--- a/example/cli-audit-logging.yaml
+++ b/example/cli-audit-logging.yaml
@@ -1,0 +1,37 @@
+# Ready-made logging config enabling CLI audit logging.
+#
+# Pass it to a privileged 'soliplex-cli' command group via '--cli-log-config'
+# (before the subcommand) or the 'SOLIPLEX_CLI_LOG_CONFIG' env var, e.g.:
+#
+#   soliplex-cli room-authz --cli-log-config example/cli-audit-logging.yaml \
+#       make-private example/minimal.yaml faux
+#
+# It routes the dedicated 'soliplex-audit' logger to a file (so audit records
+# do not intermingle with normal CLI output). Without such a config, CLI
+# audit records are suppressed. See: docs/config/logging.md
+#
+# https://docs.python.org/3/library/logging.config.html#dictionary-schema-details
+version: 1
+disable_existing_loggers: false
+formatters:
+
+  audit:
+    # 'outcome' is one of: success, denied, error.
+    format: "$asctime|$levelname|$outcome|$message"
+    datefmt: "%Y-%m-%dT%H:%M:%S"
+    style: "$"
+
+handlers:
+
+  audit_file:
+    class: "logging.FileHandler"
+    formatter: "audit"
+    filename: "soliplex-cli-audit.log"
+
+loggers:
+
+  soliplex-audit:
+    level: "INFO"
+    handlers:
+      - "audit_file"
+    propagate: false

--- a/src/soliplex/cli/admin_users.py
+++ b/src/soliplex/cli/admin_users.py
@@ -49,7 +49,10 @@ def _admin_users_callback(
             "verbose-by-default setting."
         ),
     ),
+    cli_log_config: pathlib.Path | None = cli_util.CLI_LOG_CONFIG_OPTION,
 ):
+    cli_util._configure_cli_logging(cli_log_config)
+
     if quiet:
         effective = False
     elif verbose:

--- a/src/soliplex/cli/audit.py
+++ b/src/soliplex/cli/audit.py
@@ -111,7 +111,9 @@ app = typer.Typer(
 def _audit_callback(
     ctx: typer.Context,
     quiet: bool = _QUIET_OPTION,
+    cli_log_config: pathlib.Path | None = cli_util.CLI_LOG_CONFIG_OPTION,
 ):
+    cli_util._configure_cli_logging(cli_log_config)
     ctx.obj = {"quiet": quiet}
 
 

--- a/src/soliplex/cli/cli_util.py
+++ b/src/soliplex/cli/cli_util.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import contextlib
 import getpass
+import logging
 import os
 import pathlib
+from logging import config as logging_config
 
 import typer
 from rich import console
@@ -11,11 +13,27 @@ from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import authz
 from soliplex import installation
+from soliplex import loggers
 from soliplex.authz import persistence as authz_persistence
 from soliplex.authz import schema as authz_schema
 from soliplex.config import installation as config_installation
 
 the_console = console.Console()
+
+
+# Shared across the audit-relevant command groups ('admin-users', 'room-authz',
+# 'audit'); see '_configure_cli_logging'.
+CLI_LOG_CONFIG_OPTION = typer.Option(
+    None,
+    "--cli-log-config",
+    envvar="SOLIPLEX_CLI_LOG_CONFIG",
+    help=(
+        "Path to a Python logging-config YAML enabling CLI audit logging "
+        "(e.g. routing the 'soliplex-audit' logger to a file). Without it, "
+        "audit records are suppressed so they don't intermingle with CLI "
+        "output."
+    ),
+)
 
 
 def get_installation(
@@ -54,6 +72,43 @@ def _check_ram_dburi(dburi: str, command: str):
         raise typer.Exit(1)
 
 
+# Logging is process-global; the first caller (a group callback, or the
+# '_authz_session' safety net for the callback-bypassing hidden aliases)
+# wins and the rest no-op.
+_CLI_LOGGING_CONFIGURED = False
+
+
+def _configure_cli_logging(cli_log_config: pathlib.Path | None = None) -> None:
+    """Configure (or silence) audit logging for an audited CLI operation.
+
+    Opt-in only: 'cli_log_config' (from '--cli-log-config' /
+    'SOLIPLEX_CLI_LOG_CONFIG') names a Python logging-config YAML the operator
+    wants applied -- e.g. routing 'soliplex-audit' to a file. With nothing
+    set, the CLI stays silent so audit records never intermingle with
+    interactive output. The installation's own (stdout-targeting)
+    'logging_config' is deliberately NOT consulted here, keeping STIG audit
+    logging segregated from ordinary CLI use.
+    """
+    global _CLI_LOGGING_CONFIGURED
+    if _CLI_LOGGING_CONFIGURED:
+        return
+
+    if cli_log_config is not None:
+        logging_config.dictConfig(
+            config_installation._load_config_yaml(cli_log_config)
+        )
+    else:
+        audit_logger = logging.getLogger(loggers.SOLIPLEX_AUDIT_LOGGER_NAME)
+        # Replace (not append) any handlers and stop propagation: a
+        # NullHandler alone still lets records bubble to ancestor handlers,
+        # and with no handler at all 'lastResort' still prints ERROR records
+        # to stderr.
+        audit_logger.handlers[:] = [logging.NullHandler()]
+        audit_logger.propagate = False
+
+    _CLI_LOGGING_CONFIGURED = True
+
+
 @contextlib.asynccontextmanager
 async def _authz_session(dburi):
     """Yield an async session over the authz DB, disposing its engine.
@@ -67,6 +122,10 @@ async def _authz_session(dburi):
     'typer.Exit' paths -- so the underlying SQLite connection is released
     deterministically instead of leaking it until garbage collection.
     """
+    # Safety net: the hidden 'add-admin-user' / 'show-room-authz' / ...
+    # aliases bypass the group callbacks, so silence audit output here unless
+    # a callback already configured it.
+    _configure_cli_logging()
     engine = installation._create_async_engine(dburi)
     try:
         async with engine.begin() as connection:

--- a/src/soliplex/cli/room_authz.py
+++ b/src/soliplex/cli/room_authz.py
@@ -51,7 +51,10 @@ def _room_authz_callback(
             "verbose-by-default setting."
         ),
     ),
+    cli_log_config: pathlib.Path | None = cli_util.CLI_LOG_CONFIG_OPTION,
 ):
+    cli_util._configure_cli_logging(cli_log_config)
+
     if quiet:
         effective = False
     elif verbose:

--- a/tests/unit/cli/test_cli_admin_users.py
+++ b/tests/unit/cli/test_cli_admin_users.py
@@ -34,7 +34,9 @@ def ctx():
         (True, True, True, False),
     ],
 )
+@mock.patch("soliplex.cli.cli_util._configure_cli_logging")
 def test__admin_users_callback(
+    configure_logging,
     ctx,
     w_verbose,
     w_quiet,
@@ -50,9 +52,11 @@ def test__admin_users_callback(
             ctx,
             verbose=w_verbose,
             quiet=w_quiet,
+            cli_log_config=None,
         )
 
     assert ctx.obj == {"verbose": exp_effective}
+    configure_logging.assert_called_once_with(None)
 
 
 @pytest.mark.parametrize(
@@ -496,6 +500,28 @@ def _invoke(cli_runner, scratch, subcommand, *rest, **kwargs):
         [subcommand, str(scratch.path), *rest],
         **kwargs,
     )
+
+
+@mock.patch("soliplex.cli.cli_util._configure_cli_logging")
+def test_cli_log_config_from_env(
+    configure_logging, scratch_installation, cli_runner, tmp_path
+):
+    # The '--cli-log-config' option is backed by 'SOLIPLEX_CLI_LOG_CONFIG'
+    # via Typer's 'envvar='; the env value reaches the callback as a Path.
+    cfg = tmp_path / "audit-logging.yaml"
+    cfg.write_text("version: 1\n")
+
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "list",
+        env={"SOLIPLEX_CLI_LOG_CONFIG": str(cfg)},
+    )
+
+    assert result.exit_code == 0
+    # The group callback (which runs first) forwards the env-derived Path;
+    # the '_authz_session' safety net then calls it again with no argument.
+    assert configure_logging.call_args_list[0] == mock.call(cfg)
 
 
 # -- list -------------------------------------------------------------------

--- a/tests/unit/cli/test_cli_audit.py
+++ b/tests/unit/cli/test_cli_audit.py
@@ -170,12 +170,38 @@ def test__auditgroup_parse_args(parse_args, ctx, w_args, exp_args):
 
 
 @pytest.mark.parametrize("w_quiet", [False, True])
-def test__audit_callback(ctx, w_quiet):
+@mock.patch("soliplex.cli.cli_util._configure_cli_logging")
+def test__audit_callback(configure_logging, ctx, w_quiet):
     w_quiet_kw = {"quiet": w_quiet}
 
-    cli_audit._audit_callback(ctx, **w_quiet_kw)
+    cli_audit._audit_callback(ctx, cli_log_config=None, **w_quiet_kw)
 
     assert ctx.obj["quiet"] == w_quiet
+    configure_logging.assert_called_once_with(None)
+
+
+@mock.patch("soliplex.cli.cli_util._configure_cli_logging")
+def test_cli_log_config_from_env(
+    configure_logging, scratch_installation, cli_runner, tmp_path
+):
+    # 'audit room-authz' (like 'audit admin-users') reads security objects
+    # through the authz policy, so it emits security-object-read audit
+    # records -- hence the group's '--cli-log-config' option, backed by
+    # 'SOLIPLEX_CLI_LOG_CONFIG' via Typer's 'envvar='. Verify the env value
+    # reaches the callback as a Path. Regression guard.
+    cfg = tmp_path / "audit-logging.yaml"
+    cfg.write_text("version: 1\n")
+
+    result = cli_runner.invoke(
+        cli_audit.app,
+        ["room-authz", str(scratch_installation.path)],
+        env={"SOLIPLEX_CLI_LOG_CONFIG": str(cfg)},
+    )
+
+    assert result.exit_code == 0
+    # The group callback (which runs first) forwards the env-derived Path;
+    # the '_authz_session' safety net then calls it again with no argument.
+    assert configure_logging.call_args_list[0] == mock.call(cfg)
 
 
 @pytest.mark.parametrize("w_errors", [False, True])

--- a/tests/unit/cli/test_cli_room_authz.py
+++ b/tests/unit/cli/test_cli_room_authz.py
@@ -43,7 +43,9 @@ def the_installation() -> installation.Installation:
         (True, True, True, False),
     ],
 )
+@mock.patch("soliplex.cli.cli_util._configure_cli_logging")
 def test__room_authz_callback(
+    configure_logging,
     ctx,
     w_verbose,
     w_quiet,
@@ -59,9 +61,11 @@ def test__room_authz_callback(
             ctx,
             verbose=w_verbose,
             quiet=w_quiet,
+            cli_log_config=None,
         )
 
     assert ctx.obj == {"verbose": exp_effective}
+    configure_logging.assert_called_once_with(None)
 
 
 @pytest.mark.parametrize(
@@ -727,6 +731,29 @@ def _invoke(cli_runner, scratch, subcommand, *rest, **kwargs):
         [subcommand, str(scratch.path), *rest],
         **kwargs,
     )
+
+
+@mock.patch("soliplex.cli.cli_util._configure_cli_logging")
+def test_cli_log_config_from_env(
+    configure_logging, scratch_installation, cli_runner, tmp_path
+):
+    # The '--cli-log-config' option is backed by 'SOLIPLEX_CLI_LOG_CONFIG'
+    # via Typer's 'envvar='; the env value reaches the callback as a Path.
+    cfg = tmp_path / "audit-logging.yaml"
+    cfg.write_text("version: 1\n")
+
+    result = _invoke(
+        cli_runner,
+        scratch_installation,
+        "show",
+        "chat",
+        env={"SOLIPLEX_CLI_LOG_CONFIG": str(cfg)},
+    )
+
+    assert result.exit_code == 0
+    # The group callback (which runs first) forwards the env-derived Path;
+    # the '_authz_session' safety net then calls it again with no argument.
+    assert configure_logging.call_args_list[0] == mock.call(cfg)
 
 
 # -- show -------------------------------------------------------------------

--- a/tests/unit/cli/test_cli_util.py
+++ b/tests/unit/cli/test_cli_util.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import contextlib
+import logging
+import pathlib
 from unittest import mock
 
 import pytest
@@ -8,6 +10,7 @@ import typer
 
 from soliplex import authz
 from soliplex import installation
+from soliplex import loggers
 from soliplex.cli import cli_util
 from soliplex.config import installation as config_installation
 
@@ -115,8 +118,86 @@ def test__check_ram_dburi(the_console, dburi, expectation):
         )
 
 
+@pytest.fixture
+def reset_cli_logging():
+    """Isolate the process-global state '_configure_cli_logging' touches.
+
+    Resets the "configure once" guard to False before the test (so the real
+    logic runs) and restores the 'soliplex-audit' logger's handlers /
+    propagate -- plus the guard -- afterward, so the mutation does not leak
+    into other tests.
+    """
+    audit_logger = logging.getLogger(loggers.SOLIPLEX_AUDIT_LOGGER_NAME)
+    saved_handlers = list(audit_logger.handlers)
+    saved_propagate = audit_logger.propagate
+    saved_flag = cli_util._CLI_LOGGING_CONFIGURED
+    cli_util._CLI_LOGGING_CONFIGURED = False
+    try:
+        yield
+    finally:
+        audit_logger.handlers[:] = saved_handlers
+        audit_logger.propagate = saved_propagate
+        cli_util._CLI_LOGGING_CONFIGURED = saved_flag
+
+
+@mock.patch("soliplex.cli.cli_util.logging_config")
+@mock.patch("soliplex.cli.cli_util.config_installation._load_config_yaml")
+def test__configure_cli_logging_applies_config(
+    load_config_yaml, logging_config, reset_cli_logging
+):
+    cli_log_config = pathlib.Path("/etc/soliplex/audit-logging.yaml")
+
+    cli_util._configure_cli_logging(cli_log_config)
+
+    load_config_yaml.assert_called_once_with(cli_log_config)
+    logging_config.dictConfig.assert_called_once_with(
+        load_config_yaml.return_value,
+    )
+    assert cli_util._CLI_LOGGING_CONFIGURED is True
+
+
+def test__configure_cli_logging_silences_audit(reset_cli_logging):
+    cli_util._configure_cli_logging(None)
+
+    audit_logger = logging.getLogger(loggers.SOLIPLEX_AUDIT_LOGGER_NAME)
+    assert [type(h) for h in audit_logger.handlers] == [logging.NullHandler]
+    assert audit_logger.propagate is False
+    assert cli_util._CLI_LOGGING_CONFIGURED is True
+
+
+@mock.patch("soliplex.cli.cli_util.logging_config")
+def test__configure_cli_logging_noop_when_already_configured(
+    logging_config, reset_cli_logging
+):
+    # The first caller wins; a later call (here passing 'None') must not
+    # re-silence a logger an earlier '--cli-log-config' already configured.
+    cli_util._CLI_LOGGING_CONFIGURED = True
+    audit_logger = logging.getLogger(loggers.SOLIPLEX_AUDIT_LOGGER_NAME)
+    saved_handlers = list(audit_logger.handlers)
+    saved_propagate = audit_logger.propagate
+
+    cli_util._configure_cli_logging(None)
+
+    logging_config.dictConfig.assert_not_called()
+    assert audit_logger.handlers == saved_handlers
+    assert audit_logger.propagate is saved_propagate
+
+
 @pytest.mark.anyio
-async def test__admin_user_policy(tmp_path):
+@mock.patch("soliplex.cli.cli_util._configure_cli_logging")
+async def test__authz_session_configures_logging(configure_logging, tmp_path):
+    db_path = tmp_path / "authz.sqlite"
+    dburi = f"sqlite+aiosqlite:///{db_path}"
+
+    async with cli_util._authz_session(dburi):
+        pass
+
+    configure_logging.assert_called_once_with()
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.cli.cli_util._configure_cli_logging")
+async def test__admin_user_policy(_configure_logging, tmp_path):
     db_path = tmp_path / "authz.sqlite"
     dburi = f"sqlite+aiosqlite:///{db_path}"
     json_path = authz.token_field_json_path("email", "alice@example.com")
@@ -129,7 +210,8 @@ async def test__admin_user_policy(tmp_path):
 
 
 @pytest.mark.anyio
-async def test__room_authz_policy(tmp_path):
+@mock.patch("soliplex.cli.cli_util._configure_cli_logging")
+async def test__room_authz_policy(_configure_logging, tmp_path):
     db_path = tmp_path / "authz.sqlite"
     dburi = f"sqlite+aiosqlite:///{db_path}"
 


### PR DESCRIPTION
  ... configured via '--cli-log-config <path-to-logging.yaml>'

Privileged CLI commands ('admin-users', 'room-authz', 'audit') emit audit log records to the 'soliplex-audit' logger.

Normal CLI operations do *not* configure logging, because the emitted log records would be interleaved with the commands' own output.

If auditing these CLI commands is required, pass the option (or set the equivalent 'SOLIPLEX_CLI_LOG_CONFIG' envvar) to route the log recrods to the appropriate sink.

Closes #1099.