### PR TITLE
rag-access audit logging

### DIFF
--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -620,6 +620,15 @@ class RoomSkillsConfig(_SkillConfigModelBase):
         }
 
     @property
+    def rag_db_paths(self) -> dict[str, str]:
+        """Map each haiku-rag skill's name to the LanceDB path it reads."""
+        return {
+            skill_config.name: str(skill_config.rag_lancedb_path)
+            for skill_config in self.skill_configs.values()
+            if isinstance(skill_config, _HR_SkillConfigBase)
+        }
+
+    @property
     def skill_preambles(self) -> list[str]:
         preambles = []
 

--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -426,8 +426,14 @@ class RAGAccessAuditLog(AuditLogWrapper):
     # Records the knowledge-base accesses a skill makes while answering a
     # request. 'db_path' names the LanceDB the access targeted; 'selector' is
     # the query / document reference / chunk ids the access used; 'result_refs'
-    # are the identifiers returned (not their content). Reads that return
-    # nothing or whose tool errored are recorded as failures.
+    # are the identifiers returned (not their content), empty when the read
+    # matched nothing.
+    #
+    # On the run-mediated path Soliplex sees only the rendered tool result, not
+    # a tool-error signal, so every observed skill access is recorded via
+    # 'access' (outcome=success). 'access_failed' (outcome=error) is reserved
+    # for the direct helper endpoints (views.rooms), where the HTTP outcome
+    # authoritatively distinguishes a refused or absent access.
     def __init__(self, claims: dict[str, typing.Any], **extra):
         extra_with_claims = {"claims": claims} | extra
         super().__init__(scope=AuditLogScopes.RAG_ACCESS, **extra_with_claims)

--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -124,6 +124,9 @@ AUDIT_SERVER_STARTING = "server starting"
 AUDIT_SERVER_STARTED = "server started"
 AUDIT_SERVER_STOPPING = "server stopping"
 
+# rag-access audit events
+AUDIT_RAG_ACCESS = "rag access"
+
 
 class _StructuredFieldsAdapter(logging.LoggerAdapter):
     """LoggerAdapter that folds caller keyword fields into 'extra'."""
@@ -420,9 +423,37 @@ class InstallationConfigAuditLog(AuditLogWrapper):
 
 
 class RAGAccessAuditLog(AuditLogWrapper):
-    # Deferred (rag-access out of scope pending the haiku-rag approach); the
-    # scope and class exist so the audit vocabulary is complete, but no events
-    # are wired yet.
+    # Records the knowledge-base accesses a skill makes while answering a
+    # request. 'db_path' names the LanceDB the access targeted; 'selector' is
+    # the query / document reference / chunk ids the access used; 'result_refs'
+    # are the identifiers returned (not their content). Reads that return
+    # nothing or whose tool errored are recorded as failures.
     def __init__(self, claims: dict[str, typing.Any], **extra):
         extra_with_claims = {"claims": claims} | extra
         super().__init__(scope=AuditLogScopes.RAG_ACCESS, **extra_with_claims)
+
+    def access(
+        self,
+        db_path: str,
+        tool: str,
+        selector: typing.Any,
+        result_refs: typing.Any,
+    ):
+        self._succeeded(
+            AUDIT_RAG_ACCESS,
+            db_path=db_path,
+            tool=tool,
+            selector=selector,
+            result_refs=result_refs,
+        )
+
+    def access_failed(
+        self, db_path: str, tool: str, selector: typing.Any, reason: str
+    ):
+        self._failed(
+            AUDIT_RAG_ACCESS,
+            db_path=db_path,
+            tool=tool,
+            selector=selector,
+            reason=reason,
+        )

--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -127,6 +127,12 @@ AUDIT_SERVER_STOPPING = "server stopping"
 # rag-access audit events
 AUDIT_RAG_ACCESS = "rag access"
 
+# rag-access 'action' values: the kind of protected-data read, carried as a
+# field so both access paths share one vocabulary. The run-mediated path
+# records 'rag-retrieval'; the direct helper endpoints (future) will add
+# 'search' / 'chunk-viz' / 'doc-list' alongside their own methods.
+AUDIT_RAG_ACTION_RETRIEVAL = "rag-retrieval"
+
 
 class _StructuredFieldsAdapter(logging.LoggerAdapter):
     """LoggerAdapter that folds caller keyword fields into 'extra'."""
@@ -285,6 +291,11 @@ class AuditLogWrapper(_StructuredFieldsAdapter):
 
 
 class ProcessLifetimeAuditLog(AuditLogWrapper):
+    """Record process lifetime audit events
+
+    Each method corresponds to an event type.
+    """
+
     def __init__(self, **extra):
         super().__init__(scope=AuditLogScopes.PROCESS_LIFETIME, **extra)
 
@@ -299,6 +310,11 @@ class ProcessLifetimeAuditLog(AuditLogWrapper):
 
 
 class RoomAuthzAuditLog(AuditLogWrapper):
+    """Record room authorization audit events
+
+    Each method corresponds to an event type, with variants for outcomes.
+    """
+
     def __init__(self, claims: dict[str, typing.Any], **extra):
         extra_with_claims = {"claims": claims} | extra
         super().__init__(scope=AuditLogScopes.ROOM_AUTHZ, **extra_with_claims)
@@ -357,11 +373,17 @@ class RoomAuthzAuditLog(AuditLogWrapper):
             reason=reason,
         )
 
+    # policy / security-object deletion
     def acl_cleared(self, room_id: str):
         self._succeeded(AUDIT_ROOM_ACL_CLEARED, room_id=room_id)
 
 
 class AdminUsersAuditLog(AuditLogWrapper):
+    """Record admin users audit events
+
+    Each method corresponds to an event type, with variants for outcomes.
+    """
+
     def __init__(self, claims: dict[str, typing.Any], **extra):
         extra_with_claims = {"claims": claims} | extra
         super().__init__(scope=AuditLogScopes.ADMIN_USERS, **extra_with_claims)
@@ -402,6 +424,11 @@ class AdminUsersAuditLog(AuditLogWrapper):
 
 
 class InstallationConfigAuditLog(AuditLogWrapper):
+    """Record installation configuratino audit events
+
+    Each method corresponds to an access type.
+    """
+
     def __init__(self, claims: dict[str, typing.Any], **extra):
         extra_with_claims = {"claims": claims} | extra
         super().__init__(
@@ -423,22 +450,35 @@ class InstallationConfigAuditLog(AuditLogWrapper):
 
 
 class RAGAccessAuditLog(AuditLogWrapper):
-    # Records the knowledge-base accesses a skill makes while answering a
-    # request. 'db_path' names the LanceDB the access targeted; 'selector' is
-    # the query / document reference / chunk ids the access used; 'result_refs'
-    # are the identifiers returned (not their content), empty when the read
-    # matched nothing.
-    #
-    # On the run-mediated path Soliplex sees only the rendered tool result, not
-    # a tool-error signal, so every observed skill access is recorded via
-    # 'access' (outcome=success). 'access_failed' (outcome=error) is reserved
-    # for the direct helper endpoints (views.rooms), where the HTTP outcome
-    # authoritatively distinguishes a refused or absent access.
+    """Record knowledge-base accesses made while answering a request
+
+    Each method corresponds to an access type (the 'action' field).
+
+    The 'retrieval' acation covers the run-mediated path: Soliplex sees only
+    the rendered tool result, not a tool-error signal, so every observed
+    skill access is recorded as a success.
+
+    The direct helper endpoints for API endpoints (`views.rooms`) will add
+    their own action methods ('search' / 'chunk-viz' / 'doc-list') with
+    failure variants, where the HTTP outcome authoritatively distinguishes a
+    refused or absent access.
+
+    Room-level agent tool access will use the same action methods, but log
+    failure variants based on exceptions raised.
+
+    Action method parameters:
+
+    - 'db_path' names the LanceDB the access targeted
+    - 'selector' is the query / document reference / chunk ids used
+    - 'result_refs' are the identifiers returned (not their content);
+      empty when the read matched nothing.
+    """
+
     def __init__(self, claims: dict[str, typing.Any], **extra):
         extra_with_claims = {"claims": claims} | extra
         super().__init__(scope=AuditLogScopes.RAG_ACCESS, **extra_with_claims)
 
-    def access(
+    def retrieval(
         self,
         db_path: str,
         tool: str,
@@ -447,19 +487,9 @@ class RAGAccessAuditLog(AuditLogWrapper):
     ):
         self._succeeded(
             AUDIT_RAG_ACCESS,
+            action=AUDIT_RAG_ACTION_RETRIEVAL,
             db_path=db_path,
             tool=tool,
             selector=selector,
             result_refs=result_refs,
-        )
-
-    def access_failed(
-        self, db_path: str, tool: str, selector: typing.Any, reason: str
-    ):
-        self._failed(
-            AUDIT_RAG_ACCESS,
-            db_path=db_path,
-            tool=tool,
-            selector=selector,
-            reason=reason,
         )

--- a/src/soliplex/rag_audit.py
+++ b/src/soliplex/rag_audit.py
@@ -53,9 +53,12 @@ class RagAccessAuditor:
             captured = self._selectors.pop(content["tool_call_id"], None)
             if captured is None:
                 return
+            db_path = self._db_path_for(content["skill"])
+            if db_path is None:
+                return
             tool, selector = captured
             self._audit_log.access(
-                self._db_path_for(content["skill"]),
+                db_path,
                 tool,
                 selector,
                 _result_refs(content["result"]),

--- a/src/soliplex/rag_audit.py
+++ b/src/soliplex/rag_audit.py
@@ -1,0 +1,62 @@
+import json
+import re
+import typing
+
+import ag_ui.core as agui_core
+
+# Each search result is rendered as "[<chunk_id>] [rank N of M]\n...", so the
+# chunk ids a query returned can be recovered from the result text.
+_CHUNK_REF = re.compile(r"^\[([^\]]+)\] \[rank", re.MULTILINE)
+
+_CALL = "skill_tool_call"
+_RESULT = "skill_tool_result"
+
+
+def _result_refs(result: str) -> list[str]:
+    return _CHUNK_REF.findall(result)
+
+
+class RagAccessAuditor:
+    """Records knowledge-base accesses from a skill's AG-UI activity events.
+
+    A skill sub-agent's tool calls surface as paired ``skill_tool_call`` /
+    ``skill_tool_result`` activity snapshots sharing a ``tool_call_id``. Feed
+    every run event to ``handle``; each completed access is recorded on the
+    supplied ``RAGAccessAuditLog``. ``db_path_for`` maps a skill name to the
+    LanceDB path the skill reads.
+    """
+
+    def __init__(
+        self,
+        audit_log: typing.Any,
+        db_path_for: typing.Callable[[str], str | None],
+    ):
+        self._audit_log = audit_log
+        self._db_path_for = db_path_for
+        self._selectors: dict[str, tuple[str, typing.Any]] = {}
+
+    def handle(self, event: typing.Any) -> None:
+        if getattr(event, "type", None) is not (
+            agui_core.EventType.ACTIVITY_SNAPSHOT
+        ):
+            return
+
+        content = event.content
+
+        if event.activity_type == _CALL:
+            self._selectors[content["tool_call_id"]] = (
+                content["tool_name"],
+                json.loads(content["args"]),
+            )
+
+        elif event.activity_type == _RESULT:
+            captured = self._selectors.pop(content["tool_call_id"], None)
+            if captured is None:
+                return
+            tool, selector = captured
+            self._audit_log.access(
+                self._db_path_for(content["skill"]),
+                tool,
+                selector,
+                _result_refs(content["result"]),
+            )

--- a/src/soliplex/rag_audit.py
+++ b/src/soliplex/rag_audit.py
@@ -1,8 +1,13 @@
 import json
+import logging
 import re
 import typing
 
 import ag_ui.core as agui_core
+
+from soliplex import loggers
+
+_logger = logging.getLogger(loggers.SOLIPLEX_LOGGER_NAME)
 
 # Each search result is rendered as "[<chunk_id>] [rank N of M]\n...", so the
 # chunk ids a query returned can be recovered from the result text.
@@ -36,6 +41,17 @@ class RagAccessAuditor:
         self._selectors: dict[str, tuple[str, typing.Any]] = {}
 
     def handle(self, event: typing.Any) -> None:
+        # Auditing must never break the run it observes: a malformed activity
+        # event (missing content key, non-JSON args, upstream schema drift) is
+        # logged and swallowed rather than propagated into the event stream.
+        try:
+            self._handle(event)
+        except Exception:
+            _logger.exception(
+                "rag-access audit skipped a malformed skill activity event",
+            )
+
+    def _handle(self, event: typing.Any) -> None:
         if getattr(event, "type", None) is not (
             agui_core.EventType.ACTIVITY_SNAPSHOT
         ):

--- a/src/soliplex/rag_audit.py
+++ b/src/soliplex/rag_audit.py
@@ -73,7 +73,7 @@ class RagAccessAuditor:
             if db_path is None:
                 return
             tool, selector = captured
-            self._audit_log.access(
+            self._audit_log.retrieval(
                 db_path,
                 tool,
                 selector,

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -20,6 +20,7 @@ from soliplex import authz
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
+from soliplex import rag_audit
 from soliplex import titles
 from soliplex import util
 from soliplex import views
@@ -632,6 +633,8 @@ async def drive_llm_stream(
     run_id: str,
     title_agent_config: config_agents.AgentConfig | None = None,
     messages: list[agui_core.Message] | None = None,
+    claims: authn.UserClaims | None = None,
+    rag_db_paths: dict[str, str] | None = None,
 ):
     """Primary consumer of LLM event stream
 
@@ -640,6 +643,10 @@ async def drive_llm_stream(
     Events are pushed to the queue (for the live SSE client) and
     saved to the database incrementally (for reconnect).
     """
+    auditor = rag_audit.RagAccessAuditor(
+        loggers.RAGAccessAuditLog(claims=claims or {}),
+        (rag_db_paths or {}).get,
+    )
     with logfire.span(
         "AG-UI event stream: {room_id}/{thread_id}/{run_id}",
         room_id=room_id,
@@ -654,6 +661,7 @@ async def drive_llm_stream(
             async for event in llm_stream:
                 event_list.append(event)
                 await event_queue.put(event)
+                auditor.handle(event)
 
                 try:
                     await save_single_event(
@@ -744,6 +752,13 @@ def find_skill_toolset(
         if isinstance(toolset, hs_agent.SkillToolset):
             return toolset
     return None
+
+
+def _rag_db_paths(room_config: config_rooms.RoomConfig) -> dict[str, str]:
+    skills = room_config.skills
+    if skills is None:
+        return {}
+    return skills.rag_db_paths
 
 
 async def init_agent_stream(
@@ -906,6 +921,14 @@ async def post_room_agui_thread_id_run_id(
 
     skill_toolset = find_skill_toolset(agent)
 
+    room_config = await the_installation.get_room_config(
+        room_id=room_id,
+        user=the_user_claims,
+        the_room_authz=the_room_authz,
+        the_logger=the_logger,
+    )
+    rag_db_paths = _rag_db_paths(room_config)
+
     # We use an unbounded queue here, so that the 'drive_llm_stream'
     # task completes even when the SSE stream gets cancelled due to a
     # client disconnect, thereby permitting the client to see the
@@ -941,6 +964,8 @@ async def post_room_agui_thread_id_run_id(
             run_id=run_id,
             title_agent_config=title_agent_config,
             messages=agui_adapter.run_input.messages,
+            claims=the_user_claims,
+            rag_db_paths=rag_db_paths,
         )
     )
     bg_tasks.add(task)

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -644,7 +644,12 @@ async def drive_llm_stream(
     saved to the database incrementally (for reconnect).
     """
     auditor = rag_audit.RagAccessAuditor(
-        loggers.RAGAccessAuditLog(claims=claims or {}),
+        loggers.RAGAccessAuditLog(
+            claims=claims or {},
+            room_id=room_id,
+            thread_id=thread_id,
+            run_id=run_id,
+        ),
         (rag_db_paths or {}).get,
     )
     with logfire.span(

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -1174,6 +1174,33 @@ def test_roomskillsconfig_skills(installation_config):
     assert found == {SKILL_NAME: skill_config.skill}
 
 
+def test_roomskillsconfig_rag_db_paths(
+    installation_config,
+    haiku_rag_config,
+    lancedb,
+    config_path,
+):
+    skill_config = config_skills.HR_RAG_SkillConfig(
+        rag_lancedb_override_path=lancedb,
+        _haiku_rag_config=haiku_rag_config,
+        _config_path=config_path,
+        _installation_config=installation_config,
+    )
+    installation_config.skill_configs = {
+        SKILL_NAME: skill_config,
+        "other_skill": object(),
+    }
+
+    room_skill_config = config_skills.RoomSkillsConfig(
+        installation_skill_names=[SKILL_NAME, "other_skill"],
+        _installation_config=installation_config,
+    )
+
+    found = room_skill_config.rag_db_paths
+
+    assert found == {skill_config.name: str(skill_config.rag_lancedb_path)}
+
+
 def test_roomskillsconfig_skill_preambles(
     installation_config,
     haiku_rag_config,

--- a/tests/unit/test_loggers.py
+++ b/tests/unit/test_loggers.py
@@ -676,3 +676,45 @@ def test_ragaccessauditlog_ctor(w_claims):
     scope = found.extra[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA]
     assert scope == SCOPE_RAG_ACCESS
     assert found.extra["claims"] == w_claims
+
+
+def test_rag_access(audit_records):
+    wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
+
+    wrapper.access("db", "search", "what is x", ["c1", "c2"])
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_RAG_ACCESS,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_RAG_ACCESS,
+        fields={
+            "claims": CLAIMS,
+            "db_path": "db",
+            "tool": "search",
+            "selector": "what is x",
+            "result_refs": ["c1", "c2"],
+        },
+    )
+
+
+def test_rag_access_failed(audit_records):
+    wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
+
+    wrapper.access_failed("db", "cite", ["c9"], "unresolved")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_RAG_ACCESS,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_ERROR,
+        scope=SCOPE_RAG_ACCESS,
+        fields={
+            "claims": CLAIMS,
+            "db_path": "db",
+            "tool": "cite",
+            "selector": ["c9"],
+            "reason": "unresolved",
+        },
+    )

--- a/tests/unit/test_loggers.py
+++ b/tests/unit/test_loggers.py
@@ -678,10 +678,10 @@ def test_ragaccessauditlog_ctor(w_claims):
     assert found.extra["claims"] == w_claims
 
 
-def test_rag_access(audit_records):
+def test_rag_retrieval(audit_records):
     wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
 
-    wrapper.access("db", "search", "what is x", ["c1", "c2"])
+    wrapper.retrieval("db", "search", "what is x", ["c1", "c2"])
 
     _assert_audit_record(
         audit_records[-1],
@@ -691,30 +691,10 @@ def test_rag_access(audit_records):
         scope=SCOPE_RAG_ACCESS,
         fields={
             "claims": CLAIMS,
+            "action": loggers.AUDIT_RAG_ACTION_RETRIEVAL,
             "db_path": "db",
             "tool": "search",
             "selector": "what is x",
             "result_refs": ["c1", "c2"],
-        },
-    )
-
-
-def test_rag_access_failed(audit_records):
-    wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
-
-    wrapper.access_failed("db", "cite", ["c9"], "unresolved")
-
-    _assert_audit_record(
-        audit_records[-1],
-        message=loggers.AUDIT_RAG_ACCESS,
-        levelno=logging.ERROR,
-        outcome=loggers.AUDIT_OUTCOME_ERROR,
-        scope=SCOPE_RAG_ACCESS,
-        fields={
-            "claims": CLAIMS,
-            "db_path": "db",
-            "tool": "cite",
-            "selector": ["c9"],
-            "reason": "unresolved",
         },
     )

--- a/tests/unit/test_rag_audit.py
+++ b/tests/unit/test_rag_audit.py
@@ -1,4 +1,9 @@
+import datetime as dt
+
 import ag_ui.core as agui_core
+from haiku.rag.store.models import chunk as hr_chunk
+from haiku.skills import agent as hs_agent
+from pydantic_ai import messages as ai_messages
 
 from soliplex import loggers
 from soliplex import rag_audit
@@ -213,3 +218,55 @@ def test_ragaccessauditor__handle_non_json_args_swallowed_warned(caplog):
     assert log.calls == []
     assert len(caplog.records) == 1
     assert caplog.records[0].levelname == "ERROR"
+
+
+# -- upstream-contract regression guards -------------------------------
+#
+# The auditor depends on surfaces owned by haiku.rag / haiku.skills that are
+# not part of a stable public API: the agent-facing search render
+# ('SearchResult.format_for_agent') and the skill activity events
+# ('_events_to_activity', a private upstream helper). If either drifts, the
+# auditor would silently record nothing rather than fail. These tests exercise
+# the real upstream code so a future dependency bump breaks here -- loudly --
+# instead of in production.
+
+
+def test_contract_searchresult_render_yields_recoverable_chunk_ids():
+    rendered = "\n\n".join(
+        hr_chunk.SearchResult(
+            content="x", score=1.0, chunk_id=chunk_id
+        ).format_for_agent(rank=rank, total=2)
+        for rank, chunk_id in enumerate(["c1", "c2"], start=1)
+    )
+
+    refs = rag_audit._result_refs(rendered)
+
+    assert refs == ["c1", "c2"]
+
+
+def test_contract_skill_activity_events_drive_the_auditor():
+    call = ai_messages.FunctionToolCallEvent(
+        part=ai_messages.ToolCallPart(
+            tool_name="search", args={"query": "x"}, tool_call_id="t1"
+        )
+    )
+    result = ai_messages.FunctionToolResultEvent(
+        part=ai_messages.ToolReturnPart(
+            tool_name="search",
+            content=hr_chunk.SearchResult(
+                content="x", score=1.0, chunk_id="c1"
+            ).format_for_agent(rank=1, total=1),
+            tool_call_id="t1",
+            timestamp=dt.datetime(2024, 1, 1, tzinfo=dt.UTC),
+        )
+    )
+    events = hs_agent._events_to_activity("rag", [call, result])
+    log = _RecordingLog()
+    auditor = _auditor(log)
+
+    for event in events:
+        auditor.handle(event)
+
+    assert log.calls == [
+        ("/dbs/rag.lancedb", "search", {"query": "x"}, ["c1"])
+    ]

--- a/tests/unit/test_rag_audit.py
+++ b/tests/unit/test_rag_audit.py
@@ -1,0 +1,145 @@
+import ag_ui.core as agui_core
+
+from soliplex import rag_audit
+
+SEARCH_RESULT = (
+    "[c1] [rank 1 of 2]\nSource: doc\nContent:\nalpha"
+    "\n\n---\n\n"
+    "[c2] [rank 2 of 2]\nContent:\nbeta"
+)
+
+
+class _RecordingLog:
+    def __init__(self):
+        self.calls = []
+
+    def access(self, db_path, tool, selector, result_refs):
+        self.calls.append((db_path, tool, selector, result_refs))
+
+
+def _activity(activity_type, content):
+    return agui_core.ActivitySnapshotEvent(
+        type=agui_core.EventType.ACTIVITY_SNAPSHOT,
+        message_id="m1",
+        activity_type=activity_type,
+        content=content,
+        replace=False,
+    )
+
+
+def _auditor(log):
+    return rag_audit.RagAccessAuditor(
+        log, db_path_for=lambda skill: f"/dbs/{skill}.lancedb"
+    )
+
+
+def test_search_call_then_result_records_access():
+    log = _RecordingLog()
+    auditor = _auditor(log)
+
+    auditor.handle(
+        _activity(
+            "skill_tool_call",
+            {
+                "skill": "rag",
+                "tool_name": "search",
+                "tool_call_id": "t1",
+                "args": '{"query": "what is x"}',
+            },
+        )
+    )
+    auditor.handle(
+        _activity(
+            "skill_tool_result",
+            {
+                "skill": "rag",
+                "tool_name": "search",
+                "tool_call_id": "t1",
+                "result": SEARCH_RESULT,
+            },
+        )
+    )
+
+    assert log.calls == [
+        (
+            "/dbs/rag.lancedb",
+            "search",
+            {"query": "what is x"},
+            ["c1", "c2"],
+        )
+    ]
+
+
+def test_cite_records_chunk_ids_as_selector():
+    log = _RecordingLog()
+    auditor = _auditor(log)
+
+    auditor.handle(
+        _activity(
+            "skill_tool_call",
+            {
+                "skill": "rag",
+                "tool_name": "cite",
+                "tool_call_id": "t2",
+                "args": '{"chunk_ids": ["c1", "c2"]}',
+            },
+        )
+    )
+    auditor.handle(
+        _activity(
+            "skill_tool_result",
+            {
+                "skill": "rag",
+                "tool_name": "cite",
+                "tool_call_id": "t2",
+                "result": "Registered 2 citation(s).",
+            },
+        )
+    )
+
+    assert log.calls == [
+        ("/dbs/rag.lancedb", "cite", {"chunk_ids": ["c1", "c2"]}, [])
+    ]
+
+
+def test_non_activity_event_is_ignored():
+    log = _RecordingLog()
+    auditor = _auditor(log)
+
+    auditor.handle(
+        agui_core.RunStartedEvent(
+            type=agui_core.EventType.RUN_STARTED,
+            thread_id="t",
+            run_id="r",
+        )
+    )
+
+    assert log.calls == []
+
+
+def test_unrelated_activity_type_is_ignored():
+    log = _RecordingLog()
+    auditor = _auditor(log)
+
+    auditor.handle(_activity("some_other_activity", {"foo": "bar"}))
+
+    assert log.calls == []
+
+
+def test_orphan_result_is_ignored():
+    log = _RecordingLog()
+    auditor = _auditor(log)
+
+    auditor.handle(
+        _activity(
+            "skill_tool_result",
+            {
+                "skill": "rag",
+                "tool_name": "search",
+                "tool_call_id": "missing",
+                "result": SEARCH_RESULT,
+            },
+        )
+    )
+
+    assert log.calls == []

--- a/tests/unit/test_rag_audit.py
+++ b/tests/unit/test_rag_audit.py
@@ -1,5 +1,6 @@
 import ag_ui.core as agui_core
 
+from soliplex import loggers
 from soliplex import rag_audit
 
 SEARCH_RESULT = (
@@ -33,7 +34,7 @@ def _auditor(log):
     )
 
 
-def test_search_call_then_result_records_access():
+def test_ragaccessauditor__handle_search_call_then_result_records_access():
     log = _RecordingLog()
     auditor = _auditor(log)
 
@@ -70,7 +71,7 @@ def test_search_call_then_result_records_access():
     ]
 
 
-def test_cite_records_chunk_ids_as_selector():
+def test_ragaccessauditor__handle_cite_records_chunk_ids_as_selector():
     log = _RecordingLog()
     auditor = _auditor(log)
 
@@ -102,7 +103,7 @@ def test_cite_records_chunk_ids_as_selector():
     ]
 
 
-def test_non_activity_event_is_ignored():
+def test_ragaccessauditor__handle_non_activity_event_is_ignored():
     log = _RecordingLog()
     auditor = _auditor(log)
 
@@ -117,7 +118,7 @@ def test_non_activity_event_is_ignored():
     assert log.calls == []
 
 
-def test_unrelated_activity_type_is_ignored():
+def test_ragaccessauditor__handle_unrelated_activity_type_is_ignored():
     log = _RecordingLog()
     auditor = _auditor(log)
 
@@ -126,7 +127,7 @@ def test_unrelated_activity_type_is_ignored():
     assert log.calls == []
 
 
-def test_unknown_skill_is_skipped():
+def test_ragaccessauditor__handle_unknown_skill_is_skipped():
     log = _RecordingLog()
     auditor = rag_audit.RagAccessAuditor(log, db_path_for=lambda skill: None)
 
@@ -156,7 +157,7 @@ def test_unknown_skill_is_skipped():
     assert log.calls == []
 
 
-def test_orphan_result_is_ignored():
+def test_ragaccessauditor__handle_orphan_result_is_ignored():
     log = _RecordingLog()
     auditor = _auditor(log)
 
@@ -173,3 +174,42 @@ def test_orphan_result_is_ignored():
     )
 
     assert log.calls == []
+
+
+def test_ragaccessauditor__handle_missing_content_key_swallowed_warned(caplog):
+    log = _RecordingLog()
+    auditor = _auditor(log)
+
+    with caplog.at_level("WARNING", logger=loggers.SOLIPLEX_LOGGER_NAME):
+        auditor.handle(
+            _activity(
+                "skill_tool_call",
+                {"skill": "rag", "tool_name": "search", "args": "{}"},
+            )
+        )
+
+    assert log.calls == []
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "ERROR"
+
+
+def test_ragaccessauditor__handle_non_json_args_swallowed_warned(caplog):
+    log = _RecordingLog()
+    auditor = _auditor(log)
+
+    with caplog.at_level("WARNING", logger=loggers.SOLIPLEX_LOGGER_NAME):
+        auditor.handle(
+            _activity(
+                "skill_tool_call",
+                {
+                    "skill": "rag",
+                    "tool_name": "search",
+                    "tool_call_id": "t1",
+                    "args": "not json",
+                },
+            )
+        )
+
+    assert log.calls == []
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "ERROR"

--- a/tests/unit/test_rag_audit.py
+++ b/tests/unit/test_rag_audit.py
@@ -19,7 +19,7 @@ class _RecordingLog:
     def __init__(self):
         self.calls = []
 
-    def access(self, db_path, tool, selector, result_refs):
+    def retrieval(self, db_path, tool, selector, result_refs):
         self.calls.append((db_path, tool, selector, result_refs))
 
 

--- a/tests/unit/test_rag_audit.py
+++ b/tests/unit/test_rag_audit.py
@@ -126,6 +126,36 @@ def test_unrelated_activity_type_is_ignored():
     assert log.calls == []
 
 
+def test_unknown_skill_is_skipped():
+    log = _RecordingLog()
+    auditor = rag_audit.RagAccessAuditor(log, db_path_for=lambda skill: None)
+
+    auditor.handle(
+        _activity(
+            "skill_tool_call",
+            {
+                "skill": "not-a-rag-skill",
+                "tool_name": "search",
+                "tool_call_id": "t3",
+                "args": '{"query": "x"}',
+            },
+        )
+    )
+    auditor.handle(
+        _activity(
+            "skill_tool_result",
+            {
+                "skill": "not-a-rag-skill",
+                "tool_name": "search",
+                "tool_call_id": "t3",
+                "result": SEARCH_RESULT,
+            },
+        )
+    )
+
+    assert log.calls == []
+
+
 def test_orphan_result_is_ignored():
     log = _RecordingLog()
     auditor = _auditor(log)

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1322,6 +1322,80 @@ async def test_drive_llm_stream_save_event_error(
 
 
 @pytest.mark.asyncio
+@mock.patch("soliplex.views.agui.titles.maybe_generate_title")
+@mock.patch("soliplex.views.agui.finish_run")
+@mock.patch("soliplex.views.agui.save_single_event")
+@mock.patch("soliplex.views.agui.logfire")
+async def test_drive_llm_stream_audits_rag_access(logfire, sse, fr, mgt):
+    """A skill tool-call / result pair emits a rag-access audit record."""
+    import logging
+
+    records = []
+    handler = logging.Handler()
+    handler.emit = records.append
+    audit_logger = logging.getLogger(loggers.SOLIPLEX_AUDIT_LOGGER_NAME)
+    audit_logger.setLevel(logging.DEBUG)
+    audit_logger.addHandler(handler)
+
+    def _activity(activity_type, content):
+        return agui_core.ActivitySnapshotEvent(
+            type=agui_core.EventType.ACTIVITY_SNAPSHOT,
+            message_id="m1",
+            activity_type=activity_type,
+            content=content,
+            replace=False,
+        )
+
+    async def event_iter():
+        yield _activity(
+            "skill_tool_call",
+            {
+                "skill": "rag",
+                "tool_name": "search",
+                "tool_call_id": "t1",
+                "args": '{"query": "x"}',
+            },
+        )
+        yield _activity(
+            "skill_tool_result",
+            {
+                "skill": "rag",
+                "tool_name": "search",
+                "tool_call_id": "t1",
+                "result": "[c1] [rank 1 of 1]\nContent:\nx",
+            },
+        )
+
+    try:
+        await agui_views.drive_llm_stream(
+            event_iter(),
+            sqla_engine=mock.AsyncMock(spec_set=()),
+            event_queue=asyncio.Queue(),
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID_STR,
+            run_id=TEST_RUN_ID_STR,
+            claims={"email": "x@example.com"},
+            rag_db_paths={"rag": "/db.lancedb"},
+        )
+    finally:
+        audit_logger.removeHandler(handler)
+
+    scope_key = loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA
+    rag_records = [
+        record
+        for record in records
+        if record.__dict__.get(scope_key) == loggers.AuditLogScopes.RAG_ACCESS
+    ]
+    assert len(rag_records) == 1
+    record = rag_records[0]
+    assert record.db_path == "/db.lancedb"
+    assert record.tool == "search"
+    assert record.selector == {"query": "x"}
+    assert record.result_refs == ["c1"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("num_events", [0, 1, 10, 100])
 async def test_stream_llm_events(num_events):
     expected = [
@@ -1364,6 +1438,18 @@ def test_find_skill_toolset_returns_skill_toolset():
     agent = mock.MagicMock()
     agent.toolsets = [mock.MagicMock(), skill_ts]
     assert agui_views.find_skill_toolset(agent) is skill_ts
+
+
+def test__rag_db_paths_without_skills():
+    room_config = mock.Mock()
+    room_config.skills = None
+    assert agui_views._rag_db_paths(room_config) == {}
+
+
+def test__rag_db_paths_with_skills():
+    room_config = mock.Mock()
+    room_config.skills.rag_db_paths = {"rag": "/db.lancedb"}
+    assert agui_views._rag_db_paths(room_config) == {"rag": "/db.lancedb"}
 
 
 # -- init_agent_stream -------------------------------------------------
@@ -1580,6 +1666,11 @@ async def test_post_room_agui_thread_id_run_id_streaming(
         assert ias_kwargs["run_id"] == TEST_RUN_ID_STR
         assert ias_kwargs["title_agent_config"] is exp_title_config
         assert ias_kwargs["messages"] is exp_adapter.run_input.messages
+        assert ias_kwargs["claims"] is THE_USER_CLAIMS
+        exp_room_config = the_installation.get_room_config.return_value
+        assert (
+            ias_kwargs["rag_db_paths"] is exp_room_config.skills.rag_db_paths
+        )
 
         # Verify run_stream_kwargs contains deps, conversation_id,
         # and on_complete

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1393,6 +1393,9 @@ async def test_drive_llm_stream_audits_rag_access(logfire, sse, fr, mgt):
     assert record.tool == "search"
     assert record.selector == {"query": "x"}
     assert record.result_refs == ["c1"]
+    assert record.room_id == TEST_ROOM_ID
+    assert record.thread_id == TEST_THREAD_ID_STR
+    assert record.run_id == TEST_RUN_ID_STR
 
 
 @pytest.mark.asyncio

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1389,6 +1389,7 @@ async def test_drive_llm_stream_audits_rag_access(logfire, sse, fr, mgt):
     ]
     assert len(rag_records) == 1
     record = rag_records[0]
+    assert record.action == loggers.AUDIT_RAG_ACTION_RETRIEVAL
     assert record.db_path == "/db.lancedb"
     assert record.tool == "search"
     assert record.selector == {"query": "x"}


### PR DESCRIPTION
Fills the deferred `RAGAccessAuditLog` stub and wires it up.

Each skill knowledge-base access is recorded as one audit record
(`db_path`, `tool`, `selector`, `result_refs`) by correlating the
`skill_tool_call` / `skill_tool_result` activity events in
`drive_llm_stream`. Non-RAG skills are skipped.

Toward #1092. Addresses ggozad/haiku.rag#451.