### PR TITLE
feat: emit audit log events for room REST API endpoints

### DIFF
--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -131,9 +131,12 @@ AUDIT_RAG_ACCESS = "rag access"
 
 # rag-access 'action' values: the kind of protected-data read, carried as a
 # field so both access paths share one vocabulary. The run-mediated path
-# records 'rag-retrieval'; the direct helper endpoints (future) will add
-# 'search' / 'chunk-viz' / 'doc-list' alongside their own methods.
+# records 'rag-retrieval'; the direct helper endpoints record 'search' /
+# 'chunk-viz' / 'doc-list'.
 AUDIT_RAG_ACTION_RETRIEVAL = "rag-retrieval"
+AUDIT_RAG_ACTION_SEARCH = "search"
+AUDIT_RAG_ACTION_CHUNK_VIZ = "chunk-viz"
+AUDIT_RAG_ACTION_DOC_LIST = "doc-list"
 
 
 class _StructuredFieldsAdapter(logging.LoggerAdapter):
@@ -460,10 +463,9 @@ class RAGAccessAuditLog(AuditLogWrapper):
     the rendered tool result, not a tool-error signal, so every observed
     skill access is recorded as a success.
 
-    The direct helper endpoints for API endpoints (`views.rooms`) will add
-    their own action methods ('search' / 'chunk-viz' / 'doc-list') with
-    failure variants, where the HTTP outcome authoritatively distinguishes a
-    refused or absent access.
+    The direct helper API endpoints (`views.rooms`) have their own action
+    methods ('search' / 'chunk-viz' / 'doc-list') with failure variants, where
+    the HTTP outcome authoritatively distinguishes a refused or absent access.
 
     Room-level agent tool access will use the same action methods, but log
     failure variants based on exceptions raised.
@@ -494,4 +496,45 @@ class RAGAccessAuditLog(AuditLogWrapper):
             tool=tool,
             selector=selector,
             result_refs=result_refs,
+        )
+
+    def search(
+        self, db_path: str, selector: typing.Any, result_refs: typing.Any
+    ):
+        self._succeeded(
+            AUDIT_RAG_ACCESS,
+            action=AUDIT_RAG_ACTION_SEARCH,
+            db_path=db_path,
+            selector=selector,
+            result_refs=result_refs,
+        )
+
+    def doc_list(self, db_path: str, result_refs: typing.Any):
+        self._succeeded(
+            AUDIT_RAG_ACCESS,
+            action=AUDIT_RAG_ACTION_DOC_LIST,
+            db_path=db_path,
+            result_refs=result_refs,
+        )
+
+    def chunk_viz(
+        self, db_path: str, selector: typing.Any, result_refs: typing.Any
+    ):
+        self._succeeded(
+            AUDIT_RAG_ACCESS,
+            action=AUDIT_RAG_ACTION_CHUNK_VIZ,
+            db_path=db_path,
+            selector=selector,
+            result_refs=result_refs,
+        )
+
+    def chunk_viz_failed(
+        self, db_path: str | None, selector: typing.Any, reason: str
+    ):
+        self._failed(
+            AUDIT_RAG_ACCESS,
+            action=AUDIT_RAG_ACTION_CHUNK_VIZ,
+            db_path=db_path,
+            selector=selector,
+            reason=reason,
         )

--- a/src/soliplex/views/rooms.py
+++ b/src/soliplex/views/rooms.py
@@ -189,6 +189,7 @@ async def get_room_documents(
             detail=f"{loggers.ROOM_UNKNOWN_ROOM_ID}: {room_id}",
         ) from None
 
+    audit = loggers.RAGAccessAuditLog(claims=the_user_claims, room_id=room_id)
     document_set = {}
 
     for hr_client_kw in room_config.list_haiku_rag_client_kw(
@@ -196,9 +197,12 @@ async def get_room_documents(
     ):
         source_tag = hr_client_kw.pop("source")
         source = models.RAGSource.from_source_tag(source_tag)
+        db_path = str(hr_client_kw["db_path"])
 
         async with hr_client.HaikuRAG(**hr_client_kw) as rag:
             results = await rag.list_documents()
+
+        audit.doc_list(db_path, [document.id for document in results])
 
         for document in results:
             document_set[document.id] = models.RAGDocument(
@@ -246,12 +250,14 @@ async def get_chunk_visualization(
             detail=f"{loggers.ROOM_UNKNOWN_ROOM_ID}: {room_id}",
         ) from None
 
+    audit = loggers.RAGAccessAuditLog(claims=the_user_claims, room_id=room_id)
     images = None
     for hr_client_kw in room_config.list_haiku_rag_client_kw(
         include_source=True,
     ):
         source_tag = hr_client_kw.pop("source")
         source = models.RAGSource.from_source_tag(source_tag)
+        db_path = str(hr_client_kw["db_path"])
 
         async with hr_client.HaikuRAG(**hr_client_kw) as rag:
             chunk = await rag.chunk_repository.get_by_id(chunk_id)
@@ -262,6 +268,7 @@ async def get_chunk_visualization(
 
     else:
         the_logger.error(loggers.ROOM_UNKNOWN_CHUNK_ID, chunk_id=chunk_id)
+        audit.chunk_viz_failed(None, chunk_id, loggers.ROOM_UNKNOWN_CHUNK_ID)
         raise fastapi.HTTPException(
             status_code=404,
             detail=f"{loggers.ROOM_UNKNOWN_CHUNK_ID}: {chunk_id}",
@@ -275,6 +282,9 @@ async def get_chunk_visualization(
             loggers.ROOM_CHUNK_IMAGES_NOT_AVAILALBE,
             chunk_id=chunk_id,
         )
+        audit.chunk_viz_failed(
+            db_path, chunk_id, loggers.ROOM_CHUNK_IMAGES_NOT_AVAILALBE
+        )
         raise fastapi.HTTPException(
             status_code=404,
             detail=f"{loggers.ROOM_CHUNK_IMAGES_NOT_AVAILALBE}: {chunk_id}",
@@ -285,6 +295,8 @@ async def get_chunk_visualization(
         img.save(buffer, format="PNG")
         buffer.seek(0)
         base64_images.append(base64.b64encode(buffer.read()).decode("utf-8"))
+
+    audit.chunk_viz(db_path, chunk_id, [chunk.document_uri])
 
     return models.ChunkVisualization(
         source=source,
@@ -324,6 +336,7 @@ async def get_search(
             detail=f"{loggers.ROOM_UNKNOWN_ROOM_ID}: {room_id}",
         ) from None
 
+    audit = loggers.RAGAccessAuditLog(claims=the_user_claims, room_id=room_id)
     aggregate_hits = []
 
     for hr_client_kw in room_config.list_haiku_rag_client_kw(
@@ -331,12 +344,15 @@ async def get_search(
     ):
         source_tag = hr_client_kw.pop("source")
         source = models.RAGSource.from_source_tag(source_tag)
+        db_path = str(hr_client_kw["db_path"])
 
         async with hr_client.HaikuRAG(**hr_client_kw) as rag:
             hits = await rag.search(
                 query=query,
                 search_type=search_type,
             )
+
+        audit.search(db_path, query, [hit.chunk_id for hit in hits])
 
         for hit in hits:
             aggregate_hits.append(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import tempfile
 from unittest import mock
@@ -6,6 +7,7 @@ import _test_features as agui_features
 import pytest
 
 from soliplex import authz
+from soliplex import loggers
 from soliplex.config import agents as config_agents
 from soliplex.config import agui as config_agui
 from soliplex.config import authsystem as config_authsystem
@@ -40,6 +42,21 @@ def anyio_backend():
 def temp_dir() -> pathlib.Path:
     with tempfile.TemporaryDirectory() as td:
         yield pathlib.Path(td).resolve()
+
+
+@pytest.fixture
+def audit_records():
+    """Capture records emitted to the 'soliplex-audit' logger in a list."""
+    records = []
+    handler = logging.Handler()
+    handler.emit = records.append
+    logger = logging.getLogger(loggers.SOLIPLEX_AUDIT_LOGGER_NAME)
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
 
 
 @pytest.fixture(params=[0, 1, 2])

--- a/tests/unit/test_loggers.py
+++ b/tests/unit/test_loggers.py
@@ -175,21 +175,6 @@ def test_auditlogwrapper_ctor(scope):
     assert found.extra[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA] == scope
 
 
-@pytest.fixture
-def audit_records():
-    """Capture records emitted to the 'soliplex-audit' logger in a list."""
-    records = []
-    handler = logging.Handler()
-    handler.emit = records.append
-    logger = logging.getLogger(loggers.SOLIPLEX_AUDIT_LOGGER_NAME)
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(handler)
-    try:
-        yield records
-    finally:
-        logger.removeHandler(handler)
-
-
 def _assert_audit_record(record, *, message, levelno, outcome, scope, fields):
     """Shared assertions for a single emitted audit record."""
     assert record.getMessage() == message
@@ -696,5 +681,88 @@ def test_rag_retrieval(audit_records):
             "tool": "search",
             "selector": "what is x",
             "result_refs": ["c1", "c2"],
+        },
+    )
+
+
+def test_rag_search(audit_records):
+    wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
+
+    wrapper.search("db", "what is x", ["c1", "c2"])
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_RAG_ACCESS,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_RAG_ACCESS,
+        fields={
+            "claims": CLAIMS,
+            "action": loggers.AUDIT_RAG_ACTION_SEARCH,
+            "db_path": "db",
+            "selector": "what is x",
+            "result_refs": ["c1", "c2"],
+        },
+    )
+
+
+def test_rag_doc_list(audit_records):
+    wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
+
+    wrapper.doc_list("db", ["d1", "d2"])
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_RAG_ACCESS,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_RAG_ACCESS,
+        fields={
+            "claims": CLAIMS,
+            "action": loggers.AUDIT_RAG_ACTION_DOC_LIST,
+            "db_path": "db",
+            "result_refs": ["d1", "d2"],
+        },
+    )
+
+
+def test_rag_chunk_viz(audit_records):
+    wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
+
+    wrapper.chunk_viz("db", "chunk-uuid", ["doc://uri"])
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_RAG_ACCESS,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_RAG_ACCESS,
+        fields={
+            "claims": CLAIMS,
+            "action": loggers.AUDIT_RAG_ACTION_CHUNK_VIZ,
+            "db_path": "db",
+            "selector": "chunk-uuid",
+            "result_refs": ["doc://uri"],
+        },
+    )
+
+
+def test_rag_chunk_viz_failed(audit_records):
+    wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
+
+    wrapper.chunk_viz_failed(None, "chunk-uuid", "unknown chunk id")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_RAG_ACCESS,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_ERROR,
+        scope=SCOPE_RAG_ACCESS,
+        fields={
+            "claims": CLAIMS,
+            "action": loggers.AUDIT_RAG_ACTION_CHUNK_VIZ,
+            "db_path": None,
+            "selector": "chunk-uuid",
+            "reason": "unknown chunk id",
         },
     )

--- a/tests/unit/views/test_rooms_views.py
+++ b/tests/unit/views/test_rooms_views.py
@@ -303,12 +303,12 @@ async def test_get_room_mcp_token(gust, w_error):
     "w_hrc_kws",
     [
         [],
-        [{"source": "agent", "foo": "bar"}],
-        [{"source": "skill:test", "foo": "bar"}],
-        [{"source": "tool:test", "foo": "bar"}],
+        [{"source": "agent", "db_path": "/db/agent", "foo": "bar"}],
+        [{"source": "skill:test", "db_path": "/db/skill", "foo": "bar"}],
+        [{"source": "tool:test", "db_path": "/db/tool", "foo": "bar"}],
         [
-            {"source": "skill:test", "foo": "bar"},
-            {"source": "tool:test", "foo": "bar"},
+            {"source": "skill:test", "db_path": "/db/skill", "foo": "bar"},
+            {"source": "tool:test", "db_path": "/db/tool", "foo": "bar"},
         ],
     ],
 )
@@ -318,6 +318,7 @@ async def test_get_room_documents(
     w_hrc_kws,
     temp_dir,
     room_configs,
+    audit_records,
 ):
     ROOM_ID = "foo"
 
@@ -388,6 +389,7 @@ async def test_get_room_documents(
             loggers.ROOM_UNKNOWN_ROOM_ID,
             room_id=ROOM_ID,
         )
+        assert audit_records == []
     else:
         room_config = room_configs[ROOM_ID]
         room_config.list_haiku_rag_client_kw.return_value = w_hrc_kws
@@ -425,6 +427,22 @@ async def test_get_room_documents(
         else:
             hr_klass.assert_not_called()
 
+        rag_records = [
+            record
+            for record in audit_records
+            if record.__dict__.get(loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA)
+            == loggers.AuditLogScopes.RAG_ACCESS
+        ]
+        assert len(rag_records) == len(sources)
+        for record, kws, source in zip(
+            rag_records, w_hrc_kws, sources, strict=True
+        ):
+            assert record.action == loggers.AUDIT_RAG_ACTION_DOC_LIST
+            assert record.outcome == loggers.AUDIT_OUTCOME_SUCCESS
+            assert record.room_id == ROOM_ID
+            assert record.db_path == kws["db_path"]
+            assert record.result_refs == [documents[source].id]
+
     the_installation.get_room_config.assert_awaited_once_with(
         room_id=ROOM_ID,
         user=THE_USER_CLAIMS,
@@ -434,6 +452,18 @@ async def test_get_room_documents(
     the_logger.debug.assert_called_once_with(loggers.ROOM_GET_ROOM_DOCUMENTS)
 
 
+def _sole_rag_record(audit_records):
+    """Return the single rag-access audit record, asserting there is one."""
+    rag_records = [
+        record
+        for record in audit_records
+        if record.__dict__.get(loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA)
+        == loggers.AuditLogScopes.RAG_ACCESS
+    ]
+    assert len(rag_records) == 1
+    return rag_records[0]
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize("w_image", [False, True])
 @pytest.mark.parametrize("w_chunk_index", [None, 0, -1])
@@ -441,12 +471,12 @@ async def test_get_room_documents(
     "w_hrc_kws",
     [
         [],
-        [{"source": "agent", "foo": "bar"}],
-        [{"source": "skill:test", "foo": "bar"}],
-        [{"source": "tool:test", "foo": "bar"}],
+        [{"source": "agent", "db_path": "/db/agent", "foo": "bar"}],
+        [{"source": "skill:test", "db_path": "/db/skill", "foo": "bar"}],
+        [{"source": "tool:test", "db_path": "/db/tool", "foo": "bar"}],
         [
-            {"source": "skill:test", "foo": "bar"},
-            {"source": "tool:test", "foo": "bar"},
+            {"source": "skill:test", "db_path": "/db/skill", "foo": "bar"},
+            {"source": "tool:test", "db_path": "/db/tool", "foo": "bar"},
         ],
     ],
 )
@@ -460,6 +490,7 @@ async def test_get_chunk_visualization(
     w_image,
     temp_dir,
     room_configs,
+    audit_records,
 ):
     ROOM_ID = "foo"
     CHUNK_ID = "test-chunk-123"
@@ -544,6 +575,7 @@ async def test_get_chunk_visualization(
             loggers.ROOM_UNKNOWN_ROOM_ID,
             room_id=ROOM_ID,
         )
+        assert audit_records == []
 
     else:
         room_config = room_configs[ROOM_ID]
@@ -571,6 +603,14 @@ async def test_get_chunk_visualization(
                 loggers.ROOM_UNKNOWN_CHUNK_ID, chunk_id=CHUNK_ID
             )
 
+            record = _sole_rag_record(audit_records)
+            assert record.action == loggers.AUDIT_RAG_ACTION_CHUNK_VIZ
+            assert record.outcome == loggers.AUDIT_OUTCOME_ERROR
+            assert record.room_id == ROOM_ID
+            assert record.db_path is None
+            assert record.selector == CHUNK_ID
+            assert record.reason == loggers.ROOM_UNKNOWN_CHUNK_ID
+
         elif w_chunk_index is None:
             with pytest.raises(fastapi.HTTPException) as exc:
                 await rooms_views.get_chunk_visualization(
@@ -589,6 +629,14 @@ async def test_get_chunk_visualization(
             the_logger.error.assert_called_once_with(
                 loggers.ROOM_UNKNOWN_CHUNK_ID, chunk_id=CHUNK_ID
             )
+
+            record = _sole_rag_record(audit_records)
+            assert record.action == loggers.AUDIT_RAG_ACTION_CHUNK_VIZ
+            assert record.outcome == loggers.AUDIT_OUTCOME_ERROR
+            assert record.room_id == ROOM_ID
+            assert record.db_path is None
+            assert record.selector == CHUNK_ID
+            assert record.reason == loggers.ROOM_UNKNOWN_CHUNK_ID
 
         elif not w_image:
             with pytest.raises(fastapi.HTTPException) as exc:
@@ -609,6 +657,14 @@ async def test_get_chunk_visualization(
                 loggers.ROOM_CHUNK_IMAGES_NOT_AVAILALBE, chunk_id=CHUNK_ID
             )
 
+            record = _sole_rag_record(audit_records)
+            assert record.action == loggers.AUDIT_RAG_ACTION_CHUNK_VIZ
+            assert record.outcome == loggers.AUDIT_OUTCOME_ERROR
+            assert record.room_id == ROOM_ID
+            assert record.db_path == w_hrc_kws[w_chunk_index]["db_path"]
+            assert record.selector == CHUNK_ID
+            assert record.reason == loggers.ROOM_CHUNK_IMAGES_NOT_AVAILALBE
+
         else:
             found = await rooms_views.get_chunk_visualization(
                 room_id=ROOM_ID,
@@ -626,6 +682,14 @@ async def test_get_chunk_visualization(
                 document_uri=DOCUMENT_URI,
                 images_base_64=PAGES_B64,
             )
+
+            record = _sole_rag_record(audit_records)
+            assert record.action == loggers.AUDIT_RAG_ACTION_CHUNK_VIZ
+            assert record.outcome == loggers.AUDIT_OUTCOME_SUCCESS
+            assert record.room_id == ROOM_ID
+            assert record.db_path == w_hrc_kws[w_chunk_index]["db_path"]
+            assert record.selector == CHUNK_ID
+            assert record.result_refs == [DOCUMENT_URI]
 
         room_config.list_haiku_rag_client_kw.assert_called_once_with(
             include_source=True,
@@ -648,12 +712,12 @@ async def test_get_chunk_visualization(
     "w_hrc_kws",
     [
         [],
-        [{"source": "agent", "foo": "bar"}],
-        [{"source": "skill:test", "foo": "bar"}],
-        [{"source": "tool:test", "foo": "bar"}],
+        [{"source": "agent", "db_path": "/db/agent", "foo": "bar"}],
+        [{"source": "skill:test", "db_path": "/db/skill", "foo": "bar"}],
+        [{"source": "tool:test", "db_path": "/db/tool", "foo": "bar"}],
         [
-            {"source": "skill:test", "foo": "bar"},
-            {"source": "tool:test", "foo": "bar"},
+            {"source": "skill:test", "db_path": "/db/skill", "foo": "bar"},
+            {"source": "tool:test", "db_path": "/db/tool", "foo": "bar"},
         ],
     ],
 )
@@ -664,6 +728,7 @@ async def test_get_search(
     w_search_type,
     temp_dir,
     room_configs,
+    audit_records,
 ):
     QUERY = "test query"
     SEARCH_TYPE = "hybrid"
@@ -731,6 +796,7 @@ async def test_get_search(
             loggers.ROOM_UNKNOWN_ROOM_ID,
             room_id=ROOM_ID,
         )
+        assert audit_records == []
 
     else:
         room_config = room_configs[ROOM_ID]
@@ -785,3 +851,20 @@ async def test_get_search(
                 query=QUERY,
                 search_type=exp_search_type,
             )
+
+        rag_records = [
+            record
+            for record in audit_records
+            if record.__dict__.get(loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA)
+            == loggers.AuditLogScopes.RAG_ACCESS
+        ]
+        assert len(rag_records) == len(sources)
+        for record, kws, exp_result in zip(
+            rag_records, w_hrc_kws, search_results, strict=True
+        ):
+            assert record.action == loggers.AUDIT_RAG_ACTION_SEARCH
+            assert record.outcome == loggers.AUDIT_OUTCOME_SUCCESS
+            assert record.room_id == ROOM_ID
+            assert record.db_path == kws["db_path"]
+            assert record.selector == QUERY
+            assert record.result_refs == [exp_result.chunk_id]


### PR DESCRIPTION
- 'GET /v1/rooms/{room_id}/search'
- 'GET /v1/rooms/{room_id}/documents'
- 'GET /v1/rooms/{room_id}/chunk/{chunk_id}'

feat: additional RAG access audit log methods

- 'logger.RAGAccessAuditLog.search'
- 'logger.RAGAccessAuditLog.doc_list'
- 'logger.RAGAccessAuditLog.chunk_viz'
- 'logger.RAGAccessAuditLog.chunk_viz_failed'

Toward #1092.