### PR TITLE
feat: 'tools.rag.search_documents' emits audit log events

### DIFF
--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -509,6 +509,17 @@ class RAGAccessAuditLog(AuditLogWrapper):
             result_refs=result_refs,
         )
 
+    def search_failed(
+        self, db_path: str | None, selector: typing.Any, reason: str
+    ):
+        self._failed(
+            AUDIT_RAG_ACCESS,
+            action=AUDIT_RAG_ACTION_SEARCH,
+            db_path=db_path,
+            selector=selector,
+            reason=reason,
+        )
+
     def doc_list(self, db_path: str, result_refs: typing.Any):
         self._succeeded(
             AUDIT_RAG_ACCESS,

--- a/src/soliplex/rag_audit.py
+++ b/src/soliplex/rag_audit.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import logging
 import re
@@ -79,3 +80,46 @@ class RagAccessAuditor:
                 selector,
                 _result_refs(content["result"]),
             )
+
+
+class _ToolAccessRecorder:
+    """Carries the ids a wrapped RAG tool returned back to the auditor.
+
+    The tool sets ``result_refs`` before its body returns; the surrounding
+    ``audit_tool_access`` reads it to record what the access disclosed.
+    """
+
+    def __init__(self):
+        self.result_refs: list[typing.Any] = []
+
+    def record_refs(self, refs: list[typing.Any]):
+        self.result_refs.extend(refs)
+
+
+@contextlib.contextmanager
+def audit_tool_access(
+    deps: typing.Any, *, audit_method: str, db_path: str, selector: typing.Any
+):
+    """Bracket a room-agent RAG tool body, emitting one rag-access record.
+
+    ``deps`` is the tool's ``RunContext.deps`` (an ``AgentDependencies``);
+    identity and run correlation are taken from it. ``audit_method`` names the
+    ``RAGAccessAuditLog`` success method ('search' today); its '<name>_failed'
+    sibling records a body exception (reason = the exception type, never its
+    message). Yields a recorder whose ``result_refs`` the tool sets.
+    """
+    audit = loggers.RAGAccessAuditLog(
+        claims=(deps.user.model_dump() if deps.user else {}),
+        room_id=deps.room_id,
+        thread_id=deps.thread_id,
+        run_id=deps.run_id,
+    )
+    recorder = _ToolAccessRecorder()
+    try:
+        yield recorder
+    except Exception as exc:
+        getattr(audit, f"{audit_method}_failed")(
+            db_path, selector, type(exc).__name__
+        )
+        raise
+    getattr(audit, audit_method)(db_path, selector, recorder.result_refs)

--- a/src/soliplex/tools/rag.py
+++ b/src/soliplex/tools/rag.py
@@ -5,6 +5,7 @@ from haiku.rag import client as hr_client
 from haiku.rag.store.models import chunk as rag_store_models_chunk
 
 from soliplex import agents
+from soliplex import rag_audit
 from soliplex.config import tools as config_tools
 
 
@@ -26,14 +27,22 @@ async def search_documents(
 
     hr_config = tool_config.haiku_rag_config
 
-    async with hr_client.HaikuRAG(
-        db_path=tool_config.rag_lancedb_path,
-        config=hr_config,
-        read_only=True,
-    ) as rag:
-        results = await rag.search(
-            query,
-            limit=tool_config.search_documents_limit,
-        )
+    with rag_audit.audit_tool_access(
+        ctx.deps,
+        audit_method="search",
+        db_path=str(tool_config.rag_lancedb_path),
+        selector=query,
+    ) as access:
+        async with hr_client.HaikuRAG(
+            db_path=tool_config.rag_lancedb_path,
+            config=hr_config,
+            read_only=True,
+        ) as rag:
+            results = await rag.search(
+                query,
+                limit=tool_config.search_documents_limit,
+            )
+
+        access.record_refs([result.chunk_id for result in results])
 
         return results

--- a/tests/unit/test_loggers.py
+++ b/tests/unit/test_loggers.py
@@ -706,6 +706,27 @@ def test_rag_search(audit_records):
     )
 
 
+def test_rag_search_failed(audit_records):
+    wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
+
+    wrapper.search_failed("db", "what is x", "RuntimeError")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_RAG_ACCESS,
+        levelno=logging.ERROR,
+        outcome=loggers.AUDIT_OUTCOME_ERROR,
+        scope=SCOPE_RAG_ACCESS,
+        fields={
+            "claims": CLAIMS,
+            "action": loggers.AUDIT_RAG_ACTION_SEARCH,
+            "db_path": "db",
+            "selector": "what is x",
+            "reason": "RuntimeError",
+        },
+    )
+
+
 def test_rag_doc_list(audit_records):
     wrapper = loggers.RAGAccessAuditLog(claims=CLAIMS)
 

--- a/tests/unit/test_rag_audit.py
+++ b/tests/unit/test_rag_audit.py
@@ -1,6 +1,8 @@
 import datetime as dt
 
 import ag_ui.core as agui_core
+import pydantic
+import pytest
 from haiku.rag.store.models import chunk as hr_chunk
 from haiku.skills import agent as hs_agent
 from pydantic_ai import messages as ai_messages
@@ -270,3 +272,80 @@ def test_contract_skill_activity_events_drive_the_auditor():
     assert log.calls == [
         ("/dbs/rag.lancedb", "search", {"query": "x"}, ["c1"])
     ]
+
+
+# -- audit_tool_access (room-agent RAG tool wrapper) -------------------
+
+USER_EMAIL = "x@a.test"
+ROOM_ID = "room-1"
+THREAD_ID = "thread-1"
+RUN_ID = "run-1"
+
+
+class SimpleClaims(pydantic.BaseModel):
+    email: str
+
+
+class ToolDeps(pydantic.BaseModel):
+    user: SimpleClaims | None
+    room_id: str
+    thread_id: str
+    run_id: str
+
+
+def _tool_deps(user):
+    return ToolDeps(
+        user=user,
+        room_id=ROOM_ID,
+        thread_id=THREAD_ID,
+        run_id=RUN_ID,
+    )
+
+
+def test_audit_tool_access_records_search(audit_records):
+    claims = SimpleClaims(email=USER_EMAIL)
+    deps = _tool_deps(claims)
+
+    with rag_audit.audit_tool_access(
+        deps, audit_method="search", db_path="/db", selector="q"
+    ) as access:
+        access.record_refs(["c1", "c2"])
+
+    record = audit_records[-1]
+    assert record.action == loggers.AUDIT_RAG_ACTION_SEARCH
+    assert record.outcome == loggers.AUDIT_OUTCOME_SUCCESS
+    assert record.db_path == "/db"
+    assert record.selector == "q"
+    assert record.result_refs == ["c1", "c2"]
+    assert record.claims == {"email": USER_EMAIL}
+    assert record.room_id == ROOM_ID
+    assert record.thread_id == THREAD_ID
+    assert record.run_id == RUN_ID
+
+
+def test_audit_tool_access_without_user_uses_empty_claims(audit_records):
+    deps = _tool_deps(None)
+
+    with rag_audit.audit_tool_access(
+        deps, audit_method="search", db_path="/db", selector="q"
+    ):
+        pass
+
+    assert audit_records[-1].claims == {}
+
+
+def test_audit_tool_access_records_failure(audit_records):
+    deps = _tool_deps(None)
+
+    with pytest.raises(RuntimeError):
+        with rag_audit.audit_tool_access(
+            deps, audit_method="search", db_path="/db", selector="q"
+        ):
+            raise RuntimeError("boom")
+
+    record = audit_records[-1]
+    assert record.action == loggers.AUDIT_RAG_ACTION_SEARCH
+    assert record.outcome == loggers.AUDIT_OUTCOME_ERROR
+    assert record.db_path == "/db"
+    assert record.selector == "q"
+    assert record.reason == "RuntimeError"

--- a/tests/unit/tools/test_rag_tools.py
+++ b/tests/unit/tools/test_rag_tools.py
@@ -4,6 +4,7 @@ import pydantic_ai
 import pytest
 
 from soliplex import agents
+from soliplex import loggers
 from soliplex.config import tools as config_tools
 from soliplex.tools import rag as rag_tools
 
@@ -30,7 +31,7 @@ def ctx_w_deps(sd_tool_config):
 @pytest.mark.parametrize("n_docs", [0, 1, 10])
 @mock.patch("soliplex.tools.rag.hr_client")
 async def test_search_documents(
-    hr_client, ctx_w_deps, sd_tool_config, n_docs, w_limit
+    hr_client, ctx_w_deps, sd_tool_config, n_docs, w_limit, audit_records
 ):
     hr_class = hr_client.HaikuRAG = mock.MagicMock()
     hr = hr_class.return_value
@@ -39,15 +40,22 @@ async def test_search_documents(
 
     search_results = [
         mock.Mock(
-            spec=["content", "document_uri", "score"],
+            spec=["content", "document_uri", "score", "chunk_id"],
             content=f"Doc #{i_doc}",
             document_uri=f"https://example.com/docs/doc_{i_doc}.pdf",
             score=i_doc,
+            chunk_id=f"chunk-{i_doc}",
         )
         for i_doc in range(n_docs)
     ]
 
     search.return_value = search_results
+
+    sd_tool_config.rag_lancedb_path = "/db/tool"
+    ctx_w_deps.deps.user = None
+    ctx_w_deps.deps.room_id = "room-1"
+    ctx_w_deps.deps.thread_id = "thread-1"
+    ctx_w_deps.deps.run_id = "run-1"
 
     if w_limit is None:
         sd_tool_config.search_documents_limit = exp_limit = 5
@@ -69,3 +77,41 @@ async def test_search_documents(
         config=sd_tool_config.haiku_rag_config,
         read_only=True,
     )
+
+    record = audit_records[-1]
+    assert record.action == loggers.AUDIT_RAG_ACTION_SEARCH
+    assert record.outcome == loggers.AUDIT_OUTCOME_SUCCESS
+    assert record.db_path == "/db/tool"
+    assert record.selector == QUESTION
+    assert record.result_refs == [f"chunk-{i_doc}" for i_doc in range(n_docs)]
+    assert record.claims == {}
+    assert record.room_id == "room-1"
+    assert record.thread_id == "thread-1"
+    assert record.run_id == "run-1"
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.tools.rag.hr_client")
+async def test_search_documents_records_failure(
+    hr_client, ctx_w_deps, sd_tool_config, audit_records
+):
+    hr_class = hr_client.HaikuRAG = mock.MagicMock()
+    client = hr_class.return_value.__aenter__.return_value
+    client.search.side_effect = RuntimeError("boom")
+
+    sd_tool_config.rag_lancedb_path = "/db/tool"
+    sd_tool_config.search_documents_limit = 5
+    ctx_w_deps.deps.user = None
+    ctx_w_deps.deps.room_id = "room-1"
+    ctx_w_deps.deps.thread_id = "thread-1"
+    ctx_w_deps.deps.run_id = "run-1"
+
+    with pytest.raises(RuntimeError):
+        await rag_tools.search_documents(ctx_w_deps, query=QUESTION)
+
+    record = audit_records[-1]
+    assert record.action == loggers.AUDIT_RAG_ACTION_SEARCH
+    assert record.outcome == loggers.AUDIT_OUTCOME_ERROR
+    assert record.db_path == "/db/tool"
+    assert record.selector == QUESTION
+    assert record.reason == "RuntimeError"


### PR DESCRIPTION
feat: 'rag_audit.audit_tool_access'

Context manager allowing RAG-based tools to record references on success; captures all other audit-relveant fields from agent depenedencies, and emits the log record using a tool-supplied action method name (or its '_failure' equivalent).

Closes #1092.