### PR TITLE
feat(agui): expose per-event timestamps for live and replay

### DIFF
--- a/src/soliplex/agui/schema.py
+++ b/src/soliplex/agui/schema.py
@@ -382,6 +382,9 @@ class RunEvent(Base):
             rai = agui_core.RunAgentInput.model_validate(rai)
             event.run_agent_input = rai
 
+        if event.timestamp is None and self.created is not None:
+            event.timestamp = agui_util._epoch_ms(self.created)
+
         return event
 
     @property

--- a/src/soliplex/agui/util.py
+++ b/src/soliplex/agui/util.py
@@ -8,3 +8,14 @@ def _make_uuid_str() -> str:
 
 def _timestamp() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)  # noqa UP07
+
+
+def _epoch_ms(value: datetime.datetime) -> int:
+    """Whole milliseconds since the Unix epoch.
+
+    Naive values are assumed to be UTC, matching how the backend writes
+    timestamps and how SQLite returns them (without zone) on read.
+    """
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.UTC)
+    return int(value.timestamp() * 1000)

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -25,6 +25,7 @@ from soliplex import titles
 from soliplex import util
 from soliplex import views
 from soliplex.agui import persistence as agui_persistence
+from soliplex.agui import util as agui_util
 from soliplex.config import agents as config_agents
 from soliplex.config import agui as config_agui
 from soliplex.config import rooms as config_rooms
@@ -664,6 +665,8 @@ async def drive_llm_stream(
         event_index = 0
         try:
             async for event in llm_stream:
+                event.timestamp = agui_util._epoch_ms(agui_util._timestamp())
+
                 event_list.append(event)
                 await event_queue.put(event)
                 auditor.handle(event)

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -1107,7 +1107,8 @@ async def test_threadstorage_save_run_events(
         strict=True,
     ):
         assert found_event == exp_event
-        assert db_event == exp_event
+        assert isinstance(db_event.timestamp, int)
+        assert db_event.model_copy(update={"timestamp": None}) == exp_event
 
 
 @pytest.mark.asyncio
@@ -1162,9 +1163,11 @@ async def test_threadstorage_save_single_event(the_async_session):
 
     assert len(pairs) == 2
     assert pairs[0][0] == 0
-    assert pairs[0][1] == event_0
+    assert isinstance(pairs[0][1].timestamp, int)
+    assert pairs[0][1].model_copy(update={"timestamp": None}) == event_0
     assert pairs[1][0] == 1
-    assert pairs[1][1] == event_1
+    assert isinstance(pairs[1][1].timestamp, int)
+    assert pairs[1][1].model_copy(update={"timestamp": None}) == event_1
 
     # Query with after_index=0 should only return the second
     pairs_after = await ts.list_run_events_after(
@@ -1177,7 +1180,8 @@ async def test_threadstorage_save_single_event(the_async_session):
 
     assert len(pairs_after) == 1
     assert pairs_after[0][0] == 1
-    assert pairs_after[0][1] == event_1
+    assert isinstance(pairs_after[0][1].timestamp, int)
+    assert pairs_after[0][1].model_copy(update={"timestamp": None}) == event_1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/agui/test_agui_schema.py
+++ b/tests/unit/agui/test_agui_schema.py
@@ -1,11 +1,13 @@
 from unittest import mock
 
 import pytest
+from ag_ui import core as agui_core
 from sqlalchemy import orm as sqla_orm
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import util
 from soliplex.agui import schema as agui_schema
+from soliplex.agui import util as agui_util
 from soliplex.config import installation as config_installation
 from tests.unit.agui import agui_constants
 
@@ -197,6 +199,51 @@ def test_runevent_from_agui_event(agui_event):
     assert found.type == agui_event.type
 
 
+def test_runevent_to_agui_model_fills_timestamp_from_created(the_session):
+    with the_session as session:
+        thread = agui_schema.Thread(room_id=ROOM_ID, user_name=USER_NAME)
+        session.add(thread)
+        session.commit()
+
+        run = agui_schema.Run(thread=thread)
+        session.add(run)
+        session.commit()
+
+        run_event = agui_schema.RunEvent.from_agui_model(
+            run,
+            agui_core.events.RawEvent(event={"k": "v"}),
+        )
+        session.add(run_event)
+        session.commit()
+
+        found = run_event.to_agui_model()
+
+        assert isinstance(found.timestamp, int)
+        assert found.timestamp == agui_util._epoch_ms(run_event.created)
+
+
+def test_runevent_to_agui_model_keeps_existing_timestamp(the_session):
+    with the_session as session:
+        thread = agui_schema.Thread(room_id=ROOM_ID, user_name=USER_NAME)
+        session.add(thread)
+        session.commit()
+
+        run = agui_schema.Run(thread=thread)
+        session.add(run)
+        session.commit()
+
+        run_event = agui_schema.RunEvent.from_agui_model(
+            run,
+            agui_core.events.RawEvent(event={"k": "v"}, timestamp=999),
+        )
+        session.add(run_event)
+        session.commit()
+
+        found = run_event.to_agui_model()
+
+        assert found.timestamp == 999
+
+
 @pytest.mark.parametrize(
     "email_kwargs, exp_email",
     [
@@ -335,7 +382,9 @@ async def test_run_events(the_session):
             await run.list_events(),
             strict=True,
         ):
-            assert db_event == agui_event
+            assert isinstance(db_event.timestamp, int)
+            stripped = db_event.model_copy(update={"timestamp": None})
+            assert stripped == agui_event
 
 
 @pytest.mark.parametrize("init_schema", [None, False, True])

--- a/tests/unit/agui/test_agui_util.py
+++ b/tests/unit/agui/test_agui_util.py
@@ -1,4 +1,7 @@
+import datetime
 from unittest import mock
+
+import pytest
 
 from soliplex.agui import util as agui_util
 
@@ -22,3 +25,14 @@ def test__timestamp(dt, tz):
     assert found is dt.now.return_value
 
     dt.now.assert_called_once_with(tz.utc)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (datetime.datetime(1970, 1, 1, 0, 0, 1, tzinfo=datetime.UTC), 1000),
+        (datetime.datetime(1970, 1, 1, 0, 0, 1), 1000),
+    ],
+)
+def test__epoch_ms(value, expected):
+    assert agui_util._epoch_ms(value) == expected

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1148,6 +1148,7 @@ def test_parse_last_event_id(header, expected):
 )
 @pytest.mark.parametrize("w_finished_error", [None, "finished", "error"])
 @pytest.mark.parametrize("w_title_config", [False, True])
+@mock.patch("soliplex.views.agui.agui_util._epoch_ms")
 @mock.patch("soliplex.views.agui.titles.maybe_generate_title")
 @mock.patch("soliplex.views.agui.finish_run")
 @mock.patch("soliplex.views.agui.save_single_event")
@@ -1157,12 +1158,16 @@ async def test_drive_llm_stream(
     sse,
     fr,
     maybe_gen_title,
+    epoch_ms,
     w_title_config,
     w_finished_error,
     w_finish_error,
     finish_expectation,
     w_event_count,
 ):
+    FIXED_TIMESTAMP_MS = 1_700_000_000_000
+    epoch_ms.return_value = FIXED_TIMESTAMP_MS
+
     sqla_engine = mock.AsyncMock(spec_set=())
     event_queue = asyncio.Queue()
 
@@ -1189,6 +1194,8 @@ async def test_drive_llm_stream(
             yield error_event
 
     expected = [event async for event in event_iter()]
+    for expected_event in expected:
+        expected_event.timestamp = FIXED_TIMESTAMP_MS
 
     with finish_expectation as finish_expected:
         await agui_views.drive_llm_stream(
@@ -1278,6 +1285,39 @@ async def test_drive_llm_stream(
         )
     else:
         maybe_gen_title.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@mock.patch("soliplex.views.agui.titles.maybe_generate_title")
+@mock.patch("soliplex.views.agui.finish_run")
+@mock.patch("soliplex.views.agui.save_single_event")
+@mock.patch("soliplex.views.agui.logfire")
+async def test_drive_llm_stream_stamps_live_timestamp(logfire, sse, fr, mgt):
+    sqla_engine = mock.AsyncMock(spec_set=())
+    event_queue = asyncio.Queue()
+
+    async def event_iter():
+        yield agui_core.events.RawEvent(event={"i": 0})
+        yield agui_core.events.RawEvent(event={"i": 1})
+
+    before = int(datetime.datetime.now(datetime.UTC).timestamp() * 1000)
+    await agui_views.drive_llm_stream(
+        event_iter(),
+        sqla_engine=sqla_engine,
+        event_queue=event_queue,
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+        thread_id=TEST_THREAD_ID_STR,
+        run_id=TEST_RUN_ID_STR,
+    )
+    after = int(datetime.datetime.now(datetime.UTC).timestamp() * 1000)
+
+    queued = [await event_queue.get(), await event_queue.get()]
+    assert await event_queue.get() is None  # sentinel
+
+    for event in queued:
+        assert isinstance(event.timestamp, int)
+        assert before <= event.timestamp <= after
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

Backend half of the frontend chat-timestamps feature: expose each AG-UI event's per-event creation time to clients on the wire, for **both live streaming and history replay**, so a message's real time is available per-event instead of only at run granularity.

The AG-UI protocol already defines `BaseEvent.timestamp: Optional[int]` (ms since epoch) and clients already parse it, so **no protocol or generated-schema change is needed** — we just populate it.

## Changes

1. **`agui/util.py`** — new `_epoch_ms(datetime) -> int` helper (datetime → int ms; naive datetimes assumed UTC, since SQLite returns zoneless datetimes on read).
2. **`agui/schema.py`** — `RunEvent.to_agui_model()` fills `event.timestamp` from the DB column `created` (via `_epoch_ms`), **fill-only** (only when the event carries no timestamp and `created` is set). This is the single chokepoint for every read path — SSE reconnect/replay and the GET-history endpoints — so it covers them all. `created` has been `NOT NULL` since the first migration, so this retroactively corrects historical runs (no backfill needed).
3. **`views/agui.py`** — `drive_llm_stream` stamps `event.timestamp` from the server clock **before** the event is queued/persisted, so live clients get the server time too. Stamping is unconditional, matching the existing house pattern `run.finished = agui_util._timestamp()`.

### Design notes
- **Live == replay:** the live path persists the emit-time stamp into the event's `data`, so replay of new rows returns the exact value the live client saw (fill-only preserves it); legacy rows fall back to `created`.
- **No new column:** the event's own protocol `timestamp` field is the single home; a dedicated `occurred_at` column was a considered YAGNI cut (nothing queries events by time at the SQL level).
- **Asymmetry is intentional:** live overwrites (backend owns emit time), replay preserves (read-time backfill). They can't diverge because the only writer of `data["timestamp"]` is the live path.

## Testing
- TDD throughout. New tests for the ms conversion (incl. naive→UTC), replay fill-from-`created`, fill-only preserve, and live stamping with real-clock bounds. Existing round-trip tests updated to assert the timestamp is populated while comparing all other fields unchanged.
- `uv run pytest` → **3589 passed, 100.00% branch coverage**; `ruff check` / `ruff format --check` clean.
- Reviewed by code-quality, test-coverage, comment-accuracy, and silent-failure agents; findings addressed.

## Acceptance criteria
- [x] Replayed events carry a `timestamp` reflecting per-event creation time (incl. historical runs)
- [x] Live events carry a `timestamp` reflecting server emit time, present on the wire
- [x] No AG-UI protocol or generated-schema changes
- [x] 100% branch coverage; lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
