### PR TITLE
fix: configure 'SessionMiddleware' cookie safe-by-default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ markers = [
 [tool.coverage.run]
 omit = [
     "src/soliplex/cli/__init__.py",
-    "src/soliplex/cli/serve.py",
 
     "src/soliplex/examples.py",
     "src/soliplex/tui.py",

--- a/src/soliplex/cli/serve.py
+++ b/src/soliplex/cli/serve.py
@@ -13,6 +13,10 @@ from soliplex import main
 from soliplex.cli import cli_util
 from soliplex.cli import types
 
+WEBSOCKETS_SANSIO = "websockets-sansio"
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+
 
 class ReloadOption(enum.StrEnum):
     CONFIG = "config"
@@ -78,6 +82,13 @@ def serve(
         "--no-auth-mode",
         help="Disable OIDC authentication providers",
     ),
+    insecure_session_cookie: bool = typer.Option(
+        False,
+        "--insecure-session-cookie",
+        help="Allow the session cookie over plain HTTP for local "
+        "development only; clears the cookie Secure flag. Do not use "
+        "in production.",
+    ),
     add_admin_user: str | None = typer.Option(
         None,
         "--add-admin-user",
@@ -88,13 +99,13 @@ Passing this option now fails with a non-zero exit.
 """,
     ),
     host: str = typer.Option(
-        "127.0.0.1",
+        DEFAULT_HOST,
         "-H",
         "--host",
         help="Bind socket to this host",
     ),
     port: int = typer.Option(
-        8000,
+        DEFAULT_PORT,
         "-p",
         "--port",
         help="Port number",
@@ -176,7 +187,7 @@ Passing this option now fails with a non-zero exit.
     uvicorn_kw = {
         "host": host,
         "port": port,
-        "ws": "websockets-sansio",
+        "ws": WEBSOCKETS_SANSIO,
     }
 
     if uds is not None:
@@ -224,6 +235,9 @@ Passing this option now fails with a non-zero exit.
         if log_config is not None:  # pass to the app, disable Uvicorn.
             os.environ["_SOLIPLEX_LOG_CONFIG_FILE"] = str(log_config)
 
+        if insecure_session_cookie:
+            os.environ["_SOLIPLEX_INSECURE_SESSION_COOKIE"] = "Y"
+
         if app_factory_name is None:
             app_factory_name = "soliplex.main:create_app_from_environment"
 
@@ -243,5 +257,6 @@ Passing this option now fails with a non-zero exit.
             installation_path=installation_path,
             no_auth_mode=no_auth_mode,
             log_config_file=log_config,
+            session_https_only=not insecure_session_cookie,
         )
         uvicorn.run(app, **uvicorn_kw)

--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -52,10 +52,18 @@ def app_with_cors(app: fastapi.FastAPI) -> fastapi.FastAPI:
     return app
 
 
-def app_with_session(app: fastapi.FastAPI, token: str) -> fastapi.FastAPI:
+def app_with_session(
+    app: fastapi.FastAPI,
+    token: str,
+    *,
+    https_only: bool = True,
+    same_site: str = "lax",
+) -> fastapi.FastAPI:
     app.add_middleware(
         starlette_mw_sessions.SessionMiddleware,
         secret_key=token.encode("ascii"),
+        https_only=https_only,
+        same_site=same_site,
     )
     return app
 
@@ -64,6 +72,7 @@ def create_app(
     installation_path: pathlib.Path,
     no_auth_mode: bool,
     log_config_file: str = None,
+    session_https_only: bool = True,
     curry_lifespan=None,
     app_with_lifespan=None,
     app_with_cors=None,
@@ -98,7 +107,7 @@ def create_app(
     session_token = tmp_installation.get_secret(
         "secret:SESSION_MIDDLEWARE_TOKEN"
     )
-    app = app_with_session(app, session_token)
+    app = app_with_session(app, session_token, https_only=session_https_only)
 
     return app
 
@@ -114,11 +123,15 @@ def create_app_from_environment():
     installation_path = pathlib.Path(installation_path_str)
     no_auth_mode = os.environ.get("_SOLIPLEX_NO_AUTH_MODE") == "Y"
     log_config_file = os.environ.get("_SOLIPLEX_LOG_CONFIG_FILE")
+    session_https_only = (
+        os.environ.get("_SOLIPLEX_INSECURE_SESSION_COOKIE") != "Y"
+    )
 
     return create_app(
         installation_path=installation_path,
         log_config_file=log_config_file,
         no_auth_mode=no_auth_mode,
+        session_https_only=session_https_only,
     )
 
 

--- a/tests/unit/cli/test_cli_serve.py
+++ b/tests/unit/cli/test_cli_serve.py
@@ -1,0 +1,270 @@
+import os
+import pathlib
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import typer
+
+from soliplex.cli import serve
+
+ADMIN_EMAIL = "admin@example.com"
+WORKERS = 4
+UDS_PATH = "/run/soliplex.sock"
+SOCKET_FD = 7
+FORWARDED_ALLOW_IPS = "*"
+APP_FACTORY_NAME = "my.module:factory"
+
+
+def _serve_kwargs(installation_path, **overrides):
+    """Build a full keyword set for a direct 'serve.serve(...)' call.
+
+    The command is a Typer command, but the underlying function is a plain
+    callable. Driving it directly (rather than through 'CliRunner') is the
+    only way to exercise the callable-injection branches: '--app-maker'
+    cannot carry a callable over the command line, and a string there would
+    raise 'TypeError' when invoked.
+    """
+    kwargs = dict(
+        ctx=None,
+        installation_path=installation_path,
+        no_auth_mode=False,
+        insecure_session_cookie=False,
+        add_admin_user=None,
+        host=serve.DEFAULT_HOST,
+        port=serve.DEFAULT_PORT,
+        uds=None,
+        fd=None,
+        reload=None,
+        reload_dirs=[],
+        reload_includes=[],
+        workers=None,
+        log_config=None,
+        log_level=None,
+        access_log=None,
+        proxy_headers=None,
+        forwarded_allow_ips=None,
+        app_factory_name=None,
+        app_maker=None,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.fixture
+def patched_serve():
+    """Patch the command's external collaborators and isolate 'os.environ'.
+
+    'get_installation' returns a mock whose '_logging_config_file' is 'None'
+    by default (the "no installation-level logging config" branch); tests
+    that need the opposite reassign it. 'os.environ' is cleared so the
+    private '_SOLIPLEX_*' contract writes are deterministic to assert.
+    """
+    inst = mock.Mock()
+    inst._config._logging_config_file = None
+
+    with (
+        mock.patch.object(serve.uvicorn, "run") as uvicorn_run,
+        mock.patch.object(
+            serve.cli_util, "get_installation", return_value=inst
+        ) as get_installation,
+        mock.patch.object(serve.main, "create_app") as create_app,
+        mock.patch.dict("os.environ", {}, clear=True),
+    ):
+        yield SimpleNamespace(
+            uvicorn_run=uvicorn_run,
+            get_installation=get_installation,
+            create_app=create_app,
+            installation=inst,
+        )
+
+
+def test_serve_add_admin_user_removed_exits(patched_serve, tmp_path):
+    kwargs = _serve_kwargs(
+        tmp_path / "installation.yaml",
+        add_admin_user=ADMIN_EMAIL,
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        serve.serve(**kwargs)
+
+    assert exc_info.value.exit_code == 1
+    patched_serve.get_installation.assert_not_called()
+    patched_serve.create_app.assert_not_called()
+    patched_serve.uvicorn_run.assert_not_called()
+
+
+def test_serve_direct_default_uses_create_app(patched_serve, tmp_path):
+    i_path = tmp_path / "installation.yaml"
+    kwargs = _serve_kwargs(i_path)
+
+    serve.serve(**kwargs)
+
+    patched_serve.create_app.assert_called_once_with(
+        installation_path=i_path,
+        no_auth_mode=False,
+        log_config_file=None,
+        session_https_only=True,
+    )
+    patched_serve.uvicorn_run.assert_called_once_with(
+        patched_serve.create_app.return_value,
+        host=serve.DEFAULT_HOST,
+        port=serve.DEFAULT_PORT,
+        ws=serve.WEBSOCKETS_SANSIO,
+    )
+
+
+def test_serve_direct_honors_explicit_app_maker(patched_serve, tmp_path):
+    i_path = tmp_path / "installation.yaml"
+    app_maker = mock.Mock()
+    kwargs = _serve_kwargs(i_path, app_maker=app_maker)
+
+    serve.serve(**kwargs)
+
+    app_maker.assert_called_once_with(
+        installation_path=i_path,
+        no_auth_mode=False,
+        log_config_file=None,
+        session_https_only=True,
+    )
+    patched_serve.create_app.assert_not_called()
+    patched_serve.uvicorn_run.assert_called_once_with(
+        app_maker.return_value,
+        host=serve.DEFAULT_HOST,
+        port=serve.DEFAULT_PORT,
+        ws=serve.WEBSOCKETS_SANSIO,
+    )
+
+
+def test_serve_direct_uses_installation_logging_config(
+    patched_serve, tmp_path
+):
+    # No '--log-config' on the command line, but the installation carries
+    # its own logging config -> it is forwarded to Uvicorn.
+    i_path = tmp_path / "installation.yaml"
+    log_path = pathlib.Path("/etc/soliplex/logging.yaml")
+    patched_serve.installation._config._logging_config_file = log_path
+    patched_serve.installation._config.logging_config_file = log_path
+    kwargs = _serve_kwargs(i_path)
+
+    serve.serve(**kwargs)
+
+    patched_serve.uvicorn_run.assert_called_once_with(
+        patched_serve.create_app.return_value,
+        host=serve.DEFAULT_HOST,
+        port=serve.DEFAULT_PORT,
+        ws=serve.WEBSOCKETS_SANSIO,
+        log_config=str(log_path),
+    )
+
+
+def test_serve_reload_both_directory_factory(patched_serve, tmp_path):
+    # 'tmp_path' is a real directory, so the 'is_dir()' branch watches it
+    # directly; 'BOTH' also adds the 'soliplex' package directory.
+    kwargs = _serve_kwargs(tmp_path, reload=serve.ReloadOption.BOTH)
+
+    serve.serve(**kwargs)
+
+    patched_serve.create_app.assert_not_called()
+    assert os.environ["_SOLIPLEX_INSTALLATION_PATH"] == str(tmp_path)
+    assert "_SOLIPLEX_NO_AUTH_MODE" not in os.environ
+    assert "_SOLIPLEX_LOG_CONFIG_FILE" not in os.environ
+    assert "_SOLIPLEX_INSECURE_SESSION_COOKIE" not in os.environ
+
+    args, call_kwargs = patched_serve.uvicorn_run.call_args
+    assert args == ("soliplex.main:create_app_from_environment",)
+    assert call_kwargs["factory"] is True
+    assert call_kwargs["reload"] is serve.ReloadOption.BOTH
+    assert str(tmp_path) in call_kwargs["reload_dirs"]
+    assert call_kwargs["reload_includes"] == ["*.yaml", "*.yml", "*.txt"]
+    assert call_kwargs["host"] == serve.DEFAULT_HOST
+    assert call_kwargs["port"] == serve.DEFAULT_PORT
+    assert call_kwargs["ws"] == serve.WEBSOCKETS_SANSIO
+
+
+def test_serve_reload_config_file_watches_parent_dir(patched_serve, tmp_path):
+    # A non-directory installation path -> watch its parent. 'CONFIG' (not
+    # 'PYTHON'/'BOTH') does not add the 'soliplex' package directory.
+    i_file = tmp_path / "installation.yaml"
+    kwargs = _serve_kwargs(i_file, reload=serve.ReloadOption.CONFIG)
+
+    serve.serve(**kwargs)
+
+    args, call_kwargs = patched_serve.uvicorn_run.call_args
+    assert args == ("soliplex.main:create_app_from_environment",)
+    assert call_kwargs["reload"] is serve.ReloadOption.CONFIG
+    assert call_kwargs["reload_dirs"] == [str(tmp_path)]
+    assert call_kwargs["reload_includes"] == ["*.yaml", "*.yml", "*.txt"]
+
+
+def test_serve_workers_factory_with_all_options(patched_serve, tmp_path):
+    # The workers path is a factory path even without '--reload'. Set every
+    # optional Uvicorn knob and both other '_SOLIPLEX_*' env writes, plus an
+    # explicit app-factory name (so the default is not substituted).
+    i_file = tmp_path / "installation.yaml"
+    log_cfg = tmp_path / "logging.yaml"
+    kwargs = _serve_kwargs(
+        i_file,
+        workers=WORKERS,
+        no_auth_mode=True,
+        log_config=log_cfg,
+        uds=UDS_PATH,
+        fd=SOCKET_FD,
+        log_level=serve.LogLevelOption.DEBUG,
+        access_log=False,
+        proxy_headers=True,
+        forwarded_allow_ips=FORWARDED_ALLOW_IPS,
+        app_factory_name=APP_FACTORY_NAME,
+    )
+
+    serve.serve(**kwargs)
+
+    assert os.environ["_SOLIPLEX_INSTALLATION_PATH"] == str(i_file)
+    assert os.environ["_SOLIPLEX_NO_AUTH_MODE"] == "Y"
+    assert os.environ["_SOLIPLEX_LOG_CONFIG_FILE"] == str(log_cfg)
+
+    args, call_kwargs = patched_serve.uvicorn_run.call_args
+    assert args == (APP_FACTORY_NAME,)
+    assert call_kwargs["factory"] is True
+    assert call_kwargs["reload"] is None
+    assert call_kwargs["uds"] == UDS_PATH
+    assert call_kwargs["fd"] == SOCKET_FD
+    assert call_kwargs["workers"] == WORKERS
+    assert call_kwargs["log_level"] is serve.LogLevelOption.DEBUG
+    assert call_kwargs["log_config"] == str(log_cfg)
+    assert call_kwargs["access_log"] is False
+    assert call_kwargs["proxy_headers"] is True
+    assert call_kwargs["forwarded_allow_ips"] == FORWARDED_ALLOW_IPS
+
+
+def test_serve_direct_insecure_session_cookie(patched_serve, tmp_path):
+    # '--insecure-session-cookie' on the direct path turns off the cookie's
+    # Secure flag via the app factory.
+    i_path = tmp_path / "installation.yaml"
+    kwargs = _serve_kwargs(i_path, insecure_session_cookie=True)
+
+    serve.serve(**kwargs)
+
+    patched_serve.create_app.assert_called_once_with(
+        installation_path=i_path,
+        no_auth_mode=False,
+        log_config_file=None,
+        session_https_only=False,
+    )
+
+
+def test_serve_factory_insecure_session_cookie(patched_serve, tmp_path):
+    # On the factory path the flag is forwarded through the private
+    # '_SOLIPLEX_*' env contract to 'create_app_from_environment'.
+    i_file = tmp_path / "installation.yaml"
+    kwargs = _serve_kwargs(
+        i_file,
+        workers=WORKERS,
+        insecure_session_cookie=True,
+    )
+
+    serve.serve(**kwargs)
+
+    assert os.environ["_SOLIPLEX_INSECURE_SESSION_COOKIE"] == "Y"
+    args, _call_kwargs = patched_serve.uvicorn_run.call_args
+    assert args == ("soliplex.main:create_app_from_environment",)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -10,6 +10,7 @@ from soliplex import main
 
 LOG_CONFIG_FILE_PATH = "/path/to/logging.yaml"
 EXPLICIT_INST_PATH = "/explicit"
+TOKEN = "DEADBEEF"
 
 
 @pytest.fixture
@@ -94,7 +95,6 @@ def test_app_with_cors():
 
 
 def test_app_with_session():
-    TOKEN = "DEADBEEF"
     app = mock.Mock(spec_set=["add_middleware"])
 
     found = main.app_with_session(app, TOKEN)
@@ -104,13 +104,30 @@ def test_app_with_session():
     app.add_middleware.assert_called_once_with(
         starlette_mw_sessions.SessionMiddleware,
         secret_key=TOKEN.encode("ascii"),
+        https_only=True,
+        same_site="lax",
+    )
+
+
+def test_app_with_session_insecure():
+    app = mock.Mock(spec_set=["add_middleware"])
+
+    found = main.app_with_session(app, TOKEN, https_only=False)
+
+    assert found is app
+
+    app.add_middleware.assert_called_once_with(
+        starlette_mw_sessions.SessionMiddleware,
+        secret_key=TOKEN.encode("ascii"),
+        https_only=False,
+        same_site="lax",
     )
 
 
 @pytest.fixture
 def installation_w_session_token(explicit_inst_dir):
     secret_file = explicit_inst_dir / "session_secret.txt"
-    secret_file.write_text("DEADBEEF")
+    secret_file.write_text(TOKEN)
     i_yaml = explicit_inst_dir / "installation.yaml"
     i_yaml.write_text("""\
 id: test-create-main
@@ -123,17 +140,25 @@ secrets:
     return explicit_inst_dir
 
 
+@pytest.mark.parametrize("w_session_https_only", [None, False])
 @pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
 @pytest.mark.parametrize("w_no_auth_mode", [False, True])
 def test_create_app_with_explicit_overrides(
     installation_w_session_token,
     w_no_auth_mode,
     w_log_config_file,
+    w_session_https_only,
 ):
     kwargs = {}
 
     if w_log_config_file is not None:
         kwargs["log_config_file"] = w_log_config_file
+
+    if w_session_https_only is not None:
+        kwargs["session_https_only"] = w_session_https_only
+        exp_session_https_only = w_session_https_only
+    else:
+        exp_session_https_only = True
 
     curry_lifespan = mock.Mock(spec_set=())
     app_with_lifespan = mock.Mock(spec_set=())
@@ -153,7 +178,8 @@ def test_create_app_with_explicit_overrides(
     assert found is app_with_session.return_value
     app_with_session.assert_called_once_with(
         app_with_cors.return_value,
-        "DEADBEEF",
+        TOKEN,
+        https_only=exp_session_https_only,
     )
     app_with_cors.assert_called_once_with(
         app_with_lifespan.return_value,
@@ -168,17 +194,25 @@ def test_create_app_with_explicit_overrides(
     )
 
 
+@pytest.mark.parametrize("w_session_https_only", [None, False])
 @pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
 @pytest.mark.parametrize("w_no_auth_mode", [False, True])
 def test_create_app_wo_explicit_overrides(
     installation_w_session_token,
     w_no_auth_mode,
     w_log_config_file,
+    w_session_https_only,
 ):
     kwargs = {}
 
     if w_log_config_file is not None:
         kwargs["log_config_file"] = w_log_config_file
+
+    if w_session_https_only is not None:
+        kwargs["session_https_only"] = w_session_https_only
+        exp_session_https_only = w_session_https_only
+    else:
+        exp_session_https_only = True
 
     curry_lifespan = mock.Mock(spec_set=())
     app_with_lifespan = mock.Mock(spec_set=())
@@ -202,7 +236,8 @@ def test_create_app_wo_explicit_overrides(
 
     app_with_session.assert_called_once_with(
         app_with_cors.return_value,
-        "DEADBEEF",
+        TOKEN,
+        https_only=exp_session_https_only,
     )
     app_with_cors.assert_called_once_with(
         app_with_lifespan.return_value,
@@ -217,6 +252,7 @@ def test_create_app_wo_explicit_overrides(
     )
 
 
+@pytest.mark.parametrize("w_insecure_cookie", [False, True])
 @pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
 @pytest.mark.parametrize("w_no_auth_mode", [False, True])
 @mock.patch("soliplex.main.create_app")
@@ -225,6 +261,7 @@ def test_create_app_from_environment(
     temp_dir,
     w_no_auth_mode,
     w_log_config_file,
+    w_insecure_cookie,
 ):
     i_path = temp_dir / "installation.yaml"
 
@@ -236,6 +273,9 @@ def test_create_app_from_environment(
     if w_log_config_file:
         env_patch["_SOLIPLEX_LOG_CONFIG_FILE"] = w_log_config_file
 
+    if w_insecure_cookie:
+        env_patch["_SOLIPLEX_INSECURE_SESSION_COOKIE"] = "Y"
+
     with mock.patch.dict("os.environ", clear=True, **env_patch):
         found = main.create_app_from_environment()
 
@@ -245,4 +285,5 @@ def test_create_app_from_environment(
         installation_path=i_path,
         no_auth_mode=w_no_auth_mode,
         log_config_file=w_log_config_file,
+        session_https_only=not w_insecure_cookie,
     )


### PR DESCRIPTION
feat: 'soliplex-cli serve --insecure-session-cookie'

  Disables secure-by-default cookie setting for local development
  use (frontend not served by nginx proxy).

tests: 100% coverage for 'cli.serve'

Closes #829.