### PR TITLE
fix: audit admin uploads to rooms

### DIFF
--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -146,6 +146,10 @@ AUDIT_SANDBOX_EXEC = "sandbox exec"
 AUDIT_SANDBOX_ACTION_RUN = "run"
 AUDIT_SANDBOX_ACTION_RUN_PYTHON = "run-python"
 
+# room-upload audit events: an admin (privileged) adds shared reference
+# material to a room, changing what the room's agent and members can access.
+AUDIT_ROOM_UPLOAD_ADDED = "room upload added"
+
 
 class _StructuredFieldsAdapter(logging.LoggerAdapter):
     """LoggerAdapter that folds caller keyword fields into 'extra'."""
@@ -271,6 +275,7 @@ class AuditLogScopes(enum.StrEnum):
     INSTALLATION_CONFIG = "installation-config"
     RAG_ACCESS = "rag-access"
     SANDBOX_EXEC = "sandbox-exec"
+    ROOM_UPLOAD = "room-upload"
 
 
 class AuditLogWrapper(_StructuredFieldsAdapter):
@@ -609,4 +614,27 @@ class SandboxExecAuditLog(AuditLogWrapper):
             environment=environment,
             refs=refs,
             reason=reason,
+        )
+
+
+class RoomUploadAuditLog(AuditLogWrapper):
+    """Record privileged room-upload activity.
+
+    Adding a file to a room's shared uploads is an admin-only action that
+    changes the reference material available to the room's agent and members;
+    each successful upload is recorded for privileged-activity auditing
+    (actor 'claims', 'room_id', and the stored 'filename').
+    """
+
+    def __init__(self, claims: dict[str, typing.Any], **extra):
+        extra_with_claims = {"claims": claims} | extra
+        super().__init__(scope=AuditLogScopes.ROOM_UPLOAD, **extra_with_claims)
+
+    def room_upload_added(self, room_id: str, filename: str):
+        # NB: 'filename' is a reserved LogRecord attribute, so the stored
+        # file is recorded under 'upload_filename'.
+        self._succeeded(
+            AUDIT_ROOM_UPLOAD_ADDED,
+            room_id=room_id,
+            upload_filename=filename,
         )

--- a/src/soliplex/views/room_file_uploads.py
+++ b/src/soliplex/views/room_file_uploads.py
@@ -24,6 +24,19 @@ depend_the_user_claims = views.depend_the_user_claims
 depend_the_logger = views.depend_the_logger
 depend_the_authz_logger = soliplex_views_authz.depend_the_authz_logger
 
+RoomUploadAuditLog = loggers.RoomUploadAuditLog
+
+
+def get_the_room_upload_audit_log(
+    the_user_claims: authn_package.UserClaims = depend_the_user_claims,
+) -> RoomUploadAuditLog:
+    return RoomUploadAuditLog(claims=the_user_claims)
+
+
+depend_the_room_upload_audit_log = fastapi.Depends(
+    get_the_room_upload_audit_log,
+)
+
 
 @soliplex_views_util.logfire_span(
     "GET /v1/uploads/{room_id}",
@@ -149,6 +162,7 @@ async def post_uploads_room(
     the_user_claims: authn_package.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
     the_authz_logger: loggers.LogWrapper = depend_the_authz_logger,
+    the_audit: RoomUploadAuditLog = depend_the_room_upload_audit_log,
 ) -> fastapi.Response:
     """Upload a file for a thread within the given room
 
@@ -186,5 +200,7 @@ async def post_uploads_room(
     stripped_filename = pathlib.Path(upload_file.filename).name
     upload_target = room_dir / stripped_filename
     upload_target.write_bytes(await upload_file.read())
+
+    the_audit.room_upload_added(room_id=room_id, filename=stripped_filename)
 
     return fastapi.Response(status_code=204)

--- a/tests/unit/test_loggers.py
+++ b/tests/unit/test_loggers.py
@@ -15,6 +15,7 @@ SCOPE_ADMIN_USERS = loggers.AuditLogScopes.ADMIN_USERS
 SCOPE_INSTALLATION_CONFIG = loggers.AuditLogScopes.INSTALLATION_CONFIG
 SCOPE_RAG_ACCESS = loggers.AuditLogScopes.RAG_ACCESS
 SCOPE_SANDBOX_EXEC = loggers.AuditLogScopes.SANDBOX_EXEC
+SCOPE_ROOM_UPLOAD = loggers.AuditLogScopes.ROOM_UPLOAD
 
 
 @pytest.fixture
@@ -850,5 +851,37 @@ def test_sandbox_execute_failed(audit_records):
             "environment": None,
             "refs": ["/t/abc.py"],
             "reason": "RuntimeError",
+        },
+    )
+
+
+# --- RoomUploadAuditLog --------------------------------------------------
+
+
+@pytest.mark.parametrize("w_claims", [{}, CLAIMS])
+def test_roomuploadauditlog_ctor(w_claims):
+    found = loggers.RoomUploadAuditLog(claims=w_claims)
+
+    assert found.name == loggers.SOLIPLEX_AUDIT_LOGGER_NAME
+    scope = found.extra[loggers.SOLIPLEX_AUDIT_LOGGER_SCOPE_EXTRA]
+    assert scope == SCOPE_ROOM_UPLOAD
+    assert found.extra["claims"] == w_claims
+
+
+def test_room_upload_added(audit_records):
+    wrapper = loggers.RoomUploadAuditLog(claims=CLAIMS)
+
+    wrapper.room_upload_added("test-room", "model.md")
+
+    _assert_audit_record(
+        audit_records[-1],
+        message=loggers.AUDIT_ROOM_UPLOAD_ADDED,
+        levelno=logging.INFO,
+        outcome=loggers.AUDIT_OUTCOME_SUCCESS,
+        scope=SCOPE_ROOM_UPLOAD,
+        fields={
+            "claims": CLAIMS,
+            "room_id": "test-room",
+            "upload_filename": "model.md",
         },
     )

--- a/tests/unit/views/test_room_file_uploads.py
+++ b/tests/unit/views/test_room_file_uploads.py
@@ -216,6 +216,14 @@ async def test_get_uploads_room_filename(
     )
 
 
+@mock.patch("soliplex.views.room_file_uploads.RoomUploadAuditLog")
+def test_get_the_room_upload_audit_log(rual_klass):
+    found = room_views.get_the_room_upload_audit_log(THE_USER_CLAIMS)
+
+    assert found is rual_klass.return_value
+    rual_klass.assert_called_once_with(claims=THE_USER_CLAIMS)
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize(
     "w_filename, exp_filename",
@@ -264,6 +272,7 @@ async def test_post_uploads_room(
     the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
     the_logger = mock.create_autospec(loggers.LogWrapper)
     the_authz_logger = mock.create_autospec(loggers.LogWrapper)
+    the_audit = mock.create_autospec(loggers.RoomUploadAuditLog)
 
     if not w_admin_access:
         with pytest.raises(fastapi.HTTPException) as exc:
@@ -276,6 +285,7 @@ async def test_post_uploads_room(
                 the_user_claims=THE_USER_CLAIMS,
                 the_logger=the_logger,
                 the_authz_logger=the_authz_logger,
+                the_audit=the_audit,
             )
 
         assert exc.value.status_code == 403
@@ -284,6 +294,8 @@ async def test_post_uploads_room(
         the_authz_logger.error.assert_called_once_with(
             loggers.AUTHZ_ADMIN_ACCESS_REQUIRED
         )
+        # A refused (non-admin) attempt records no privileged-upload event.
+        the_audit.room_upload_added.assert_not_called()
 
     else:
         with expectation as expected:
@@ -296,12 +308,20 @@ async def test_post_uploads_room(
                 the_user_claims=THE_USER_CLAIMS,
                 the_logger=the_logger,
                 the_authz_logger=the_authz_logger,
+                the_audit=the_audit,
             )
 
         if not isinstance(expected, pytest.ExceptionInfo):
             assert response.status_code == expected
             exp_file = uploads_path / "rooms" / TEST_ROOM_ID / exp_filename
             assert exp_file.read_bytes() == TEST_CONTENT
+            the_audit.room_upload_added.assert_called_once_with(
+                room_id=TEST_ROOM_ID,
+                filename=exp_filename,
+            )
+        else:
+            # No upload occurred (uploads not configured) -> no audit record.
+            the_audit.room_upload_added.assert_not_called()
 
     the_authz_logger.debug.assert_called_once_with(
         loggers.UPLOADS_POST_ROOM,


### PR DESCRIPTION
User uploads to their own threads do not require an audit.

Closes #1115.