### PR TITLE
refactor: move txn mgmt from '{agui,authz}.persistence'

### DIFF
--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -587,7 +587,11 @@ async def get_the_threads(request: fastapi.Request) -> ThreadStorage:
 
     engine = request.state.threads_engine
     async with sqla_asyncio.AsyncSession(bind=engine) as session:
-        yield persistence.ThreadStorage(session)
+        # One transaction per request: the storage methods no longer
+        # commit, so the request owns the unit of work -- committed on a
+        # clean response, rolled back if the handler raises.
+        async with session.begin():
+            yield persistence.ThreadStorage(session)
 
 
 depend_the_threads = fastapi.Depends(get_the_threads)

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -55,8 +55,12 @@ class ThreadStorage(agui.ThreadStorage):
     @property
     @contextlib.asynccontextmanager
     async def session(self):
-        async with self._session.begin():
-            yield self._session
+        # Yield the caller-owned session as-is: the session owner (a
+        # FastAPI dependency, CLI context manager, or streaming helper)
+        # owns the transaction boundary and commits the unit of work
+        # exactly once. Methods here never open their own transaction or
+        # commit, so callers -- and tests -- need no interleaved commits.
+        yield self._session
 
     async def _find_user_thread(
         self,
@@ -420,8 +424,6 @@ class ThreadStorage(agui.ThreadStorage):
         event: agui_core.Event,
     ) -> None:
         """Save a single event for a run (incremental persistence)"""
-        await self._session.commit()
-
         async with self.session as session:
             run = await self._find_thread_run(
                 user_name=user_name,
@@ -448,8 +450,6 @@ class ThreadStorage(agui.ThreadStorage):
         run_id: str,
     ) -> None:
         """Mark a run as finished"""
-        await self._session.commit()
-
         async with self.session as session:
             run = await self._find_thread_run(
                 user_name=user_name,
@@ -475,8 +475,6 @@ class ThreadStorage(agui.ThreadStorage):
 
         Each element is a (event_index, event) tuple.
         """
-        await self._session.commit()
-
         async with self.session as session:
             run = await self._find_thread_run(
                 user_name=user_name,
@@ -504,8 +502,6 @@ class ThreadStorage(agui.ThreadStorage):
         run_id: str,
     ) -> bool:
         """Return True if the run has a 'finished' timestamp"""
-        await self._session.commit()
-
         async with self.session as session:
             run = await self._find_thread_run(
                 user_name=user_name,
@@ -527,8 +523,6 @@ class ThreadStorage(agui.ThreadStorage):
         events: agui.AGUI_Events,
     ) -> agui.AGUI_Events:
         """Save the events for a gven run"""
-        await self._session.commit()
-
         async with self.session as session:
             run = await self._find_thread_run(
                 user_name=user_name,
@@ -560,8 +554,6 @@ class ThreadStorage(agui.ThreadStorage):
         tool_calls: int,
     ):
         """Save the run usage statistics"""
-        await self._session.commit()
-
         async with self.session as session:
             run = await self._find_thread_run(
                 user_name=user_name,
@@ -591,8 +583,6 @@ class ThreadStorage(agui.ThreadStorage):
         reason: str,
     ):
         """Save the run feedback"""
-        await self._session.commit()
-
         async with self.session as session:
             run = await self._find_thread_run(
                 user_name=user_name,
@@ -626,8 +616,6 @@ class ThreadStorage(agui.ThreadStorage):
         run_id: str,
     ) -> agui.RunFeedbackType | None:
         """Get the run feedback"""
-        await self._session.commit()
-
         async with self.session as session:
             run = await self._find_thread_run(
                 user_name=user_name,
@@ -657,8 +645,6 @@ class ThreadStorage(agui.ThreadStorage):
         """
         if limit is None and since is None:
             limit = 20
-
-        await self._session.commit()
 
         async with self.session as session:
             query = (

--- a/src/soliplex/authz/persistence.py
+++ b/src/soliplex/authz/persistence.py
@@ -80,8 +80,13 @@ class _SessionPolicy:
     @property
     @contextlib.asynccontextmanager
     async def session(self):
-        async with self._session.begin():
-            yield self._session
+        # Yield the caller-owned session as-is: the session owner (a
+        # FastAPI dependency or the CLI '_authz_session' context manager)
+        # owns the transaction boundary and commits the unit of work
+        # exactly once. Policy methods here never open their own
+        # transaction or commit, so callers -- and tests -- need no
+        # interleaved commits.
+        yield self._session
 
 
 class AdminUserPolicy(_SessionPolicy, authz.AdminUserPolicy):

--- a/src/soliplex/cli/cli_util.py
+++ b/src/soliplex/cli/cli_util.py
@@ -132,6 +132,12 @@ async def _authz_session(dburi):
             await connection.run_sync(authz_schema.Base.metadata.create_all)
         async with sqla_asyncio.AsyncSession(bind=engine) as session:
             yield session
+            # The policy methods no longer commit; this context manager
+            # owns the session, so it commits the CLI command's unit of
+            # work once here. On a 'typer.Exit'/exception through the
+            # 'yield' this line is skipped and 'AsyncSession.__aexit__'
+            # rolls back.
+            await session.commit()
     finally:
         await engine.dispose()
 

--- a/src/soliplex/titles.py
+++ b/src/soliplex/titles.py
@@ -114,11 +114,14 @@ async def maybe_generate_title(
             bind=threads_engine,
         ) as session:
             the_threads = agui_persistence.ThreadStorage(session)
-            await the_threads.update_thread_metadata(
-                user_name=user_name,
-                room_id=room_id,
-                thread_id=thread_id,
-                thread_metadata={"name": title},
-            )
+            # This helper owns the session, so it owns the commit: the
+            # storage method no longer commits on its own.
+            async with session.begin():
+                await the_threads.update_thread_metadata(
+                    user_name=user_name,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    thread_metadata={"name": title},
+                )
     except Exception:
         logfire.exception("Failed to generate thread title")

--- a/src/soliplex/views/__init__.py
+++ b/src/soliplex/views/__init__.py
@@ -94,7 +94,10 @@ async def get_the_admin_user_policy(
 
     engine = request.state.authorization_engine
     async with sqla_asyncio.AsyncSession(bind=engine) as session:
-        yield persistence.AdminUserPolicy(session, the_user_claims)
+        # One transaction per request: the policy methods no longer
+        # commit, so the request owns the unit of work.
+        async with session.begin():
+            yield persistence.AdminUserPolicy(session, the_user_claims)
 
 
 depend_the_admin_user_policy = fastapi.Depends(get_the_admin_user_policy)
@@ -108,7 +111,10 @@ async def get_the_room_authz_policy(
 
     engine = request.state.authorization_engine
     async with sqla_asyncio.AsyncSession(bind=engine) as session:
-        yield persistence.RoomAuthorizationPolicy(session, the_user_claims)
+        # One transaction per request: the policy methods no longer
+        # commit, so the request owns the unit of work.
+        async with session.begin():
+            yield persistence.RoomAuthorizationPolicy(session, the_user_claims)
 
 
 depend_the_room_authz_policy = fastapi.Depends(get_the_room_authz_policy)

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -535,16 +535,19 @@ async def capture_usage_after_stream(
         async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
             the_threads = agui_persistence.ThreadStorage(session)
 
-            await the_threads.save_run_usage(
-                user_name=user_name,
-                room_id=room_id,
-                thread_id=thread_id,
-                run_id=run_id,
-                input_tokens=usage.input_tokens,
-                output_tokens=usage.output_tokens,
-                requests=usage.requests,
-                tool_calls=usage.tool_calls,
-            )
+            # This helper owns the session, so it owns the commit: the
+            # storage method no longer commits on its own.
+            async with session.begin():
+                await the_threads.save_run_usage(
+                    user_name=user_name,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    requests=usage.requests,
+                    tool_calls=usage.tool_calls,
+                )
 
 
 async def save_thread_run_events(
@@ -564,13 +567,16 @@ async def save_thread_run_events(
     async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
         the_threads = agui_persistence.ThreadStorage(session)
 
-        await the_threads.save_run_events(
-            events=event_list,
-            user_name=user_name,
-            room_id=room_id,
-            thread_id=thread_id,
-            run_id=run_id,
-        )
+        # This helper owns the session, so it owns the commit: the
+        # storage method no longer commits on its own.
+        async with session.begin():
+            await the_threads.save_run_events(
+                events=event_list,
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+            )
 
 
 async def save_single_event(
@@ -590,13 +596,18 @@ async def save_single_event(
     async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
         the_threads = agui_persistence.ThreadStorage(session)
 
-        await the_threads.save_single_event(
-            user_name=user_name,
-            room_id=room_id,
-            thread_id=thread_id,
-            run_id=run_id,
-            event=event,
-        )
+        # This helper owns the session, so it owns the commit: the
+        # storage method no longer commits on its own.  Committing per
+        # event is what lets a reconnecting client's poll observe them
+        # incrementally.
+        async with session.begin():
+            await the_threads.save_single_event(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+                event=event,
+            )
 
 
 async def finish_run(
@@ -615,12 +626,15 @@ async def finish_run(
     async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
         the_threads = agui_persistence.ThreadStorage(session)
 
-        await the_threads.finish_run(
-            user_name=user_name,
-            room_id=room_id,
-            thread_id=thread_id,
-            run_id=run_id,
-        )
+        # This helper owns the session, so it owns the commit: the
+        # storage method no longer commits on its own.
+        async with session.begin():
+            await the_threads.finish_run(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+            )
 
 
 async def drive_llm_stream(
@@ -859,7 +873,7 @@ async def post_room_agui_thread_id_run_id(
         )
 
         db_event_stream = streaming_views.stream_from_db(
-            the_threads,
+            request.state.threads_engine,
             user_name=user_name,
             room_id=room_id,
             thread_id=thread_id,
@@ -901,14 +915,25 @@ async def post_room_agui_thread_id_run_id(
         agent=agent,
     )
 
+    # Persist the run input in its own short-lived, committed session
+    # rather than via the request-scoped 'the_threads'. This handler
+    # returns a long-lived StreamingResponse, so the request session's
+    # transaction stays open for the whole stream; committing the input
+    # write here releases its lock immediately (and keeps the request
+    # transaction from holding a writer lock behind the incremental
+    # per-event background saves).
     try:
-        await the_threads.add_run_input(
-            user_name=user_name,
-            room_id=room_id,
-            thread_id=thread_id,
-            run_id=run_id,
-            run_input=agui_adapter.run_input,
-        )
+        async with sqla_asyncio.AsyncSession(
+            bind=request.state.threads_engine,
+        ) as session:
+            async with session.begin():
+                await agui_persistence.ThreadStorage(session).add_run_input(
+                    user_name=user_name,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    run_input=agui_adapter.run_input,
+                )
 
     except agui.AGUI_Exception as exc:
         raise fastapi.HTTPException(

--- a/src/soliplex/views/streaming.py
+++ b/src/soliplex/views/streaming.py
@@ -13,9 +13,11 @@ import typing
 import fastapi
 from fastapi import WebSocket
 from fastapi.responses import StreamingResponse
+from sqlalchemy.ext import asyncio as sqla_asyncio
 from starlette.websockets import WebSocketDisconnect
 
 from soliplex import util
+from soliplex.agui import persistence as agui_persistence
 
 SSE_POLL_INTERVAL_SECS = 2.0
 SSE_KEEPALIVE_INTERVAL_SECS = 15.0
@@ -124,7 +126,7 @@ async def add_sse_event_ids(
 
 
 async def stream_from_db(
-    the_threads,
+    sqla_engine,
     *,
     user_name: str,
     room_id: str,
@@ -138,37 +140,55 @@ async def stream_from_db(
     Used for SSE reconnect: reads persisted events written by the
     background ``drive_llm_stream`` task.  Stops when the run is
     marked finished and all remaining events have been drained.
+
+    Each poll opens its own short-lived read session, so every
+    iteration observes the background task's freshly-committed events
+    regardless of backend isolation level (a new SQLite snapshot; a
+    new Postgres READ COMMITTED transaction).  The session is closed
+    before yielding to the consumer and before sleeping, so no read
+    transaction or connection is held across those awaits.
     """
     while True:
-        pairs = await the_threads.list_run_events_after(
-            user_name=user_name,
-            room_id=room_id,
-            thread_id=thread_id,
-            run_id=run_id,
-            after_index=after_index,
-        )
+        async with sqla_asyncio.AsyncSession(bind=sqla_engine) as session:
+            the_threads = agui_persistence.ThreadStorage(session)
 
-        for idx, event in pairs:
-            yield event
-            after_index = idx
-
-        finished = await the_threads.is_run_finished(
-            user_name=user_name,
-            room_id=room_id,
-            thread_id=thread_id,
-            run_id=run_id,
-        )
-
-        if finished:
-            # Drain any final events written between the last
-            # query and the finished flag being set.
-            final = await the_threads.list_run_events_after(
+            pairs = await the_threads.list_run_events_after(
                 user_name=user_name,
                 room_id=room_id,
                 thread_id=thread_id,
                 run_id=run_id,
                 after_index=after_index,
             )
+            # Highest event index seen this iteration -- the drain (and
+            # the next poll) start after it.
+            next_after = pairs[-1][0] if pairs else after_index
+
+            finished = await the_threads.is_run_finished(
+                user_name=user_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                run_id=run_id,
+            )
+
+            final = ()
+            if finished:
+                # Drain any final events written between the last
+                # query and the finished flag being set.  The finished
+                # flag is committed last, so any snapshot that sees it
+                # also sees every preceding event.
+                final = await the_threads.list_run_events_after(
+                    user_name=user_name,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    after_index=next_after,
+                )
+
+        for _idx, event in pairs:
+            yield event
+        after_index = next_after
+
+        if finished:
             for _idx, event in final:
                 yield event
             break

--- a/tests/unit/agui/test_agui_package.py
+++ b/tests/unit/agui/test_agui_package.py
@@ -218,22 +218,23 @@ async def test_compact_event_stream(events, expected):
 
 @pytest.mark.anyio
 @mock.patch("soliplex.agui.persistence.ThreadStorage")
-@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
-async def test_get_the_threads(as_klass, ts_klass):
+async def test_get_the_threads(ts_klass, fake_async_session):
     engine = object()
     request = fastapi.Request(scope={"type": "http"})
     request.state.threads_engine = engine
 
     counter = 0
 
-    async for the_threads in agui.get_the_threads(request):
-        assert the_threads is ts_klass.return_value
-        counter += 1
+    with mock.patch(
+        "sqlalchemy.ext.asyncio.AsyncSession",
+        new=fake_async_session.cls,
+    ):
+        async for the_threads in agui.get_the_threads(request):
+            assert the_threads is ts_klass.return_value
+            counter += 1
 
     assert counter == 1
 
-    ts_klass.assert_called_once_with(
-        as_klass.return_value.__aenter__.return_value,
-    )
+    ts_klass.assert_called_once_with(fake_async_session.session)
 
-    as_klass.assert_called_once_with(bind=engine)
+    fake_async_session.cls.assert_called_once_with(bind=engine)

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -40,16 +40,15 @@ def faux_sqlaa_session():
 @pytest.mark.anyio
 async def test_threadstorage_session(faux_sqlaa_session):
     ts = agui_persistence.ThreadStorage(faux_sqlaa_session)
-    begin = faux_sqlaa_session.begin
 
     async with ts.session as session:
-        assert session is faux_sqlaa_session
+        entered = session
 
-        begin.assert_called_once_with()
-        begin.return_value.__aenter__.assert_called_once_with()
-        begin.return_value.__aexit__.assert_not_called()
-
-    begin.return_value.__aenter__.assert_called_once_with()
+    # The session property is a passthrough: it yields the caller-owned
+    # session unchanged and never opens its own transaction. The session
+    # owner owns the commit boundary.
+    assert entered is faux_sqlaa_session
+    faux_sqlaa_session.begin.assert_not_called()
 
 
 @pytest_asyncio.fixture()
@@ -96,7 +95,6 @@ async def _add_run(
             room_id=room_id,
         )
         thread_id = await thread.awaitable_attrs.thread_id
-        await session.commit()
         (run,) = await thread.list_runs()
     else:
         run = await ts.new_run(
@@ -104,17 +102,15 @@ async def _add_run(
             room_id=room_id,
             thread_id=thread_id,
         )
-        await session.commit()
 
     run.created = created
     run.finished = finished
-    await session.commit()
 
     return thread_id
 
 
 @pytest.mark.asyncio
-async def test_threadstorage_thread_crud(the_async_session):
+async def test_threadstorage_thread_crud(the_async_session, unit_of_work):
     ts = agui_persistence.ThreadStorage(the_async_session)
 
     found = (await ts.list_user_threads(user_name=USER_NAME)).all()
@@ -140,8 +136,6 @@ async def test_threadstorage_thread_crud(the_async_session):
 
     thread_id = await thread.awaitable_attrs.thread_id
 
-    await the_async_session.commit()
-
     found = (await ts.list_user_threads(user_name=USER_NAME)).all()
     assert found == [thread]
 
@@ -150,16 +144,12 @@ async def test_threadstorage_thread_crud(the_async_session):
     ).all()
     assert found == [thread]
 
-    await the_async_session.commit()
-
     with pytest.raises(agui.ThreadRoomMismatch):
         await ts.get_thread(
             user_name=USER_NAME,
             room_id="NONESUCH",
             thread_id=thread_id,
         )
-
-    await the_async_session.commit()
 
     gotten = await ts.get_thread(
         user_name=USER_NAME,
@@ -168,8 +158,6 @@ async def test_threadstorage_thread_crud(the_async_session):
     )
 
     assert gotten is thread
-
-    await the_async_session.commit()
 
     with pytest.raises(agui.ThreadRoomMismatch):
         await ts.update_thread_metadata(
@@ -181,8 +169,6 @@ async def test_threadstorage_thread_crud(the_async_session):
                 "description": agui_constants.THREAD_DESCRIPTION,
             },
         )
-
-    await the_async_session.commit()
 
     updated = await ts.update_thread_metadata(
         user_name=USER_NAME,
@@ -196,14 +182,10 @@ async def test_threadstorage_thread_crud(the_async_session):
 
     assert updated is thread
 
-    await the_async_session.commit()
-
     thread_meta = await updated.awaitable_attrs.thread_metadata
 
     assert thread_meta.name == agui_constants.THREAD_NAME
     assert thread_meta.description == agui_constants.THREAD_DESCRIPTION
-
-    await the_async_session.commit()
 
     updated_again = await ts.update_thread_metadata(
         user_name=USER_NAME,
@@ -216,46 +198,36 @@ async def test_threadstorage_thread_crud(the_async_session):
 
     assert updated_again is thread
 
-    await the_async_session.commit()
-
     thread_meta = await updated.awaitable_attrs.thread_metadata
 
     assert thread_meta.name == agui_constants.THREAD_NAME
     assert thread_meta.description is None
 
-    await the_async_session.commit()
-
-    cleared = await ts.update_thread_metadata(
-        user_name=USER_NAME,
-        room_id=ROOM_ID,
-        thread_id=thread_id,
-        thread_metadata=None,
-    )
+    async with unit_of_work():
+        cleared = await ts.update_thread_metadata(
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            thread_metadata=None,
+        )
 
     assert cleared is thread
 
-    await the_async_session.commit()
-
     thread_meta = await updated.awaitable_attrs.thread_metadata
     assert thread_meta is None
 
-    await the_async_session.commit()
-
-    cleared_again = await ts.update_thread_metadata(
-        user_name=USER_NAME,
-        room_id=ROOM_ID,
-        thread_id=thread_id,
-        thread_metadata=None,
-    )
+    async with unit_of_work():
+        cleared_again = await ts.update_thread_metadata(
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            thread_metadata=None,
+        )
 
     assert cleared_again is thread
 
-    await the_async_session.commit()
-
     thread_meta = await updated.awaitable_attrs.thread_metadata
     assert thread_meta is None
-
-    await the_async_session.commit()
 
     with pytest.raises(agui.ThreadRoomMismatch):
         await ts.delete_thread(
@@ -264,17 +236,11 @@ async def test_threadstorage_thread_crud(the_async_session):
             thread_id=thread_id,
         )
 
-    await the_async_session.commit()
-
     await ts.delete_thread(
         user_name=USER_NAME,
         room_id=ROOM_ID,
         thread_id=thread_id,
     )
-
-    await the_async_session.commit()
-
-    await the_async_session.commit()
 
     found = (await ts.list_user_threads(user_name=USER_NAME)).all()
     assert found == []
@@ -283,8 +249,6 @@ async def test_threadstorage_thread_crud(the_async_session):
         await ts.list_user_threads(user_name=USER_NAME, room_id=ROOM_ID)
     ).all()
     assert found == []
-
-    await the_async_session.commit()
 
     w_md_dict = await ts.new_thread(
         user_name=USER_NAME,
@@ -298,13 +262,9 @@ async def test_threadstorage_thread_crud(the_async_session):
 
     await w_md_dict.awaitable_attrs.thread_id
 
-    await the_async_session.commit()
-
     tmd = await w_md_dict.awaitable_attrs.thread_metadata
     assert tmd.name == "w_md_dict"
     assert tmd.description == "Created with metadata as a dict"
-
-    await the_async_session.commit()
 
     w_md_obj = await ts.new_thread(
         user_name=USER_NAME,
@@ -318,17 +278,13 @@ async def test_threadstorage_thread_crud(the_async_session):
 
     await w_md_obj.awaitable_attrs.thread_id
 
-    await the_async_session.commit()
-
     tmd = await w_md_obj.awaitable_attrs.thread_metadata
     assert tmd.name == "w_md_obj"
     assert tmd.description == "Created with metadata as an object"
 
-    await the_async_session.commit()
-
 
 @pytest.mark.asyncio
-async def test_threadstorage_thread_run_cru(the_async_session):
+async def test_threadstorage_thread_run_cru(the_async_session, unit_of_work):
     ts = agui_persistence.ThreadStorage(the_async_session)
 
     thread = await ts.new_thread(
@@ -350,13 +306,9 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     assert initial_run in await thread.awaitable_attrs.runs
 
-    await the_async_session.commit()
-
     found = await thread.list_runs()
 
     assert found == runs
-
-    await the_async_session.commit()
 
     rai_added = await ts.add_run_input(
         user_name=USER_NAME,
@@ -368,14 +320,10 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     assert rai_added is initial_run
 
-    await the_async_session.commit()
-
     assert (
         await initial_run.awaitable_attrs.run_input
         == agui_constants.FULL_RUN_AGENT_INPUT
     )
-
-    await the_async_session.commit()
 
     with pytest.raises(agui.RunAlreadyStarted):
         await ts.add_run_input(
@@ -386,8 +334,6 @@ async def test_threadstorage_thread_run_cru(the_async_session):
             run_input=agui_constants.FULL_RUN_AGENT_INPUT,
         )
 
-    await the_async_session.commit()
-
     gotten = await ts.get_run(
         user_name=USER_NAME,
         room_id=ROOM_ID,
@@ -396,8 +342,6 @@ async def test_threadstorage_thread_run_cru(the_async_session):
     )
 
     assert gotten is initial_run
-
-    await the_async_session.commit()
 
     with pytest.raises(agui.UnknownRun):
         await ts.get_run(
@@ -415,8 +359,6 @@ async def test_threadstorage_thread_run_cru(the_async_session):
     )
     added_id = await added.awaitable_attrs.run_id
 
-    await the_async_session.commit()
-
     updated = await ts.update_run_metadata(
         user_name=USER_NAME,
         room_id=ROOM_ID,
@@ -431,8 +373,6 @@ async def test_threadstorage_thread_run_cru(the_async_session):
 
     rmd = await updated.awaitable_attrs.run_metadata
     assert rmd.label == agui_constants.RUN_LABEL
-
-    await the_async_session.commit()
 
     updated_again = await ts.update_run_metadata(
         user_name=USER_NAME,
@@ -449,35 +389,31 @@ async def test_threadstorage_thread_run_cru(the_async_session):
     rmd = await updated_again.awaitable_attrs.run_metadata
     assert rmd.label == agui_constants.OTHER_RUN_LABEL
 
-    await the_async_session.commit()
-
-    cleared = await ts.update_run_metadata(
-        user_name=USER_NAME,
-        room_id=ROOM_ID,
-        thread_id=thread_id,
-        run_id=added_id,
-        run_metadata=None,
-    )
+    async with unit_of_work():
+        cleared = await ts.update_run_metadata(
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            run_id=added_id,
+            run_metadata=None,
+        )
 
     assert cleared is added
 
     assert await cleared.awaitable_attrs.run_metadata is None
 
-    await the_async_session.commit()
-
-    cleared_again = await ts.update_run_metadata(
-        user_name=USER_NAME,
-        room_id=ROOM_ID,
-        thread_id=thread_id,
-        run_id=added_id,
-        run_metadata=None,
-    )
+    async with unit_of_work():
+        cleared_again = await ts.update_run_metadata(
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            run_id=added_id,
+            run_metadata=None,
+        )
 
     assert cleared_again is added
 
     assert await cleared_again.awaitable_attrs.run_metadata is None
-
-    await the_async_session.commit()
 
     parent = await ts.new_run(
         user_name=USER_NAME,
@@ -486,11 +422,7 @@ async def test_threadstorage_thread_run_cru(the_async_session):
         run_metadata=agui_schema.RunMetadata(label="parent"),
     )
 
-    await the_async_session.commit()
-
     parent_id = await parent.awaitable_attrs.run_id
-
-    await the_async_session.commit()
 
     spare = await ts.new_run(
         user_name=USER_NAME,
@@ -501,14 +433,10 @@ async def test_threadstorage_thread_run_cru(the_async_session):
     )
     await spare.awaitable_attrs.run_id
 
-    await the_async_session.commit()
-
     rmd = await spare.awaitable_attrs.run_metadata
     assert rmd.label == "spare"
 
     assert await spare.awaitable_attrs.parent is parent
-
-    await the_async_session.commit()
 
     wo_meta = await ts.new_run(
         user_name=USER_NAME,
@@ -516,14 +444,8 @@ async def test_threadstorage_thread_run_cru(the_async_session):
         thread_id=thread_id,
     )
 
-    await the_async_session.commit()
-
     rmd = await wo_meta.awaitable_attrs.run_metadata
     assert rmd is None
-
-    await the_async_session.commit()
-
-    await the_async_session.commit()
 
     before = await ts.new_run(
         user_name=USER_NAME,
@@ -531,7 +453,6 @@ async def test_threadstorage_thread_run_cru(the_async_session):
         thread_id=thread_id,
     )
 
-    await the_async_session.commit()
     before_id = await before.awaitable_attrs.run_id
 
     usage = await before.awaitable_attrs.run_usage
@@ -548,8 +469,6 @@ async def test_threadstorage_thread_run_cru(the_async_session):
         tool_calls=4,
     )
 
-    await the_async_session.commit()
-
     after = await ts.get_run(
         user_name=USER_NAME,
         room_id=ROOM_ID,
@@ -564,11 +483,11 @@ async def test_threadstorage_thread_run_cru(the_async_session):
     assert after_usage.requests == 3
     assert after_usage.tool_calls == 4
 
-    await the_async_session.commit()
-
 
 @pytest.mark.asyncio
-async def test_threadstorage_thread_run_feedback(the_async_session):
+async def test_threadstorage_thread_run_feedback(
+    the_async_session, unit_of_work
+):
     ts = agui_persistence.ThreadStorage(the_async_session)
 
     thread = await ts.new_thread(
@@ -591,8 +510,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     )
     assert pre_feedback is None
 
-    await the_async_session.commit()
-
     await ts.save_run_feedback(
         user_name=USER_NAME,
         room_id=ROOM_ID,
@@ -601,8 +518,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
         feedback="thumbs_up",
         reason="just because",
     )
-
-    await the_async_session.commit()
 
     run_feedback = await ts.get_run_feedback(
         user_name=USER_NAME,
@@ -614,8 +529,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     assert await run_feedback.awaitable_attrs.feedback == "thumbs_up"
     assert await run_feedback.awaitable_attrs.reason == "just because"
 
-    await the_async_session.commit()
-
     await ts.save_run_feedback(
         user_name=USER_NAME,
         room_id=ROOM_ID,
@@ -624,8 +537,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
         feedback="thumbs_down",
         reason="dithering",
     )
-
-    await the_async_session.commit()
 
     moar_run_feedback = await ts.get_run_feedback(
         user_name=USER_NAME,
@@ -636,8 +547,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
 
     assert await moar_run_feedback.awaitable_attrs.feedback == "thumbs_down"
     assert await moar_run_feedback.awaitable_attrs.reason == "dithering"
-
-    await the_async_session.commit()
 
     added = await ts.new_run(
         user_name=USER_NAME,
@@ -654,8 +563,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
         feedback="thumbs_up",
         reason="fresh",
     )
-
-    await the_async_session.commit()
 
     # Default query
     later, earlier = await ts.list_recent_run_feedback()
@@ -755,8 +662,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     assert await tid_earlier_fb.awaitable_attrs.feedback == "thumbs_down"
     assert await tid_earlier_fb.awaitable_attrs.reason == "dithering"
 
-    await the_async_session.commit()
-
     await ts.save_run_feedback(
         user_name=USER_NAME,
         room_id=ROOM_ID,
@@ -777,8 +682,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     assert await further_run_feedback.awaitable_attrs.feedback == "thumbs_up"
     assert await further_run_feedback.awaitable_attrs.reason == "vacillating"
 
-    await the_async_session.commit()
-
     tid_later, tid_earlier = await ts.list_recent_run_feedback(
         thread_id=thread_id,
     )
@@ -795,16 +698,13 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     tid_later_hist = await tid_later_fb.awaitable_attrs.review_history
     assert tid_later_hist == []
 
-    await the_async_session.commit()
-
-    await ts.review_run_feedback(
-        reviewer_user_name=REVIEWER_USER_NAME,
-        reviewer_email=REVIEWER_EMAIL,
-        note="reviewing feedback",
-        run_feedback=tid_later_fb,
-    )
-
-    await the_async_session.commit()
+    async with unit_of_work():
+        await ts.review_run_feedback(
+            reviewer_user_name=REVIEWER_USER_NAME,
+            reviewer_email=REVIEWER_EMAIL,
+            note="reviewing feedback",
+            run_feedback=tid_later_fb,
+        )
 
     tid_later_hist = await tid_later_fb.awaitable_attrs.review_history
     (tid_later_entry,) = tid_later_hist
@@ -814,14 +714,13 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     )
     assert await tid_later_entry.awaitable_attrs.note == "reviewing feedback"
 
-    await the_async_session.commit()
-
-    await ts.resolve_run_feedback(
-        resolver_user_name=RESOLVER_USER_NAME,
-        resolver_email=RESOLVER_EMAIL,
-        note="resolving feedback",
-        run_feedback=tid_later_fb,
-    )
+    async with unit_of_work():
+        await ts.resolve_run_feedback(
+            resolver_user_name=RESOLVER_USER_NAME,
+            resolver_email=RESOLVER_EMAIL,
+            note="resolving feedback",
+            run_feedback=tid_later_fb,
+        )
     tid_later_hist = await tid_later_fb.awaitable_attrs.review_history
 
     # Check that review history is sorted in descending order
@@ -845,20 +744,17 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     )
     assert await last_entry.awaitable_attrs.note == ("reviewing feedback")
 
-    await the_async_session.commit()
-
     # Feedback review workflow using lookup
-    await ts.review_run_feedback(
-        reviewer_user_name=REVIEWER_USER_NAME,
-        reviewer_email=REVIEWER_EMAIL,
-        note="reviewing feedback",
-        user_name=USER_NAME,
-        room_id=ROOM_ID,
-        thread_id=thread_id,
-        run_id=added_id,
-    )
-
-    await the_async_session.commit()
+    async with unit_of_work():
+        await ts.review_run_feedback(
+            reviewer_user_name=REVIEWER_USER_NAME,
+            reviewer_email=REVIEWER_EMAIL,
+            note="reviewing feedback",
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            run_id=added_id,
+        )
 
     tid_earlier_hist = await tid_earlier_fb.awaitable_attrs.review_history
     (tid_earlier_entry,) = tid_earlier_hist
@@ -870,14 +766,13 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     )
     assert await tid_earlier_entry.awaitable_attrs.note == "reviewing feedback"
 
-    await the_async_session.commit()
-
-    await ts.resolve_run_feedback(
-        resolver_user_name=RESOLVER_USER_NAME,
-        resolver_email=RESOLVER_EMAIL,
-        note="resolving feedback",
-        run_feedback=tid_later_fb,
-    )
+    async with unit_of_work():
+        await ts.resolve_run_feedback(
+            resolver_user_name=RESOLVER_USER_NAME,
+            resolver_email=RESOLVER_EMAIL,
+            note="resolving feedback",
+            run_feedback=tid_later_fb,
+        )
     tid_later_hist = await tid_later_fb.awaitable_attrs.review_history
 
     (
@@ -900,19 +795,16 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     )
     assert await last_entry.awaitable_attrs.note == "reviewing feedback"
 
-    await the_async_session.commit()
-
-    await ts.resolve_run_feedback(
-        resolver_user_name=RESOLVER_USER_NAME,
-        resolver_email=RESOLVER_EMAIL,
-        note="resolving feedback",
-        user_name=USER_NAME,
-        room_id=ROOM_ID,
-        thread_id=thread_id,
-        run_id=added_id,
-    )
-
-    await the_async_session.commit()
+    async with unit_of_work():
+        await ts.resolve_run_feedback(
+            resolver_user_name=RESOLVER_USER_NAME,
+            resolver_email=RESOLVER_EMAIL,
+            note="resolving feedback",
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            run_id=added_id,
+        )
 
     tid_earlier_hist = await tid_earlier_fb.awaitable_attrs.review_history
 
@@ -935,8 +827,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
     )
     assert await last_entry.awaitable_attrs.note == "reviewing feedback"
 
-    await the_async_session.commit()
-
     # Test lookup where no feedback found
     no_feedback = await ts.new_run(
         user_name=USER_NAME,
@@ -944,8 +834,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
         thread_id=thread_id,
     )
     no_feedback_id = await no_feedback.awaitable_attrs.run_id
-
-    await the_async_session.commit()
 
     with pytest.raises(agui_persistence.NoFeedbackFound):
         await ts.review_run_feedback(
@@ -958,8 +846,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
             run_id=no_feedback_id,
         )
 
-    await the_async_session.commit()
-
     with pytest.raises(agui_persistence.NoFeedbackFound):
         await ts.resolve_run_feedback(
             resolver_user_name=RESOLVER_USER_NAME,
@@ -971,8 +857,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
             run_id=no_feedback_id,
         )
 
-    await the_async_session.commit()
-
     # Query for reviewed status
     review_only = await ts.new_run(
         user_name=USER_NAME,
@@ -980,8 +864,6 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
         thread_id=thread_id,
     )
     review_only_id = await review_only.awaitable_attrs.run_id
-
-    await the_async_session.commit()
 
     await ts.save_run_feedback(
         user_name=USER_NAME,
@@ -992,31 +874,23 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
         reason="winning",
     )
 
-    await the_async_session.commit()
-
     review_only_fb = await review_only.awaitable_attrs.run_feedback
 
-    await the_async_session.commit()
-
-    await ts.review_run_feedback(
-        reviewer_user_name=REVIEWER_USER_NAME,
-        reviewer_email=REVIEWER_EMAIL,
-        note="reviewing feedback; no resolve",
-        run_feedback=review_only_fb,
-    )
-
-    await the_async_session.commit()
+    async with unit_of_work():
+        await ts.review_run_feedback(
+            reviewer_user_name=REVIEWER_USER_NAME,
+            reviewer_email=REVIEWER_EMAIL,
+            note="reviewing feedback; no resolve",
+            run_feedback=review_only_fb,
+        )
 
     resolve_only = await ts.new_run(
         user_name=USER_NAME,
         room_id=ROOM_ID,
         thread_id=thread_id,
     )
-    await the_async_session.commit()
 
     resolve_only_id = await resolve_only.awaitable_attrs.run_id
-
-    await the_async_session.commit()
 
     await ts.save_run_feedback(
         user_name=USER_NAME,
@@ -1027,20 +901,15 @@ async def test_threadstorage_thread_run_feedback(the_async_session):
         reason="winning",
     )
 
-    await the_async_session.commit()
-
     resolve_only_fb = await resolve_only.awaitable_attrs.run_feedback
 
-    await the_async_session.commit()
-
-    await ts.resolve_run_feedback(
-        resolver_user_name=RESOLVER_USER_NAME,
-        resolver_email=RESOLVER_EMAIL,
-        note="resolving feedback; no view",
-        run_feedback=resolve_only_fb,
-    )
-
-    await the_async_session.commit()
+    async with unit_of_work():
+        await ts.resolve_run_feedback(
+            resolver_user_name=RESOLVER_USER_NAME,
+            resolver_email=RESOLVER_EMAIL,
+            note="resolving feedback; no view",
+            run_feedback=resolve_only_fb,
+        )
 
     w_reviewed = await ts.list_recent_run_feedback(
         status=agui.FeedbackReviewStatus.REVIEWED,
@@ -1066,6 +935,7 @@ async def test_threadstorage_save_run_events(
     ts,
     the_async_session,
     w_agui_events,
+    unit_of_work,
 ):
     ts.return_value = NOW
 
@@ -1083,17 +953,14 @@ async def test_threadstorage_save_run_events(
 
     run_id = await run.awaitable_attrs.run_id
 
-    await the_async_session.commit()
-
-    found_events = await ts.save_run_events(
-        user_name=USER_NAME,
-        room_id=ROOM_ID,
-        thread_id=thread_id,
-        run_id=run_id,
-        events=w_agui_events,
-    )
-
-    await the_async_session.commit()
+    async with unit_of_work():
+        found_events = await ts.save_run_events(
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            run_id=run_id,
+            events=w_agui_events,
+        )
 
     finished = await run.awaitable_attrs.finished
     assert finished == NOW.replace(tzinfo=None)  # sqlalchemy drops zone
@@ -1126,8 +993,6 @@ async def test_threadstorage_save_single_event(the_async_session):
 
     run_id = await run.awaitable_attrs.run_id
 
-    await the_async_session.commit()
-
     event_0 = agui_constants.TEXT_MESSAGE_START_EVENT
     event_1 = agui_constants.TEXT_MESSAGE_CONTENT_EVENT
 
@@ -1139,8 +1004,6 @@ async def test_threadstorage_save_single_event(the_async_session):
         event=event_0,
     )
 
-    await the_async_session.commit()
-
     await ts.save_single_event(
         user_name=USER_NAME,
         room_id=ROOM_ID,
@@ -1148,8 +1011,6 @@ async def test_threadstorage_save_single_event(the_async_session):
         run_id=run_id,
         event=event_1,
     )
-
-    await the_async_session.commit()
 
     # Verify events were persisted
     pairs = await ts.list_run_events_after(
@@ -1185,6 +1046,7 @@ async def test_threadstorage_save_single_event(the_async_session):
 async def test_threadstorage_finish_run(
     ts_mock,
     the_async_session,
+    unit_of_work,
 ):
     ts_mock.return_value = NOW
 
@@ -1202,8 +1064,6 @@ async def test_threadstorage_finish_run(
 
     run_id = await run.awaitable_attrs.run_id
 
-    await the_async_session.commit()
-
     # Run not yet finished
     is_fin = await ts.is_run_finished(
         user_name=USER_NAME,
@@ -1213,17 +1073,14 @@ async def test_threadstorage_finish_run(
     )
     assert is_fin is False
 
-    await the_async_session.commit()
-
     # Mark it finished
-    await ts.finish_run(
-        user_name=USER_NAME,
-        room_id=ROOM_ID,
-        thread_id=thread_id,
-        run_id=run_id,
-    )
-
-    await the_async_session.commit()
+    async with unit_of_work():
+        await ts.finish_run(
+            user_name=USER_NAME,
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            run_id=run_id,
+        )
 
     # Now it should be finished
     is_fin = await ts.is_run_finished(
@@ -1233,8 +1090,6 @@ async def test_threadstorage_finish_run(
         run_id=run_id,
     )
     assert is_fin is True
-
-    await the_async_session.commit()
 
     finished = await run.awaitable_attrs.finished
     assert finished == NOW.replace(tzinfo=None)

--- a/tests/unit/authz/test_authz_persistence.py
+++ b/tests/unit/authz/test_authz_persistence.py
@@ -46,16 +46,15 @@ def _room_authz_policy(session):
 @pytest.mark.anyio
 async def test_admin_user_session(faux_sqlaa_session):
     aup = authz_persistence.AdminUserPolicy(faux_sqlaa_session, CLAIMS)
-    begin = faux_sqlaa_session.begin
 
     async with aup.session as session:
-        assert session is faux_sqlaa_session
+        entered = session
 
-        begin.assert_called_once_with()
-        begin.return_value.__aenter__.assert_called_once_with()
-        begin.return_value.__aexit__.assert_not_called()
-
-    begin.return_value.__aenter__.assert_called_once_with()
+    # The session property is a passthrough: it yields the caller-owned
+    # session unchanged and never opens its own transaction. The session
+    # owner owns the commit boundary.
+    assert entered is faux_sqlaa_session
+    faux_sqlaa_session.begin.assert_not_called()
 
 
 def test_admin_user_policy_builds_audit_log():
@@ -70,7 +69,6 @@ async def test_list_admin_user_discriminators(the_async_session):
     aup = _admin_user_policy(the_async_session)
     the_async_session.add(authz_schema.AdminUser(json_path=JSON_PATH))
     the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
-    await the_async_session.commit()
 
     found = await aup.list_admin_user_discriminators()
 
@@ -93,7 +91,6 @@ async def test_add_admin_user_discriminator(the_async_session):
 async def test_add_admin_user_discriminator_already_exists(the_async_session):
     aup = _admin_user_policy(the_async_session)
     the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
-    await the_async_session.commit()
 
     with pytest.raises(authz.AdminUserExists):
         await aup.add_admin_user_discriminator(ROLE_JSON_PATH)
@@ -110,7 +107,6 @@ async def test_add_admin_user_discriminator_already_exists(the_async_session):
 async def test_remove_admin_user_discriminator(the_async_session):
     aup = _admin_user_policy(the_async_session)
     the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
-    await the_async_session.commit()
 
     await aup.remove_admin_user_discriminator(ROLE_JSON_PATH)
 
@@ -148,7 +144,6 @@ async def test_remove_admin_user_discriminator_invalid_json_path(
             created=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
         )
     )
-    await the_async_session.commit()
 
     await aup.remove_admin_user_discriminator(INVALID_JSON_PATH)
 
@@ -162,7 +157,6 @@ async def test_clear_admin_user_discriminators(the_async_session):
     aup = _admin_user_policy(the_async_session)
     the_async_session.add(authz_schema.AdminUser(json_path=JSON_PATH))
     the_async_session.add(authz_schema.AdminUser(json_path=ROLE_JSON_PATH))
-    await the_async_session.commit()
 
     await aup.clear_admin_user_discriminators()
 
@@ -201,14 +195,12 @@ async def test_admin_user_crud(the_async_session):
         session=the_async_session,
     )
     assert user is not None
-    await the_async_session.commit()
 
     aup._audit.admin_user_added.assert_called_once_with(JSON_PATH)
     aup._audit.admin_user_added.reset_mock()
 
     found = await aup.list_admin_users()
     assert found == [JSON_PATH]
-    await the_async_session.commit()
 
     aup._audit.admin_users_listed.assert_called_once_with()
     aup._audit.admin_users_listed.reset_mock()
@@ -221,7 +213,6 @@ async def test_admin_user_crud(the_async_session):
         session=the_async_session,
     )
     assert no_dupe is user
-    await the_async_session.commit()
 
     ((args, kwargs),) = aup._audit.admin_user_add_failed.call_args_list
     (arg,) = args
@@ -233,7 +224,6 @@ async def test_admin_user_crud(the_async_session):
 
     found = await aup.list_admin_users()
     assert found == [JSON_PATH]
-    await the_async_session.commit()
 
     aup._audit.admin_users_listed.assert_called_once_with()
     aup._audit.admin_users_listed.reset_mock()
@@ -244,14 +234,12 @@ async def test_admin_user_crud(the_async_session):
         session=the_async_session,
     )
     assert gone is None
-    await the_async_session.commit()
 
     aup._audit.admin_user_removed.assert_called_once_with(JSON_PATH)
     aup._audit.admin_user_removed.reset_mock()
 
     found = await aup.list_admin_users()
     assert found == []
-    await the_async_session.commit()
 
     aup._audit.admin_users_listed.assert_called_once_with()
     aup._audit.admin_users_listed.reset_mock()
@@ -309,7 +297,6 @@ async def test_admin_user_check_admin_access_json_path(
     the_async_session.add(
         authz_schema.AdminUser(json_path='$[?$.role == "admin"]'),
     )
-    await the_async_session.commit()
 
     assert await aup.check_admin_access({"role": "admin"})
 
@@ -352,7 +339,6 @@ async def test_room_authz_check_room_access(the_async_session):
     # Policy w/ deny as default, no ACL entries
     denier = authz_schema.RoomPolicy(room_id=ROOM_ID)
     the_async_session.add(denier)
-    await the_async_session.commit()
 
     assert not await rap.check_room_access(ROOM_ID, None)
 
@@ -362,7 +348,6 @@ async def test_room_authz_check_room_access(the_async_session):
         everyone=True,
     )
     the_async_session.add(allower)
-    await the_async_session.commit()
 
     assert await rap.check_room_access(ROOM_ID, None)
 
@@ -382,7 +367,6 @@ async def test_room_authz_filter_room_ids(the_async_session):
     # Policy w/ deny as default, no ACL entries
     denier = authz_schema.RoomPolicy(room_id=ROOM_ID)
     the_async_session.add(denier)
-    await the_async_session.commit()
 
     assert await rap.filter_room_ids(room_ids, None) == []
 
@@ -392,7 +376,6 @@ async def test_room_authz_filter_room_ids(the_async_session):
         everyone=True,
     )
     the_async_session.add(allower)
-    await the_async_session.commit()
 
     assert await rap.filter_room_ids(room_ids, None) == room_ids
 
@@ -420,14 +403,12 @@ async def test_room_authz_policy_crud(the_async_session):
         acl_entries=[acl_entry_model],
     )
     await rap.update_room_policy(ROOM_ID, policy_model)
-    await the_async_session.commit()
 
     rap._audit.room_policy_updated.assert_called_once_with(ROOM_ID)
     rap._audit.room_policy_updated.reset_mock()
 
     after = await rap.get_room_policy(ROOM_ID)
     assert after == policy_model
-    await the_async_session.commit()
 
     rap._audit.room_policy_read.assert_called_once_with(ROOM_ID)
     rap._audit.room_policy_read.reset_mock()
@@ -440,33 +421,28 @@ async def test_room_authz_policy_crud(the_async_session):
         update={"acl_entries": [new_acl_entry_model]},
     )
     await rap.update_room_policy(ROOM_ID, new_policy_model)
-    await the_async_session.commit()
 
     rap._audit.room_policy_updated.assert_called_once_with(ROOM_ID)
     rap._audit.room_policy_updated.reset_mock()
 
     policy = await rap.get_room_policy(ROOM_ID)
     assert policy == new_policy_model
-    await the_async_session.commit()
 
     rap._audit.room_policy_read.assert_called_once_with(ROOM_ID)
     rap._audit.room_policy_read.reset_mock()
 
     await rap.delete_room_policy(ROOM_ID)
-    await the_async_session.commit()
 
     rap._audit.room_policy_deleted.assert_called_once_with(ROOM_ID)
     rap._audit.room_policy_deleted.reset_mock()
 
     gone = await rap.get_room_policy(ROOM_ID)
     assert gone is None
-    await the_async_session.commit()
 
     rap._audit.room_policy_read.assert_called_once_with(ROOM_ID)
     rap._audit.room_policy_read.reset_mock()
 
     await rap.delete_room_policy(ROOM_ID)
-    await the_async_session.commit()
 
     rap._audit.room_policy_deleted.assert_called_once_with(ROOM_ID)
     rap._audit.room_policy_deleted.reset_mock()
@@ -496,7 +472,6 @@ async def _seed_policy(session, *, default=DENY, entries=()):
     for entry in entries:
         entry.room_policy = policy
         session.add(entry)
-    await session.commit()
     return policy
 
 
@@ -506,6 +481,12 @@ async def _seed_stale_entry(session, *, allow_deny=ALLOW):
         default=DENY,
         entries=[_orm_entry(allow_deny, json_path=JSON_PATH)],
     )
+    # Flush so the entry is a persistent row (not just pending state)
+    # before the raw UPDATE corrupts its 'json_path' out from under the
+    # ORM '@validates' hook. This is ORM setup for the stale-value
+    # scenario, not a transaction-boundary commit: the enclosing
+    # session still owns the (single) commit.
+    await session.flush()
     await session.execute(
         sqla_sql.text(
             "UPDATE room_acl_entries SET json_path = :stale "
@@ -513,7 +494,6 @@ async def _seed_stale_entry(session, *, allow_deny=ALLOW):
         ),
         {"stale": STALE_JSON_PATH, "placeholder": JSON_PATH},
     )
-    await session.commit()
     session.expire_all()
 
 
@@ -562,7 +542,6 @@ async def test_list_room_policies(the_async_session):
     the_async_session.add(
         authz_schema.RoomPolicy(room_id="beta", default_allow_deny=DENY)
     )
-    await the_async_session.commit()
 
     found = await rap.list_room_policies()
 
@@ -601,7 +580,6 @@ async def test_update_room_policy_room_id_is_authoritative(the_async_session):
     )
 
     await rap.update_room_policy(ROOM_ID, policy_model)
-    await the_async_session.commit()
 
     rap._audit.room_policy_updated.assert_called_once_with(ROOM_ID)
     stored = await rap.get_room_policy(ROOM_ID)
@@ -624,7 +602,6 @@ async def test_delete_room_policy_removes_acl_entries(the_async_session):
     )
 
     await rap.delete_room_policy(ROOM_ID)
-    await the_async_session.commit()
 
     remaining = (
         await the_async_session.scalars(sqla_sql.select(authz_schema.ACLEntry))
@@ -634,7 +611,7 @@ async def test_delete_room_policy_removes_acl_entries(the_async_session):
 
 
 @pytest.mark.asyncio
-async def test_clear_room_acl(the_async_session):
+async def test_clear_room_acl(the_async_session, unit_of_work):
     rap = _room_authz_policy(the_async_session)
     await _seed_policy(
         the_async_session,
@@ -645,8 +622,8 @@ async def test_clear_room_acl(the_async_session):
         ],
     )
 
-    await rap.clear_room_acl(ROOM_ID)
-    await the_async_session.commit()
+    async with unit_of_work():
+        await rap.clear_room_acl(ROOM_ID)
 
     rap._audit.acl_cleared.assert_called_once_with(ROOM_ID)
     after = await rap.get_room_policy(ROOM_ID)
@@ -671,7 +648,6 @@ async def test_add_acl_entry_to_policy(the_async_session):
     entry = models.ACLEntry(allow_deny=ALLOW, everyone=True)
 
     await rap.add_acl_entry(ROOM_ID, entry)
-    await the_async_session.commit()
 
     rap._audit.acl_entry_added.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
@@ -707,7 +683,7 @@ async def test_add_acl_entry_no_policy_raises(the_async_session):
 )
 @pytest.mark.asyncio
 async def test_add_acl_entry_replaces_same_discriminator(
-    the_async_session, discriminator_kwargs
+    the_async_session, discriminator_kwargs, unit_of_work
 ):
     rap = _room_authz_policy(the_async_session)
     await _seed_policy(
@@ -717,8 +693,8 @@ async def test_add_acl_entry_replaces_same_discriminator(
     )
     entry = models.ACLEntry(allow_deny=DENY, **discriminator_kwargs)
 
-    await rap.add_acl_entry(ROOM_ID, entry)
-    await the_async_session.commit()
+    async with unit_of_work():
+        await rap.add_acl_entry(ROOM_ID, entry)
 
     rap._audit.acl_entry_added.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
@@ -737,7 +713,6 @@ async def test_add_acl_entry_keeps_other_discriminator(the_async_session):
     entry = models.ACLEntry(allow_deny=DENY, json_path=ROLE_JSON_PATH)
 
     await rap.add_acl_entry(ROOM_ID, entry)
-    await the_async_session.commit()
 
     rap._audit.acl_entry_added.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
@@ -763,7 +738,7 @@ async def test_add_acl_entry_keeps_other_discriminator(the_async_session):
 )
 @pytest.mark.asyncio
 async def test_remove_acl_entry_matches_discriminator(
-    the_async_session, seed_kwargs, remove_kwargs
+    the_async_session, seed_kwargs, remove_kwargs, unit_of_work
 ):
     rap = _room_authz_policy(the_async_session)
     await _seed_policy(
@@ -773,8 +748,8 @@ async def test_remove_acl_entry_matches_discriminator(
     )
     entry = models.ACLEntryUnchecked(allow_deny=ALLOW, **remove_kwargs)
 
-    await rap.remove_acl_entry(ROOM_ID, entry)
-    await the_async_session.commit()
+    async with unit_of_work():
+        await rap.remove_acl_entry(ROOM_ID, entry)
 
     rap._audit.acl_entry_removed.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
@@ -835,7 +810,6 @@ async def test_remove_acl_entry_stale_json_path(the_async_session):
     )
 
     await rap.remove_acl_entry(ROOM_ID, entry)
-    await the_async_session.commit()
 
     rap._audit.acl_entry_removed.assert_called_once_with(ROOM_ID, entry)
     after = await rap.get_room_policy(ROOM_ID)
@@ -847,7 +821,6 @@ async def test_set_room_default_creates_when_missing(the_async_session):
     rap = _room_authz_policy(the_async_session)
 
     await rap.set_room_default(ROOM_ID, ALLOW)
-    await the_async_session.commit()
 
     rap._audit.room_default_set.assert_called_once_with(ROOM_ID, ALLOW)
     after = await rap.get_room_policy(ROOM_ID)
@@ -866,7 +839,6 @@ async def test_set_room_default_updates_existing(the_async_session):
     )
 
     await rap.set_room_default(ROOM_ID, ALLOW)
-    await the_async_session.commit()
 
     rap._audit.room_default_set.assert_called_once_with(ROOM_ID, ALLOW)
     after = await rap.get_room_policy(ROOM_ID)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,11 +1,14 @@
+import contextlib
 import logging
 import pathlib
 import tempfile
+import types
 from unittest import mock
 
 import _test_features as agui_features
 import pytest
 
+from soliplex import agui
 from soliplex import authz
 from soliplex import loggers
 from soliplex.config import agents as config_agents
@@ -36,6 +39,70 @@ def _auth_systems(n_auth_systems):
 def anyio_backend():
     """Run anyio-marked tests on asyncio only (no trio)."""
     return "asyncio"
+
+
+@pytest.fixture
+def unit_of_work(the_async_session):
+    """Group storage writes into one committed unit of work.
+
+    The persistence APIs no longer commit -- the session owner does. In
+    production that owner is a FastAPI dependency (or the CLI session
+    context manager) that commits once per request/invocation. Tests
+    mirror that boundary: statements that mutate go inside
+
+        async with unit_of_work():
+            await storage.mutate(...)
+
+    which commits on clean exit, and any assertion that observes the
+    *persisted* result (a reloaded attribute, a refreshed relationship,
+    a datetime round-tripped through the DB) is made afterwards, outside
+    the block, where a fresh view is guaranteed. Resolves whichever
+    'the_async_session' is in scope for the requesting test.
+    """
+
+    @contextlib.asynccontextmanager
+    async def _unit_of_work():
+        yield the_async_session
+        await the_async_session.commit()
+
+    return _unit_of_work
+
+
+@pytest.fixture
+def fake_async_session():
+    """Stand-in for ``sqla_asyncio.AsyncSession``.
+
+    Production code opens a fresh per-call session with
+    ``async with sqla_asyncio.AsyncSession(bind=...) as session:`` and
+    sometimes a nested ``async with session.begin():``. Patch
+    ``.cls`` in for ``AsyncSession`` (in whichever module opens the
+    session); it records its construction call and yields ``.session``
+    as the context value.
+
+    ``session.begin()`` is a non-suppressing async context manager (its
+    ``__aexit__`` returns ``False``), so code that wraps a call in a
+    transaction still propagates exceptions from the body.
+    """
+    session = mock.MagicMock()
+    session.begin.return_value.__aenter__ = mock.AsyncMock()
+    session.begin.return_value.__aexit__ = mock.AsyncMock(return_value=False)
+
+    @contextlib.asynccontextmanager
+    async def _open(*_args, **_kwargs):
+        yield session
+
+    cls = mock.MagicMock(side_effect=_open)
+    return types.SimpleNamespace(cls=cls, session=session)
+
+
+@pytest.fixture
+def mock_thread_storage():
+    """Stand-in ``ThreadStorage`` for code that builds one per call.
+
+    Patch ``agui_persistence.ThreadStorage`` (in whichever module builds
+    it) with ``return_value=`` this mock, then drive/assert its methods.
+    """
+    return mock.create_autospec(agui.ThreadStorage)
 
 
 @pytest.fixture

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -980,9 +980,10 @@ async def test_delete_room_agui_thread_id(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("w_usage", [False, True])
 @mock.patch("soliplex.agui.persistence.ThreadStorage")
-@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
-async def test_capture_usage_after_stream(a_session, t_storage, w_usage):
-    w_session = a_session.return_value.__aenter__.return_value
+async def test_capture_usage_after_stream(
+    t_storage, w_usage, fake_async_session
+):
+    w_session = fake_async_session.session
     the_threads = t_storage.return_value
     the_threads.save_run_usage = mock.AsyncMock(spec_set=())
     sqla_engine = object()
@@ -999,14 +1000,18 @@ async def test_capture_usage_after_stream(a_session, t_storage, w_usage):
     else:
         result = object()
 
-    await agui_views.capture_usage_after_stream(
-        result,
-        sqla_engine=sqla_engine,
-        user_name=USER_NAME,
-        room_id=TEST_ROOM_ID,
-        thread_id=TEST_THREAD_ID_STR,
-        run_id=TEST_RUN_ID_STR,
-    )
+    with mock.patch(
+        "soliplex.views.agui.sqla_asyncio.AsyncSession",
+        new=fake_async_session.cls,
+    ):
+        await agui_views.capture_usage_after_stream(
+            result,
+            sqla_engine=sqla_engine,
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID_STR,
+            run_id=TEST_RUN_ID_STR,
+        )
 
     if w_usage:
         the_threads.save_run_usage.assert_awaited_once_with(
@@ -1020,31 +1025,34 @@ async def test_capture_usage_after_stream(a_session, t_storage, w_usage):
             tool_calls=4,
         )
         t_storage.assert_called_once_with(w_session)
-        a_session.assert_called_once_with(bind=sqla_engine)
+        fake_async_session.cls.assert_called_once_with(bind=sqla_engine)
     else:
         the_threads.save_run_usage.assert_not_awaited()
         t_storage.assert_not_called()
-        a_session.assert_not_called()
+        fake_async_session.cls.assert_not_called()
 
 
 @pytest.mark.asyncio
 @mock.patch("soliplex.agui.persistence.ThreadStorage")
-@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
-async def test_save_thread_run_events(a_session, t_storage):
-    w_session = a_session.return_value.__aenter__.return_value
+async def test_save_thread_run_events(t_storage, fake_async_session):
+    w_session = fake_async_session.session
     the_threads = t_storage.return_value
     the_threads.save_run_events = mock.AsyncMock(spec_set=())
     sqla_engine = object()
     event_list = [object()]
 
-    await agui_views.save_thread_run_events(
-        sqla_engine=sqla_engine,
-        event_list=event_list,
-        user_name=USER_NAME,
-        room_id=TEST_ROOM_ID,
-        thread_id=TEST_THREAD_ID_STR,
-        run_id=TEST_RUN_ID_STR,
-    )
+    with mock.patch(
+        "soliplex.views.agui.sqla_asyncio.AsyncSession",
+        new=fake_async_session.cls,
+    ):
+        await agui_views.save_thread_run_events(
+            sqla_engine=sqla_engine,
+            event_list=event_list,
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID_STR,
+            run_id=TEST_RUN_ID_STR,
+        )
 
     the_threads.save_run_events.assert_called_once_with(
         events=event_list,
@@ -1056,27 +1064,30 @@ async def test_save_thread_run_events(a_session, t_storage):
 
     t_storage.assert_called_once_with(w_session)
 
-    a_session.assert_called_once_with(bind=sqla_engine)
+    fake_async_session.cls.assert_called_once_with(bind=sqla_engine)
 
 
 @pytest.mark.asyncio
 @mock.patch("soliplex.agui.persistence.ThreadStorage")
-@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
-async def test_save_single_event_helper(a_session, t_storage):
-    w_session = a_session.return_value.__aenter__.return_value
+async def test_save_single_event_helper(t_storage, fake_async_session):
+    w_session = fake_async_session.session
     the_threads = t_storage.return_value
     the_threads.save_single_event = mock.AsyncMock(spec_set=())
     sqla_engine = object()
     event = object()
 
-    await agui_views.save_single_event(
-        sqla_engine,
-        user_name=USER_NAME,
-        room_id=TEST_ROOM_ID,
-        thread_id=TEST_THREAD_ID_STR,
-        run_id=TEST_RUN_ID_STR,
-        event=event,
-    )
+    with mock.patch(
+        "soliplex.views.agui.sqla_asyncio.AsyncSession",
+        new=fake_async_session.cls,
+    ):
+        await agui_views.save_single_event(
+            sqla_engine,
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID_STR,
+            run_id=TEST_RUN_ID_STR,
+            event=event,
+        )
 
     the_threads.save_single_event.assert_called_once_with(
         user_name=USER_NAME,
@@ -1087,25 +1098,28 @@ async def test_save_single_event_helper(a_session, t_storage):
     )
 
     t_storage.assert_called_once_with(w_session)
-    a_session.assert_called_once_with(bind=sqla_engine)
+    fake_async_session.cls.assert_called_once_with(bind=sqla_engine)
 
 
 @pytest.mark.asyncio
 @mock.patch("soliplex.agui.persistence.ThreadStorage")
-@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
-async def test_finish_run_helper(a_session, t_storage):
-    w_session = a_session.return_value.__aenter__.return_value
+async def test_finish_run_helper(t_storage, fake_async_session):
+    w_session = fake_async_session.session
     the_threads = t_storage.return_value
     the_threads.finish_run = mock.AsyncMock(spec_set=())
     sqla_engine = object()
 
-    await agui_views.finish_run(
-        sqla_engine,
-        user_name=USER_NAME,
-        room_id=TEST_ROOM_ID,
-        thread_id=TEST_THREAD_ID_STR,
-        run_id=TEST_RUN_ID_STR,
-    )
+    with mock.patch(
+        "soliplex.views.agui.sqla_asyncio.AsyncSession",
+        new=fake_async_session.cls,
+    ):
+        await agui_views.finish_run(
+            sqla_engine,
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=TEST_THREAD_ID_STR,
+            run_id=TEST_RUN_ID_STR,
+        )
 
     the_threads.finish_run.assert_called_once_with(
         user_name=USER_NAME,
@@ -1115,7 +1129,7 @@ async def test_finish_run_helper(a_session, t_storage):
     )
 
     t_storage.assert_called_once_with(w_session)
-    a_session.assert_called_once_with(bind=sqla_engine)
+    fake_async_session.cls.assert_called_once_with(bind=sqla_engine)
 
 
 @pytest.mark.parametrize(
@@ -1574,6 +1588,8 @@ async def test_post_room_agui_thread_id_run_id_streaming(
     run_input,
     ari_side_effect,
     expectation,
+    fake_async_session,
+    mock_thread_storage,
 ):
     USER_PROFILE = models.UserProfile(**AUTH_USER)
     agent = object()
@@ -1603,10 +1619,16 @@ async def test_post_room_agui_thread_id_run_id_streaming(
     test_run.run_input = None
     the_threads.get_run.return_value = test_run
 
+    # 'add_run_input' now runs on its own short-lived, committed session
+    # rather than the request-scoped 'the_threads'. The shared
+    # 'fake_async_session' / 'mock_thread_storage' fixtures stand that
+    # session + storage in so the call (and its AGUI_Exception ->
+    # HTTPException translation, which relies on 'session.begin()' not
+    # swallowing the error) can be exercised and asserted.
     if ari_side_effect is not None:
-        the_threads.add_run_input.side_effect = ari_side_effect
+        mock_thread_storage.add_run_input.side_effect = ari_side_effect
     else:
-        the_threads.add_run_input.return_value = test_run
+        mock_thread_storage.add_run_input.return_value = test_run
 
     aga.from_request = mock.AsyncMock()
     exp_adapter = aga.from_request.return_value
@@ -1615,7 +1637,17 @@ async def test_post_room_agui_thread_id_run_id_streaming(
 
     exp_sse_stream = exp_adapter.encode_stream.return_value
 
-    with expectation as expected:
+    with (
+        mock.patch(
+            "soliplex.views.agui.sqla_asyncio.AsyncSession",
+            new=fake_async_session.cls,
+        ),
+        mock.patch(
+            "soliplex.views.agui.agui_persistence.ThreadStorage",
+            return_value=mock_thread_storage,
+        ),
+        expectation as expected,
+    ):
         found = await agui_views.post_room_agui_thread_id_run_id(
             request,
             room_id=TEST_ROOM_ID,
@@ -1710,13 +1742,16 @@ async def test_post_room_agui_thread_id_run_id_streaming(
             agent=agent,
         )
 
-        the_threads.add_run_input.assert_called_once_with(
+        mock_thread_storage.add_run_input.assert_called_once_with(
             user_name=USER_NAME,
             room_id=TEST_ROOM_ID,
             thread_id=TEST_THREAD_ID_STR,
             run_id=TEST_RUN_ID_STR,
             run_input=exp_adapter.run_input,
         )
+        # The input write ran on its own session bound to the request's
+        # threads engine, not the request-scoped 'the_threads'.
+        fake_async_session.cls.assert_called_once_with(bind=sqla_engine)
 
         cura.assert_called_once_with(
             room_id=TEST_ROOM_ID,
@@ -1765,12 +1800,14 @@ async def test_post_room_agui_reconnect(
     exp_adapter.encode_stream = mock.MagicMock()
 
     last_event_id = f"{TEST_RUN_ID_STR}:5"
+    threads_engine = object()
     request = fastapi.Request(
         scope={
             "type": "http",
             "headers": [
                 (b"last-event-id", last_event_id.encode()),
             ],
+            "state": {"threads_engine": threads_engine},
         },
     )
 
@@ -1807,7 +1844,7 @@ async def test_post_room_agui_reconnect(
     )
 
     sfdb.assert_called_once_with(
-        the_threads,
+        threads_engine,
         user_name=USER_NAME,
         room_id=TEST_ROOM_ID,
         thread_id=TEST_THREAD_ID_STR,

--- a/tests/unit/views/test_package.py
+++ b/tests/unit/views/test_package.py
@@ -141,52 +141,58 @@ async def test_get_the_logger(the_installation, w_claims, w_claims_map):
 
 @pytest.mark.anyio
 @mock.patch("soliplex.authz.persistence.AdminUserPolicy")
-@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
-async def test_get_the_admin_user_policy(as_klass, ap_klass):
+async def test_get_the_admin_user_policy(ap_klass, fake_async_session):
     engine = object()
     request = fastapi.Request(scope={"type": "http"})
     request.state.authorization_engine = engine
 
     counter = 0
 
-    async for policy in views.get_the_admin_user_policy(
-        request, THE_USER_CLAIMS
+    with mock.patch(
+        "sqlalchemy.ext.asyncio.AsyncSession",
+        new=fake_async_session.cls,
     ):
-        assert policy is ap_klass.return_value
-        counter += 1
+        async for policy in views.get_the_admin_user_policy(
+            request, THE_USER_CLAIMS
+        ):
+            assert policy is ap_klass.return_value
+            counter += 1
 
     assert counter == 1
 
     ap_klass.assert_called_once_with(
-        as_klass.return_value.__aenter__.return_value,
+        fake_async_session.session,
         THE_USER_CLAIMS,
     )
-    as_klass.assert_called_once_with(bind=engine)
+    fake_async_session.cls.assert_called_once_with(bind=engine)
 
 
 @pytest.mark.anyio
 @mock.patch("soliplex.authz.persistence.RoomAuthorizationPolicy")
-@mock.patch("sqlalchemy.ext.asyncio.AsyncSession")
-async def test_get_the_room_authz_policy(as_klass, rap_klass):
+async def test_get_the_room_authz_policy(rap_klass, fake_async_session):
     engine = object()
     request = fastapi.Request(scope={"type": "http"})
     request.state.authorization_engine = engine
 
     counter = 0
 
-    async for policy in views.get_the_room_authz_policy(
-        request, THE_USER_CLAIMS
+    with mock.patch(
+        "sqlalchemy.ext.asyncio.AsyncSession",
+        new=fake_async_session.cls,
     ):
-        assert policy is rap_klass.return_value
-        counter += 1
+        async for policy in views.get_the_room_authz_policy(
+            request, THE_USER_CLAIMS
+        ):
+            assert policy is rap_klass.return_value
+            counter += 1
 
     assert counter == 1
 
     rap_klass.assert_called_once_with(
-        as_klass.return_value.__aenter__.return_value,
+        fake_async_session.session,
         THE_USER_CLAIMS,
     )
-    as_klass.assert_called_once_with(bind=engine)
+    fake_async_session.cls.assert_called_once_with(bind=engine)
 
 
 @pytest.mark.anyio

--- a/tests/unit/views/test_streaming.py
+++ b/tests/unit/views/test_streaming.py
@@ -1,11 +1,50 @@
 import asyncio
 import time
+import types
 from unittest import mock
 
 import fastapi
 import pytest
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
+from soliplex import installation
+from soliplex.agui import persistence as agui_persistence
+from soliplex.agui import schema as agui_schema
 from soliplex.views import streaming as views_streaming
+from tests.unit.agui import agui_constants
+
+
+@pytest.fixture
+def poll_storage(fake_async_session, mock_thread_storage):
+    """Patch ``stream_from_db``'s per-poll session + storage.
+
+    ``stream_from_db`` opens a fresh ``AsyncSession`` + ``ThreadStorage``
+    on every poll iteration; patch both (against the ``streaming``
+    module) so a single stand-in storage answers every poll. Yields a
+    namespace exposing:
+
+      * ``storage``  -- the stand-in ``ThreadStorage`` (drive its
+        ``list_run_events_after`` / ``is_run_finished`` with
+        ``side_effect``, assert its calls).
+      * ``session``  -- the session each poll receives.
+      * ``async_session`` -- the patched ``AsyncSession`` (assert it was
+        opened with the expected ``bind=`` engine each poll).
+    """
+    with (
+        mock.patch(
+            "soliplex.views.streaming.sqla_asyncio.AsyncSession",
+            new=fake_async_session.cls,
+        ),
+        mock.patch(
+            "soliplex.views.streaming.agui_persistence.ThreadStorage",
+            return_value=mock_thread_storage,
+        ),
+    ):
+        yield types.SimpleNamespace(
+            storage=mock_thread_storage,
+            session=fake_async_session.session,
+            async_session=fake_async_session.cls,
+        )
 
 
 @pytest.mark.asyncio
@@ -188,26 +227,25 @@ async def test_add_sse_event_ids(events, start_index, expected):
 
 
 @pytest.mark.asyncio
-async def test_stream_from_db_finished_run():
+async def test_stream_from_db_finished_run(poll_storage):
     """Run is already finished: replay events and stop."""
-    the_threads = mock.AsyncMock()
-
+    engine = mock.Mock()
     events = [
         (0, mock.Mock(name="evt0")),
         (1, mock.Mock(name="evt1")),
     ]
 
-    the_threads.list_run_events_after = mock.AsyncMock(
+    poll_storage.storage.list_run_events_after = mock.AsyncMock(
         side_effect=[events, []],
     )
-    the_threads.is_run_finished = mock.AsyncMock(
+    poll_storage.storage.is_run_finished = mock.AsyncMock(
         return_value=True,
     )
 
     found = [
         event
         async for event in views_streaming.stream_from_db(
-            the_threads,
+            engine,
             user_name="user",
             room_id="room",
             thread_id="thread",
@@ -217,34 +255,34 @@ async def test_stream_from_db_finished_run():
     ]
 
     assert found == [events[0][1], events[1][1]]
+    # Each poll opens its own session bound to the given engine.
+    poll_storage.async_session.assert_called_with(bind=engine)
 
 
 @pytest.mark.asyncio
-async def test_stream_from_db_in_progress_run():
+async def test_stream_from_db_in_progress_run(poll_storage):
     """Run is in progress: poll until finished."""
-    the_threads = mock.AsyncMock()
-
     evt0 = (0, mock.Mock(name="evt0"))
     evt1 = (1, mock.Mock(name="evt1"))
 
     # First poll: one event, not finished
     # Second poll: one more event, now finished
     # Final drain: empty
-    the_threads.list_run_events_after = mock.AsyncMock(
+    poll_storage.storage.list_run_events_after = mock.AsyncMock(
         side_effect=[
             [evt0],
             [evt1],
             [],
         ],
     )
-    the_threads.is_run_finished = mock.AsyncMock(
+    poll_storage.storage.is_run_finished = mock.AsyncMock(
         side_effect=[False, True],
     )
 
     found = [
         event
         async for event in views_streaming.stream_from_db(
-            the_threads,
+            mock.Mock(),
             user_name="user",
             room_id="room",
             thread_id="thread",
@@ -258,31 +296,29 @@ async def test_stream_from_db_in_progress_run():
 
 
 @pytest.mark.asyncio
-async def test_stream_from_db_final_drain_has_events():
+async def test_stream_from_db_final_drain_has_events(poll_storage):
     """Events arrive between last poll and finished flag."""
-    the_threads = mock.AsyncMock()
-
     evt0 = (0, mock.Mock(name="evt0"))
     evt1 = (1, mock.Mock(name="evt1"))
 
     # First poll: one event, not finished
     # Second poll: empty, now finished
     # Final drain: one late event
-    the_threads.list_run_events_after = mock.AsyncMock(
+    poll_storage.storage.list_run_events_after = mock.AsyncMock(
         side_effect=[
             [evt0],
             [],
             [evt1],
         ],
     )
-    the_threads.is_run_finished = mock.AsyncMock(
+    poll_storage.storage.is_run_finished = mock.AsyncMock(
         side_effect=[False, True],
     )
 
     found = [
         event
         async for event in views_streaming.stream_from_db(
-            the_threads,
+            mock.Mock(),
             user_name="user",
             room_id="room",
             thread_id="thread",
@@ -296,21 +332,19 @@ async def test_stream_from_db_final_drain_has_events():
 
 
 @pytest.mark.asyncio
-async def test_stream_from_db_empty_finished_run():
+async def test_stream_from_db_empty_finished_run(poll_storage):
     """Run finished with no events."""
-    the_threads = mock.AsyncMock()
-
-    the_threads.list_run_events_after = mock.AsyncMock(
+    poll_storage.storage.list_run_events_after = mock.AsyncMock(
         side_effect=[[], []],
     )
-    the_threads.is_run_finished = mock.AsyncMock(
+    poll_storage.storage.is_run_finished = mock.AsyncMock(
         return_value=True,
     )
 
     found = [
         event
         async for event in views_streaming.stream_from_db(
-            the_threads,
+            mock.Mock(),
             user_name="user",
             room_id="room",
             thread_id="thread",
@@ -320,3 +354,98 @@ async def test_stream_from_db_empty_finished_run():
     ]
 
     assert found == []
+
+
+@pytest.mark.asyncio
+async def test_stream_from_db_observes_cross_session_writes(tmp_path):
+    """Integration: the reconnect poll sees another session's commits.
+
+    This is the property the design turns on -- and that the mocked
+    tests above cannot exercise: ``stream_from_db`` opens a fresh
+    session per poll, so it must observe events a *separate* writer
+    session commits incrementally, then stop once the run is finished.
+    Run against a real file-backed SQLite DB (built through the app's
+    own engine factory, WAL and all) so per-transaction snapshot
+    isolation is real -- the same mechanism holds under Postgres READ
+    COMMITTED, so this guards both backends.
+    """
+    user_name = "phreddy"
+    email = "phreddy@example.com"
+    room_id = "test-room"
+    events = [
+        agui_constants.TEXT_MESSAGE_START_EVENT,
+        agui_constants.TEXT_MESSAGE_CONTENT_EVENT,
+        agui_constants.TEXT_MESSAGE_END_EVENT,
+    ]
+
+    engine = installation._create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'threads.sqlite'}",
+    )
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(agui_schema.Base.metadata.create_all)
+
+        # A thread and its initial run, each committed by their owner.
+        async with sqla_asyncio.AsyncSession(bind=engine) as session:
+            async with session.begin():
+                storage = agui_persistence.ThreadStorage(session)
+                thread = await storage.new_thread(
+                    user_name=user_name,
+                    email=email,
+                    room_id=room_id,
+                )
+                thread_id = await thread.awaitable_attrs.thread_id
+                (run,) = await thread.list_runs()
+                run_id = await run.awaitable_attrs.run_id
+
+        async def _writer():
+            # Persist each event in its own committed session (mirrors the
+            # background 'save_single_event' helper), then finish the run.
+            for event in events:
+                async with sqla_asyncio.AsyncSession(bind=engine) as s:
+                    async with s.begin():
+                        await agui_persistence.ThreadStorage(
+                            s
+                        ).save_single_event(
+                            user_name=user_name,
+                            room_id=room_id,
+                            thread_id=thread_id,
+                            run_id=run_id,
+                            event=event,
+                        )
+                await asyncio.sleep(0.01)
+            async with sqla_asyncio.AsyncSession(bind=engine) as s:
+                async with s.begin():
+                    await agui_persistence.ThreadStorage(s).finish_run(
+                        user_name=user_name,
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        run_id=run_id,
+                    )
+
+        async def _collect():
+            return [
+                event
+                async for event in views_streaming.stream_from_db(
+                    engine,
+                    user_name=user_name,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    after_index=-1,
+                    poll_interval_secs=0.01,
+                )
+            ]
+
+        writer = asyncio.create_task(_writer())
+        try:
+            seen = await asyncio.wait_for(_collect(), timeout=5.0)
+            await writer
+        finally:
+            writer.cancel()
+
+        # Every incrementally-committed event was observed, in order, and
+        # the poll terminated once the run was marked finished.
+        assert seen == events
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
  ... to callers.

Closes #1087.

tests: add full intgration test for 'views.streaming.stream_from_db'