### PR TITLE
Adopt exact-citation visual grounding and no-expand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "fastmcp >= 3.3.0, < 3.4",
     "fakeredis != 2.35.0",  # brownbag
     "greenlet",
-    "haiku.rag-slim >= 0.64, < 0.65",
+    "haiku.rag-slim >= 0.65, < 0.66",
     "haiku-skills >= 0.18.0, < 0.19",
     "idna >= 3.15",
     "itsdangerous",

--- a/src/soliplex/views/rooms.py
+++ b/src/soliplex/views/rooms.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import json
 
 import fastapi
 from fastapi import responses
@@ -226,13 +227,31 @@ async def get_room_documents(
 async def get_chunk_visualization(
     room_id: str,
     chunk_id: str,
+    refs: str | None = None,
+    expand: bool = True,
     the_installation: installation.Installation = depend_the_installation,
     the_room_authz: authz.RoomAuthorizationPolicy = depend_the_room_authz,
     the_user_claims: authn.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
 ) -> models.ChunkVisualization:
-    """Return a set of page images for a chunk, highlighting the chunk text"""
+    """Return a set of page images for a chunk, highlighting the chunk text.
+
+    ``refs`` is an optional JSON-encoded list of the citation's
+    ``doc_item_refs`` (the exact items the model saw); when given, the
+    highlight matches the cited content instead of re-expanding. ``expand``
+    (default true) re-expands the chunk's section when no refs are supplied;
+    ``expand=false`` highlights only the chunk itself.
+    """
     the_logger.debug(loggers.ROOM_GET_CHUNK_VISUALIZATION)
+
+    doc_item_refs: list[str] | None = None
+    if refs:
+        try:
+            parsed = json.loads(refs)
+        except ValueError:
+            parsed = None
+        if isinstance(parsed, list):
+            doc_item_refs = [str(r) for r in parsed]
 
     try:
         room_config = await the_installation.get_room_config(
@@ -263,7 +282,9 @@ async def get_chunk_visualization(
             chunk = await rag.chunk_repository.get_by_id(chunk_id)
 
             if chunk:
-                images = await rag.visualize_chunk(chunk)
+                images = await rag.visualize_chunk(
+                    chunk, refs=doc_item_refs, expand=expand
+                )
                 break  # first hit wins
 
     else:

--- a/tests/unit/views/test_rooms_views.py
+++ b/tests/unit/views/test_rooms_views.py
@@ -707,6 +707,75 @@ async def test_get_chunk_visualization(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("expand", [True, False])
+@pytest.mark.parametrize(
+    "refs_arg,expected_refs",
+    [
+        ('["#/texts/0", "#/texts/1"]', ["#/texts/0", "#/texts/1"]),
+        ("not valid json", None),
+        ('{"not": "a list"}', None),
+        (None, None),
+    ],
+)
+@mock.patch("haiku.rag.client.HaikuRAG")
+@mock.patch("base64.b64encode")
+async def test_get_chunk_visualization_refs_and_expand(
+    b64enc,
+    hr_klass,
+    refs_arg,
+    expected_refs,
+    expand,
+    audit_records,
+):
+    """refs (JSON list) and expand reach visualize_chunk."""
+    ROOM_ID = "foo"
+    CHUNK_ID = "test-chunk-123"
+    DOCUMENT_URI = f"https://example.com/chunks/{CHUNK_ID}"
+    PAGES_PNG = [mock.Mock(spec_set=["blob", "save"], blob="facedace8765")]
+    b64enc.return_value.decode.return_value = "facedace8765"
+
+    hr_insts = {"agent": mock.AsyncMock()}
+    rag = hr_insts["agent"].__aenter__.return_value
+    hr_klass.side_effect = hr_insts.values()
+
+    chunk = hr_chunk.Chunk(
+        chunk_id=CHUNK_ID,
+        document_uri=DOCUMENT_URI,
+        content="waaa",
+    )
+    rag.chunk_repository.get_by_id.return_value = chunk
+    rag.visualize_chunk.return_value = PAGES_PNG
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    room_config.list_haiku_rag_client_kw = mock.Mock(
+        spec_set=(),
+        return_value=[{"source": "agent", "db_path": "/db/agent"}],
+    )
+    the_installation = mock.create_autospec(installation.Installation)
+    the_installation.get_room_config.return_value = room_config
+    the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    found = await rooms_views.get_chunk_visualization(
+        room_id=ROOM_ID,
+        chunk_id=CHUNK_ID,
+        refs=refs_arg,
+        expand=expand,
+        the_installation=the_installation,
+        the_room_authz=the_room_authz,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found.chunk_id == CHUNK_ID
+    rag.visualize_chunk.assert_awaited_once_with(
+        chunk,
+        refs=expected_refs,
+        expand=expand,
+    )
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("w_search_type", [False, True])
 @pytest.mark.parametrize(
     "w_hrc_kws",

--- a/uv.lock
+++ b/uv.lock
@@ -1116,7 +1116,7 @@ wheels = [
 
 [[package]]
 name = "haiku-rag-slim"
-version = "0.64.0"
+version = "0.65.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docling-core" },
@@ -1139,9 +1139,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/db/9d16fbf428be93139072f9ff7a2d49121b80eccf52971f6754a316db1641/haiku_rag_slim-0.64.0.tar.gz", hash = "sha256:271f0d7844f65b09f4d48d49f0a532b47c720791460ae7ac74eaaa71254e0899", size = 228694, upload-time = "2026-07-08T14:22:23.214Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/cb/f0f215ad5b6cf4dd8d895b980e93fcd02c6350e486c4d8d588049ced7154/haiku_rag_slim-0.65.0.tar.gz", hash = "sha256:7d5aa43753b0a370913d34524a9be421da6ab44cc1c88d2b6e503037a3db73ed", size = 231732, upload-time = "2026-07-09T13:14:19.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/56/f5500619a69e62b51e13604f65399ae48e3cac40a943c0adb741a1301395/haiku_rag_slim-0.64.0-py3-none-any.whl", hash = "sha256:0f8d0a1b66aa8f7d05860c717a90452c1a81e3d6edc48d1993f77351d94b1e69", size = 307621, upload-time = "2026-07-08T14:22:22.073Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d0/2f308e6b61e5e56dcec7a9a4ab4329bc7cd5dbf4965d2426d091d5078516/haiku_rag_slim-0.65.0-py3-none-any.whl", hash = "sha256:688070b3c6f6d1d01ead0cb28cf0d7c78c4afac3e488671eec8c5f2bf4caa078", size = 310800, upload-time = "2026-07-09T13:14:18.629Z" },
 ]
 
 [[package]]
@@ -3323,8 +3323,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3447,7 +3447,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.3.0,<3.4" },
     { name = "greenlet" },
-    { name = "haiku-rag-slim", specifier = ">=0.64,<0.65" },
+    { name = "haiku-rag-slim", specifier = ">=0.65,<0.66" },
     { name = "haiku-skills", specifier = ">=0.18.0,<0.19" },
     { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous" },


### PR DESCRIPTION
Carry the model-seen `doc_item_refs` from the AG-UI Citation through `SourceReference` and pass them to the chunk visualization endpoint, so the highlight matches the cited content instead of re-expanding. 

Adds an `expand` flag to the API for chunk-only grounding.