### PR TITLE
feat: middleware config support

### DIFF
--- a/docs/config/installation.md
+++ b/docs/config/installation.md
@@ -417,3 +417,15 @@ completion_paths:
 ## Logfire Configuration
 
 See the [Soliplex logfire configuration](logfire.md) page.
+
+## ASGI Middleware Stack
+
+```yaml
+middleware_stack:
+```
+
+The optional `middleware_stack` section declares the ASGI middleware wrapping
+the application (outermost first). Omit it to use the built-in default stack
+(session + CORS).
+
+See the [Soliplex middleware configuration](middleware.md) page.

--- a/docs/config/middleware.md
+++ b/docs/config/middleware.md
@@ -1,0 +1,81 @@
+# ASGI Middleware Stack
+
+The `middleware_stack` section of an installation configuration declares the
+ASGI middleware that wraps the Soliplex application. It is an ordered list:
+the **first entry is the outermost layer** (it sees a request first and a
+response last), and the last entry sits closest to the application.
+
+If you omit `middleware_stack` entirely, Soliplex installs a built-in
+[default stack](#default-stack). Providing your own list **replaces** that
+default outright, so include session / CORS middleware yourself if you still
+want them.
+
+## Middleware factories
+
+Each entry names an `app_factory`: a Python "dotted name" which is imported
+and called to wrap the application. A factory receives the application (an
+ASGI app, or the middleware wrapping it) as its first positional argument and
+returns the wrapped result:
+
+```python
+def app_factory(app, **extra_params):
+    ...
+    return app
+```
+
+If a factory declares a keyword-only `installation_config` parameter, it is
+passed the resolved [`InstallationConfig`](installation.md) — for example to
+look up [secrets](secrets.md) or [environment](environment.md) values:
+
+```python
+def app_factory(app, *, installation_config, **extra_params):
+    ...
+    return app
+```
+
+Whether the installation config is injected is detected automatically from
+the factory's signature, so `installation_config` must be a real keyword-only
+parameter (not absorbed by `**kwargs`).
+
+## Configuration
+
+Each list entry accepts:
+
+- `name`, a string labelling the middleware (for diagnostics).
+
+- `app_factory`, the dotted name of the factory described above.
+
+- `extra_params` (optional), a mapping forwarded to the factory as keyword
+  arguments.
+
+Example:
+
+```yaml
+middleware_stack:
+  - name: "session"
+    app_factory: "soliplex.main.app_with_session"
+  - name: "cors"
+    app_factory: "soliplex.main.app_with_cors"
+    extra_params:
+      allow_origins: ["*"]
+      allow_credentials: true
+      allow_methods: ["*"]
+      allow_headers: ["*"]
+```
+
+## Default stack
+
+When `middleware_stack` is omitted, Soliplex uses
+`soliplex.main.default_middleware_stack()`, which is equivalent to the example
+above:
+
+- `soliplex.main.app_with_session` (outermost) — adds Starlette's
+  `SessionMiddleware`. It reads the `SESSION_MIDDLEWARE_TOKEN` secret from the
+  installation config for the cookie's signing key, and marks the cookie
+  `Secure` unless the server was started with `--insecure-session-cookie`.
+
+- `soliplex.main.app_with_cors` — adds FastAPI's `CORSMiddleware` with a
+  permissive configuration drawn from its `extra_params`.
+
+These two factories double as worked examples of the with- and
+without-`installation_config` factory shapes.

--- a/example/installation-openai.yaml
+++ b/example/installation-openai.yaml
@@ -134,6 +134,34 @@ meta:
   #------------------------------------------------------------------------
 
 #==========================================================================
+# ASGI middleware stack
+#==========================================================================
+# See: https://soliplex.github.io/soliplex/config/middleware/
+#
+# Ordered list of ASGI middleware wrapping the application, outermost
+# first. Each entry names a 'app_factory' (a dotted-name factory that
+# wraps the app it is passed and returns the result); factories that
+# declare a keyword-only 'installation_config' parameter receive the
+# resolved installation config (e.g. to look up secrets). Any additional
+# keys under 'extra_params' are forwarded to the factory as keywords.
+#
+# Omit 'middleware_stack' entirely (the default) to get Soliplex's built-in
+# stack: a session middleware wrapping a permissive CORS middleware. Provide
+# your own list to replace that default outright -- include session/CORS
+# yourself if you still want them.
+#==========================================================================
+# middleware_stack:
+#   - name: "session"
+#     app_factory: "soliplex.main.app_with_session"
+#   - name: "cors"
+#     app_factory: "soliplex.main.app_with_cors"
+#     extra_params:
+#       allow_origins: ["*"]
+#       allow_credentials: true
+#       allow_methods: ["*"]
+#       allow_headers: ["*"]
+
+#==========================================================================
 # FastAPI routers
 #==========================================================================
 # Routers from these Soliplex view modules are registered by default,

--- a/example/installation.yaml
+++ b/example/installation.yaml
@@ -145,6 +145,34 @@ meta:
   #------------------------------------------------------------------------
 
 #==========================================================================
+# ASGI middleware stack
+#==========================================================================
+# See: https://soliplex.github.io/soliplex/config/middleware/
+#
+# Ordered list of ASGI middleware wrapping the application, outermost
+# first. Each entry names a 'app_factory' (a dotted-name factory that
+# wraps the app it is passed and returns the result); factories that
+# declare a keyword-only 'installation_config' parameter receive the
+# resolved installation config (e.g. to look up secrets). Any additional
+# keys under 'extra_params' are forwarded to the factory as keywords.
+#
+# Omit 'middleware_stack' entirely (the default) to get Soliplex's built-in
+# stack: a session middleware wrapping a permissive CORS middleware. Provide
+# your own list to replace that default outright -- include session/CORS
+# yourself if you still want them.
+#==========================================================================
+# middleware_stack:
+#   - name: "session"
+#     app_factory: "soliplex.main.app_with_session"
+#   - name: "cors"
+#     app_factory: "soliplex.main.app_with_cors"
+#     extra_params:
+#       allow_origins: ["*"]
+#       allow_credentials: true
+#       allow_methods: ["*"]
+#       allow_headers: ["*"]
+
+#==========================================================================
 # FastAPI routers
 #==========================================================================
 # Routers from these Soliplex view modules are registered by default,

--- a/example/minimal-openai.yaml
+++ b/example/minimal-openai.yaml
@@ -133,6 +133,34 @@ meta:
   #------------------------------------------------------------------------
 
 #==========================================================================
+# ASGI middleware stack
+#==========================================================================
+# See: https://soliplex.github.io/soliplex/config/middleware/
+#
+# Ordered list of ASGI middleware wrapping the application, outermost
+# first. Each entry names a 'app_factory' (a dotted-name factory that
+# wraps the app it is passed and returns the result); factories that
+# declare a keyword-only 'installation_config' parameter receive the
+# resolved installation config (e.g. to look up secrets). Any additional
+# keys under 'extra_params' are forwarded to the factory as keywords.
+#
+# Omit 'middleware_stack' entirely (the default) to get Soliplex's built-in
+# stack: a session middleware wrapping a permissive CORS middleware. Provide
+# your own list to replace that default outright -- include session/CORS
+# yourself if you still want them.
+#==========================================================================
+# middleware_stack:
+#   - name: "session"
+#     app_factory: "soliplex.main.app_with_session"
+#   - name: "cors"
+#     app_factory: "soliplex.main.app_with_cors"
+#     extra_params:
+#       allow_origins: ["*"]
+#       allow_credentials: true
+#       allow_methods: ["*"]
+#       allow_headers: ["*"]
+
+#==========================================================================
 # FastAPI routers
 #==========================================================================
 # Routers from these Soliplex view modules are registered by default,

--- a/example/minimal.yaml
+++ b/example/minimal.yaml
@@ -140,6 +140,34 @@ meta:
   #------------------------------------------------------------------------
 
 #==========================================================================
+# ASGI middleware stack
+#==========================================================================
+# See: https://soliplex.github.io/soliplex/config/middleware/
+#
+# Ordered list of ASGI middleware wrapping the application, outermost
+# first. Each entry names a 'app_factory' (a dotted-name factory that
+# wraps the app it is passed and returns the result); factories that
+# declare a keyword-only 'installation_config' parameter receive the
+# resolved installation config (e.g. to look up secrets). Any additional
+# keys under 'extra_params' are forwarded to the factory as keywords.
+#
+# Omit 'middleware_stack' entirely (the default) to get Soliplex's built-in
+# stack: a session middleware wrapping a permissive CORS middleware. Provide
+# your own list to replace that default outright -- include session/CORS
+# yourself if you still want them.
+#==========================================================================
+# middleware_stack:
+#   - name: "session"
+#     app_factory: "soliplex.main.app_with_session"
+#   - name: "cors"
+#     app_factory: "soliplex.main.app_with_cors"
+#     extra_params:
+#       allow_origins: ["*"]
+#       allow_credentials: true
+#       allow_methods: ["*"]
+#       allow_headers: ["*"]
+
+#==========================================================================
 # FastAPI routers
 #==========================================================================
 # Routers from these Soliplex view modules are registered by default,

--- a/src/soliplex/cli/serve.py
+++ b/src/soliplex/cli/serve.py
@@ -218,15 +218,21 @@ Passing this option now fails with a non-zero exit.
 
     reload_dirs = [str(rd) for rd in reload_dirs]
 
+    # 'soliplex.main.app_with_session' reads this env var in-process to
+    # decide the session cookie's 'Secure' attribute, so set it for both
+    # run paths (not just the uvicorn-factory contract below).
+    if insecure_session_cookie:
+        os.environ["_SOLIPLEX_INSECURE_SESSION_COOKIE"] = "Y"
+
     if reload or workers:
         # Work around uvicorn's aversion to passing arguments to the app
         # factory.
         #
         # N.B.:  The environment variables set here are a private contract
         #        between this command and the
-        #        'soliplex.main.create_app_from_environment'
-        #        function:  do not try setting them yourself, either
-        #        directly or via a '.env' file.
+        #        'soliplex.main.create_app_from_environment' /
+        #        'soliplex.main.app_with_session' functions:  do not try
+        #        setting them yourself, either directly or via a '.env' file.
         os.environ["_SOLIPLEX_INSTALLATION_PATH"] = str(installation_path)
 
         if no_auth_mode:
@@ -234,9 +240,6 @@ Passing this option now fails with a non-zero exit.
 
         if log_config is not None:  # pass to the app, disable Uvicorn.
             os.environ["_SOLIPLEX_LOG_CONFIG_FILE"] = str(log_config)
-
-        if insecure_session_cookie:
-            os.environ["_SOLIPLEX_INSECURE_SESSION_COOKIE"] = "Y"
 
         if app_factory_name is None:
             app_factory_name = "soliplex.main:create_app_from_environment"
@@ -257,6 +260,5 @@ Passing this option now fails with a non-zero exit.
             installation_path=installation_path,
             no_auth_mode=no_auth_mode,
             log_config_file=log_config,
-            session_https_only=not insecure_session_cookie,
         )
         uvicorn.run(app, **uvicorn_kw)

--- a/src/soliplex/config/installation.py
+++ b/src/soliplex/config/installation.py
@@ -24,6 +24,7 @@ from . import completions as config_completions
 from . import exceptions as config_exc
 from . import logfire as config_logfire
 from . import meta as config_meta
+from . import middleware as config_middleware
 from . import rooms as config_rooms
 from . import routing as config_routing
 from . import secrets as config_secrets
@@ -387,6 +388,13 @@ class InstallationConfig:
     server_description: str | None = None
 
     meta: config_meta.InstallationConfigMeta = None
+
+    #
+    # ASGI middleware (Scarlett pattern).
+    #
+    middleware_stack: list[config_middleware.MiddlewareConfig] = (
+        _utils._default_list_field()
+    )
 
     #
     # FastAPI routers to be configured during app startup
@@ -893,6 +901,13 @@ class InstallationConfig:
                 config_path,
                 meta,
             )
+
+            config_dict["middleware_stack"] = [
+                config_middleware.MiddlewareConfig.from_yaml(
+                    mwc_yaml,
+                )
+                for mwc_yaml in config_dict.get("middleware_stack", ())
+            ]
 
             config_dict["app_router_operations"] = [
                 config_routing.app_router_operation_from_yaml(

--- a/src/soliplex/config/middleware.py
+++ b/src/soliplex/config/middleware.py
@@ -1,0 +1,115 @@
+from __future__ import annotations  # forward refs in typing decls
+
+import dataclasses
+import inspect
+import typing
+
+import fastapi
+
+from soliplex.config import installation as config_installation
+
+from . import _utils
+
+_no_repr = _utils._no_repr
+_default_dict_field = _utils._default_dict_field
+
+
+@typing.runtime_checkable
+class MiddlewareFactoryNoIconfig(typing.Protocol):
+    """Protocol for middelware factory without installation config"""
+
+    def __call__(
+        self,
+        app: fastapi.FastAPI,
+        **extra_params,
+    ) -> fastapi.FastAPI: ...
+
+
+@typing.runtime_checkable
+class MiddlewareFactoryWithIConfig(typing.Protocol):
+    """Protocol for middelware factory without installation config"""
+
+    def __call__(
+        self,
+        app: fastapi.FastAPI,
+        *,
+        installation_config: config_installation.InstallationConfig,
+        **extra_params,
+    ) -> fastapi.FastAPI: ...
+
+
+MiddlewareFactory = MiddlewareFactoryNoIconfig | MiddlewareFactoryWithIConfig
+
+
+@dataclasses.dataclass(kw_only=True)
+class MiddlewareConfig:
+    """Registered middleware
+
+    'app_factory'
+        dotted name of a factory returning a middleware instance, wrapped
+        around an existing ASGI application (or other middleware).
+
+    'extra_params':
+        dict parsed from other keys in the YAML for the middleware.
+
+    Example usage:
+
+        Without a factory needing an 'InstallationConfig':
+        ```
+        factory = functools.partial(
+            _utils._from_dotted_name(mw_config.app_factory),
+            **mw_config.extra_params,
+        )
+        app = factory(app)
+        ```
+
+        With a factory needing an 'InstallationConfig':
+        ```
+        factory = functools.partial(
+            _utils._from_dotted_name(mw_config.app_factory),
+            installation_config=i_config,
+            **mw_config.extra_params,
+        )
+        app = factory(app)
+        ```
+    """
+
+    name: str
+    app_factory: MiddlewareFactory
+    extra_params: dict[str, typing.Any] = _default_dict_field()
+
+    @property
+    def needs_iconfig(self):
+        argspec = inspect.getfullargspec(self.app_factory)
+        return "installation_config" in argspec.kwonlyargs
+
+    @classmethod
+    def from_yaml(cls, yaml_config: dict):
+        app_factory = yaml_config["app_factory"]
+        yaml_config["app_factory"] = _utils._from_dotted_name(app_factory)
+        return cls(**yaml_config)
+
+
+def compose_middleware_stack(
+    app,
+    installation_config: config_installation.InstallationConfig,
+    to_compose: list[MiddlewareConfig],
+):
+    composed = app
+    composing = to_compose[:]
+
+    while composing:
+        mw_config = composing.pop()
+        if mw_config.needs_iconfig:
+            composed = mw_config.app_factory(
+                composed,
+                installation_config=installation_config,
+                **mw_config.extra_params,
+            )
+        else:
+            composed = mw_config.app_factory(
+                composed,
+                **mw_config.extra_params,
+            )
+
+    return composed

--- a/src/soliplex/main.py
+++ b/src/soliplex/main.py
@@ -14,6 +14,7 @@ from starlette.middleware import sessions as starlette_mw_sessions
 
 from soliplex import installation
 from soliplex.config import installation as config_installation
+from soliplex.config import middleware as config_middleware
 
 
 def curry_lifespan(
@@ -40,25 +41,22 @@ def app_with_lifespan(curried_lifespan: typing.Callable) -> fastapi.FastAPI:
     return app
 
 
-def app_with_cors(app: fastapi.FastAPI) -> fastapi.FastAPI:
-    origins = ["*"]
+def app_with_cors(app: fastapi.FastAPI, **extra_params) -> fastapi.FastAPI:
     app.add_middleware(
         fastapi_mw_cors.CORSMiddleware,
-        allow_origins=origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        **extra_params,
     )
     return app
 
 
 def app_with_session(
     app: fastapi.FastAPI,
-    token: str,
     *,
-    https_only: bool = True,
+    installation_config: config_installation.InstallationConfig,
     same_site: str = "lax",
 ) -> fastapi.FastAPI:
+    token = installation_config.get_secret("secret:SESSION_MIDDLEWARE_TOKEN")
+    https_only = os.environ.get("_SOLIPLEX_INSECURE_SESSION_COOKIE") != "Y"
     app.add_middleware(
         starlette_mw_sessions.SessionMiddleware,
         secret_key=token.encode("ascii"),
@@ -68,15 +66,38 @@ def app_with_session(
     return app
 
 
+def default_middleware_stack() -> list[config_middleware.MiddlewareConfig]:
+    """Return the built-in middleware stack used when config omits one.
+
+    Ordered outermost-first: the session middleware wraps the CORS
+    middleware, matching Soliplex's historical registration order.
+    """
+    return [
+        config_middleware.MiddlewareConfig(
+            name="session",
+            app_factory=app_with_session,
+        ),
+        config_middleware.MiddlewareConfig(
+            name="cors",
+            app_factory=app_with_cors,
+            extra_params={
+                "allow_origins": ["*"],
+                "allow_credentials": True,
+                "allow_methods": ["*"],
+                "allow_headers": ["*"],
+            },
+        ),
+    ]
+
+
 def create_app(
     installation_path: pathlib.Path,
     no_auth_mode: bool,
     log_config_file: str = None,
-    session_https_only: bool = True,
     curry_lifespan=None,
     app_with_lifespan=None,
-    app_with_cors=None,
-    app_with_session=None,
+    compose_middleware_stack=None,
+    default_middleware_stack=None,
 ):
     """Construct the Soliplex FastAPI application
 
@@ -86,15 +107,19 @@ def create_app(
     globs = globals()
 
     # Create a temporary InstallationConfig, to permit us to use
-    # its secrets before the lifespan starts.
+    # its secrets / middleware stack before the lifespan starts.
     tmp_installation = config_installation.load_installation(
         pathlib.Path(installation_path)
     )
 
     curry_lifespan = curry_lifespan or globs["curry_lifespan"]
     app_with_lifespan = app_with_lifespan or globs["app_with_lifespan"]
-    app_with_cors = app_with_cors or globs["app_with_cors"]
-    app_with_session = app_with_session or globs["app_with_session"]
+    compose_middleware_stack = (
+        compose_middleware_stack or config_middleware.compose_middleware_stack
+    )
+    default_middleware_stack = (
+        default_middleware_stack or globs["default_middleware_stack"]
+    )
 
     curried_lifespan = curry_lifespan(
         installation_path=installation_path,
@@ -102,12 +127,11 @@ def create_app(
         log_config_file=log_config_file,
     )
     app = app_with_lifespan(curried_lifespan)
-    app = app_with_cors(app)
 
-    session_token = tmp_installation.get_secret(
-        "secret:SESSION_MIDDLEWARE_TOKEN"
+    to_compose = (
+        tmp_installation.middleware_stack or default_middleware_stack()
     )
-    app = app_with_session(app, session_token, https_only=session_https_only)
+    app = compose_middleware_stack(app, tmp_installation, to_compose)
 
     return app
 
@@ -123,15 +147,11 @@ def create_app_from_environment():
     installation_path = pathlib.Path(installation_path_str)
     no_auth_mode = os.environ.get("_SOLIPLEX_NO_AUTH_MODE") == "Y"
     log_config_file = os.environ.get("_SOLIPLEX_LOG_CONFIG_FILE")
-    session_https_only = (
-        os.environ.get("_SOLIPLEX_INSECURE_SESSION_COOKIE") != "Y"
-    )
 
     return create_app(
         installation_path=installation_path,
         log_config_file=log_config_file,
         no_auth_mode=no_auth_mode,
-        session_https_only=session_https_only,
     )
 
 

--- a/tests/unit/_test_middleware.py
+++ b/tests/unit/_test_middleware.py
@@ -1,0 +1,34 @@
+"""Test-only middleware for config_middleware tests."""
+
+import inspect
+import typing
+
+from soliplex.config import installation as config_installation
+
+
+class _Wrapped:
+    def __init__(self, app: typing.Any, i_config=None, **kwargs):
+        self.app = app
+        self.i_config = i_config
+        self.kwargs = kwargs
+        caller_info = inspect.stack()[1]
+        self.name = caller_info[3]
+
+
+def null_app_factory(app):
+    return _Wrapped(app)
+
+
+def w_iconfig_app_factory(
+    app,
+    *,
+    installation_config: config_installation.InstallationConfig,
+):
+    return _Wrapped(app, i_config=installation_config)
+
+
+def w_extra_params_app_factory(
+    app,
+    **extra_params,
+):
+    return _Wrapped(app, **extra_params)

--- a/tests/unit/cli/test_cli_serve.py
+++ b/tests/unit/cli/test_cli_serve.py
@@ -104,8 +104,8 @@ def test_serve_direct_default_uses_create_app(patched_serve, tmp_path):
         installation_path=i_path,
         no_auth_mode=False,
         log_config_file=None,
-        session_https_only=True,
     )
+    assert "_SOLIPLEX_INSECURE_SESSION_COOKIE" not in os.environ
     patched_serve.uvicorn_run.assert_called_once_with(
         patched_serve.create_app.return_value,
         host=serve.DEFAULT_HOST,
@@ -125,7 +125,6 @@ def test_serve_direct_honors_explicit_app_maker(patched_serve, tmp_path):
         installation_path=i_path,
         no_auth_mode=False,
         log_config_file=None,
-        session_https_only=True,
     )
     patched_serve.create_app.assert_not_called()
     patched_serve.uvicorn_run.assert_called_once_with(
@@ -239,17 +238,18 @@ def test_serve_workers_factory_with_all_options(patched_serve, tmp_path):
 
 def test_serve_direct_insecure_session_cookie(patched_serve, tmp_path):
     # '--insecure-session-cookie' on the direct path turns off the cookie's
-    # Secure flag via the app factory.
+    # Secure flag via the private env var read in-process by
+    # 'soliplex.main.app_with_session'.
     i_path = tmp_path / "installation.yaml"
     kwargs = _serve_kwargs(i_path, insecure_session_cookie=True)
 
     serve.serve(**kwargs)
 
+    assert os.environ["_SOLIPLEX_INSECURE_SESSION_COOKIE"] == "Y"
     patched_serve.create_app.assert_called_once_with(
         installation_path=i_path,
         no_auth_mode=False,
         log_config_file=None,
-        session_https_only=False,
     )
 
 

--- a/tests/unit/config/test_config_installation.py
+++ b/tests/unit/config/test_config_installation.py
@@ -5,6 +5,7 @@ import pathlib
 from unittest import mock
 
 import _test_features as agui_features
+import _test_middleware
 import pytest
 import yaml
 from haiku.rag import config as hr_config_module
@@ -17,6 +18,7 @@ from soliplex.config import exceptions as config_exc
 from soliplex.config import installation as config_installation
 from soliplex.config import logfire as config_logfire
 from soliplex.config import meta as config_meta
+from soliplex.config import middleware as config_middleware
 from soliplex.config import routing as config_routing
 from soliplex.config import secrets as config_secrets
 from soliplex.config import skills as config_skills
@@ -135,6 +137,22 @@ meta:
   secret_sources:
     - "config_klass": "soliplex.config.secrets.EnvVarSecretSource"
       "registered_func": "soliplex.config.test_secret_func"
+"""
+
+W_MIDDLEWARE_STACK_INSTALLATION_CONFIG_KW = {
+    "id": INSTALLATION_ID,
+    "middleware_stack": [
+        config_middleware.MiddlewareConfig(
+            name="null",
+            app_factory=_test_middleware.null_app_factory,
+        ),
+    ],
+}
+W_MIDDLEWARE_STACK_INSTALLATION_CONFIG_YAML = f"""\
+id: "{INSTALLATION_ID}"
+middleware_stack:
+    - name: "null"
+      app_factory: "_test_middleware.null_app_factory"
 """
 
 W_APP_ROUTER_OPERATIONS_INSTALLATION_CONFIG_KW = {
@@ -1684,6 +1702,10 @@ def test_installationconfig_authorization_dburi_async(w_kw, expected):
         (
             W_FULL_META_INSTALLATION_CONFIG_YAML,
             W_FULL_META_INSTALLATION_CONFIG_KW.copy(),
+        ),
+        (
+            W_MIDDLEWARE_STACK_INSTALLATION_CONFIG_YAML,
+            W_MIDDLEWARE_STACK_INSTALLATION_CONFIG_KW.copy(),
         ),
         (
             W_APP_ROUTER_OPERATIONS_INSTALLATION_CONFIG_YAML,

--- a/tests/unit/config/test_config_middleware.py
+++ b/tests/unit/config/test_config_middleware.py
@@ -1,0 +1,170 @@
+import copy
+from unittest import mock
+
+import _test_middleware
+import pytest
+import yaml
+
+from soliplex.config import middleware as config_middleware
+
+BOGUS_MWCONFIG_YAML = """\
+nonesuch: foo
+"""
+
+BARE_MIDDLEWARE_NAME = "bare"
+BARE_MWCONFIG_KW = {
+    "name": BARE_MIDDLEWARE_NAME,
+    "app_factory": _test_middleware.null_app_factory,
+}
+BARE_MWCONFIG_YAML = f"""\
+name: "{BARE_MIDDLEWARE_NAME}"
+app_factory: "_test_middleware.null_app_factory"
+"""
+
+W_NEEDS_ICONFIG_MIDDLEWARE_NAME = "w_needs_iconfig"
+W_NEEDS_ICONFIG_MWCONFIG_KW = {
+    "name": W_NEEDS_ICONFIG_MIDDLEWARE_NAME,
+    "app_factory": _test_middleware.w_iconfig_app_factory,
+}
+W_NEEDS_ICONFIG_MWCONFIG_YAML = f"""\
+name: "{W_NEEDS_ICONFIG_MIDDLEWARE_NAME}"
+app_factory: "_test_middleware.w_iconfig_app_factory"
+"""
+
+W_EXTRA_PARAMS_MIDDLEWARE_NAME = "w_extra_params"
+W_EXTRA_PARAMS_MWCONFIG_KW = {
+    "name": W_EXTRA_PARAMS_MIDDLEWARE_NAME,
+    "app_factory": _test_middleware.w_extra_params_app_factory,
+}
+W_EXTRA_PARAMS_MWCONFIG_YAML = f"""\
+name: "{W_EXTRA_PARAMS_MIDDLEWARE_NAME}"
+app_factory: "_test_middleware.w_extra_params_app_factory"
+"""
+
+
+@pytest.mark.parametrize(
+    "config_yaml, expected_kw",
+    [
+        (BOGUS_MWCONFIG_YAML, None),
+        (BARE_MWCONFIG_YAML, BARE_MWCONFIG_KW),
+        (W_NEEDS_ICONFIG_MWCONFIG_YAML, W_NEEDS_ICONFIG_MWCONFIG_KW),
+        (W_EXTRA_PARAMS_MWCONFIG_YAML, W_EXTRA_PARAMS_MWCONFIG_KW),
+    ],
+)
+def test_middlewareconfig_from_yaml(
+    temp_dir,
+    config_yaml,
+    expected_kw,
+):
+    expected_kw = copy.deepcopy(expected_kw)
+
+    yaml_file = temp_dir / "config.yaml"
+    yaml_file.write_text(config_yaml)
+
+    with yaml_file.open() as fp:
+        config_dict = yaml.safe_load(fp)
+
+    config_dict = copy.deepcopy(config_dict)
+
+    if expected_kw is None:
+        with pytest.raises(KeyError):
+            config_middleware.MiddlewareConfig.from_yaml(config_dict)
+
+    else:
+        expected = config_middleware.MiddlewareConfig(**expected_kw)
+        found = config_middleware.MiddlewareConfig.from_yaml(
+            config_dict.copy(),
+        )
+        assert found == expected
+
+
+@pytest.mark.parametrize(
+    "config_kw, expected",
+    [
+        (BARE_MWCONFIG_KW, False),
+        (W_NEEDS_ICONFIG_MWCONFIG_KW, True),
+        (W_EXTRA_PARAMS_MWCONFIG_KW, False),
+    ],
+)
+def test_middlewareconfig_needs_iconfig(
+    config_kw,
+    expected,
+):
+    mw_config = config_middleware.MiddlewareConfig(**config_kw)
+
+    found = mw_config.needs_iconfig
+
+    assert found == expected
+
+
+APP = mock.Mock(spec_set=())
+I_CONFIG = mock.Mock(spec_set=())
+
+
+@pytest.mark.parametrize(
+    "to_compose_kwargs",
+    [
+        [],
+        [
+            {
+                "name": "null",
+                "app_factory": _test_middleware.null_app_factory,
+            },
+        ],
+        [
+            {
+                "name": "w_iconfg",
+                "app_factory": _test_middleware.w_iconfig_app_factory,
+            },
+        ],
+        [
+            {
+                "name": "w_extra",
+                "app_factory": _test_middleware.w_extra_params_app_factory,
+                "extra_params": {"foo": "bar"},
+            },
+        ],
+        [
+            {
+                "name": "null",
+                "app_factory": _test_middleware.null_app_factory,
+            },
+            {
+                "name": "w_iconfg",
+                "app_factory": _test_middleware.w_iconfig_app_factory,
+            },
+            {
+                "name": "w_extra",
+                "app_factory": _test_middleware.w_extra_params_app_factory,
+                "extra_params": {"foo": "bar"},
+            },
+        ],
+    ],
+)
+def test_compose_middlware_stack(to_compose_kwargs):
+    to_compose = [
+        config_middleware.MiddlewareConfig(**kw) for kw in to_compose_kwargs
+    ]
+
+    found = config_middleware.compose_middleware_stack(
+        APP,
+        I_CONFIG,
+        to_compose,
+    )
+
+    wrappers = []
+    current = found
+
+    while current is not APP:
+        wrappers.append(current)
+        current = current.app
+
+    assert current is APP
+
+    for composed, wrapper in zip(to_compose, wrappers, strict=True):
+        if composed.needs_iconfig:
+            assert wrapper.i_config is I_CONFIG
+        else:
+            assert wrapper.i_config is None
+
+        assert wrapper.kwargs == composed.extra_params

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -13,13 +13,6 @@ EXPLICIT_INST_PATH = "/explicit"
 TOKEN = "DEADBEEF"
 
 
-@pytest.fixture
-def explicit_inst_dir(temp_dir):
-    result = temp_dir / "explicit"
-    result.mkdir()
-    return result
-
-
 @pytest.fixture(scope="module", params=[False, True])
 def no_auth_mode_kwargs(request):
     kw = {"no_auth_mode": request.param}
@@ -80,179 +73,207 @@ def test_app_with_lifespan(acm, fapi):
 
 def test_app_with_cors():
     app = mock.Mock(spec_set=["add_middleware"])
+    extra_params = {
+        "allow_origins": ["*"],
+        "allow_credentials": True,
+        "allow_methods": ["*"],
+        "allow_headers": ["*"],
+    }
 
-    found = main.app_with_cors(app)
+    found = main.app_with_cors(app, **extra_params)
 
     assert found is app
-
     app.add_middleware.assert_called_once_with(
         fastapi_mw_cors.CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        **extra_params,
     )
 
 
-def test_app_with_session():
+@pytest.mark.parametrize(
+    "env, exp_https_only",
+    [
+        ({}, True),
+        ({"_SOLIPLEX_INSECURE_SESSION_COOKIE": "Y"}, False),
+    ],
+)
+def test_app_with_session(env, exp_https_only):
     app = mock.Mock(spec_set=["add_middleware"])
+    installation_config = mock.Mock(spec_set=["get_secret"])
+    installation_config.get_secret.return_value = TOKEN
 
-    found = main.app_with_session(app, TOKEN)
+    with mock.patch.dict("os.environ", env, clear=True):
+        found = main.app_with_session(
+            app,
+            installation_config=installation_config,
+        )
 
     assert found is app
-
+    installation_config.get_secret.assert_called_once_with(
+        "secret:SESSION_MIDDLEWARE_TOKEN",
+    )
     app.add_middleware.assert_called_once_with(
         starlette_mw_sessions.SessionMiddleware,
         secret_key=TOKEN.encode("ascii"),
-        https_only=True,
+        https_only=exp_https_only,
         same_site="lax",
     )
 
 
-def test_app_with_session_insecure():
-    app = mock.Mock(spec_set=["add_middleware"])
+def test_default_middleware_stack():
+    found = main.default_middleware_stack()
 
-    found = main.app_with_session(app, TOKEN, https_only=False)
-
-    assert found is app
-
-    app.add_middleware.assert_called_once_with(
-        starlette_mw_sessions.SessionMiddleware,
-        secret_key=TOKEN.encode("ascii"),
-        https_only=False,
-        same_site="lax",
-    )
-
-
-@pytest.fixture
-def installation_w_session_token(explicit_inst_dir):
-    secret_file = explicit_inst_dir / "session_secret.txt"
-    secret_file.write_text(TOKEN)
-    i_yaml = explicit_inst_dir / "installation.yaml"
-    i_yaml.write_text("""\
-id: test-create-main
-secrets:
-  - secret_name: "SESSION_MIDDLEWARE_TOKEN"
-    sources:
-      - kind: "file_path"
-        file_path: "./session_secret.txt"
-""")
-    return explicit_inst_dir
+    session_mw, cors_mw = found
+    assert session_mw.name == "session"
+    assert session_mw.app_factory is main.app_with_session
+    assert session_mw.extra_params == {}
+    assert cors_mw.name == "cors"
+    assert cors_mw.app_factory is main.app_with_cors
+    assert cors_mw.extra_params == {
+        "allow_origins": ["*"],
+        "allow_credentials": True,
+        "allow_methods": ["*"],
+        "allow_headers": ["*"],
+    }
 
 
-@pytest.mark.parametrize("w_session_https_only", [None, False])
+def _loaded_installation(w_configured_stack):
+    """Build a mock 'InstallationConfig' with a controllable stack.
+
+    When 'w_configured_stack' is true the config carries an explicit
+    'middleware_stack'; otherwise it is empty (so 'create_app' falls back to
+    'default_middleware_stack').
+    """
+    configured_stack = [mock.Mock(name="configured_mw")]
+    inst = mock.Mock(spec_set=["middleware_stack"])
+    inst.middleware_stack = configured_stack if w_configured_stack else []
+    return inst
+
+
+@pytest.mark.parametrize("w_configured_stack", [False, True])
 @pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
 @pytest.mark.parametrize("w_no_auth_mode", [False, True])
 def test_create_app_with_explicit_overrides(
-    installation_w_session_token,
     w_no_auth_mode,
     w_log_config_file,
-    w_session_https_only,
+    w_configured_stack,
 ):
     kwargs = {}
 
     if w_log_config_file is not None:
         kwargs["log_config_file"] = w_log_config_file
 
-    if w_session_https_only is not None:
-        kwargs["session_https_only"] = w_session_https_only
-        exp_session_https_only = w_session_https_only
-    else:
-        exp_session_https_only = True
-
+    loaded_installation = _loaded_installation(w_configured_stack)
+    i_path = pathlib.Path(EXPLICIT_INST_PATH)
     curry_lifespan = mock.Mock(spec_set=())
     app_with_lifespan = mock.Mock(spec_set=())
-    app_with_cors = mock.Mock(spec_set=())
-    app_with_session = mock.Mock(spec_set=())
+    compose_middleware_stack = mock.Mock(spec_set=())
+    default_middleware_stack = mock.Mock(spec_set=())
 
-    found = main.create_app(
-        installation_path=installation_w_session_token,
-        no_auth_mode=w_no_auth_mode,
-        curry_lifespan=curry_lifespan,
-        app_with_lifespan=app_with_lifespan,
-        app_with_cors=app_with_cors,
-        app_with_session=app_with_session,
-        **kwargs,
-    )
+    with mock.patch.object(
+        main.config_installation,
+        "load_installation",
+        return_value=loaded_installation,
+    ) as load_installation:
+        found = main.create_app(
+            installation_path=i_path,
+            no_auth_mode=w_no_auth_mode,
+            curry_lifespan=curry_lifespan,
+            app_with_lifespan=app_with_lifespan,
+            compose_middleware_stack=compose_middleware_stack,
+            default_middleware_stack=default_middleware_stack,
+            **kwargs,
+        )
 
-    assert found is app_with_session.return_value
-    app_with_session.assert_called_once_with(
-        app_with_cors.return_value,
-        TOKEN,
-        https_only=exp_session_https_only,
-    )
-    app_with_cors.assert_called_once_with(
+    assert found is compose_middleware_stack.return_value
+    load_installation.assert_called_once_with(i_path)
+
+    if w_configured_stack:
+        exp_stack = loaded_installation.middleware_stack
+        default_middleware_stack.assert_not_called()
+    else:
+        exp_stack = default_middleware_stack.return_value
+        default_middleware_stack.assert_called_once_with()
+
+    compose_middleware_stack.assert_called_once_with(
         app_with_lifespan.return_value,
+        loaded_installation,
+        exp_stack,
     )
-    app_with_lifespan.assert_called_once_with(
-        curry_lifespan.return_value,
-    )
+    app_with_lifespan.assert_called_once_with(curry_lifespan.return_value)
     curry_lifespan.assert_called_once_with(
-        installation_path=installation_w_session_token,
+        installation_path=i_path,
         no_auth_mode=w_no_auth_mode,
         log_config_file=w_log_config_file,
     )
 
 
-@pytest.mark.parametrize("w_session_https_only", [None, False])
+@pytest.mark.parametrize("w_configured_stack", [False, True])
 @pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
 @pytest.mark.parametrize("w_no_auth_mode", [False, True])
 def test_create_app_wo_explicit_overrides(
-    installation_w_session_token,
     w_no_auth_mode,
     w_log_config_file,
-    w_session_https_only,
+    w_configured_stack,
 ):
     kwargs = {}
 
     if w_log_config_file is not None:
         kwargs["log_config_file"] = w_log_config_file
 
-    if w_session_https_only is not None:
-        kwargs["session_https_only"] = w_session_https_only
-        exp_session_https_only = w_session_https_only
-    else:
-        exp_session_https_only = True
-
+    loaded_installation = _loaded_installation(w_configured_stack)
+    i_path = pathlib.Path(EXPLICIT_INST_PATH)
     curry_lifespan = mock.Mock(spec_set=())
     app_with_lifespan = mock.Mock(spec_set=())
-    app_with_cors = mock.Mock(spec_set=())
-    app_with_session = mock.Mock(spec_set=())
+    compose_middleware_stack = mock.Mock(spec_set=())
+    default_middleware_stack = mock.Mock(spec_set=())
 
-    with mock.patch.multiple(
-        "soliplex.main",
-        curry_lifespan=curry_lifespan,
-        app_with_lifespan=app_with_lifespan,
-        app_with_cors=app_with_cors,
-        app_with_session=app_with_session,
+    with (
+        mock.patch.multiple(
+            "soliplex.main",
+            curry_lifespan=curry_lifespan,
+            app_with_lifespan=app_with_lifespan,
+            default_middleware_stack=default_middleware_stack,
+        ),
+        mock.patch.object(
+            main.config_middleware,
+            "compose_middleware_stack",
+            compose_middleware_stack,
+        ),
+        mock.patch.object(
+            main.config_installation,
+            "load_installation",
+            return_value=loaded_installation,
+        ) as load_installation,
     ):
         found = main.create_app(
-            installation_path=installation_w_session_token,
+            installation_path=i_path,
             no_auth_mode=w_no_auth_mode,
             **kwargs,
         )
 
-    assert found is app_with_session.return_value
+    assert found is compose_middleware_stack.return_value
+    load_installation.assert_called_once_with(i_path)
 
-    app_with_session.assert_called_once_with(
-        app_with_cors.return_value,
-        TOKEN,
-        https_only=exp_session_https_only,
-    )
-    app_with_cors.assert_called_once_with(
+    if w_configured_stack:
+        exp_stack = loaded_installation.middleware_stack
+        default_middleware_stack.assert_not_called()
+    else:
+        exp_stack = default_middleware_stack.return_value
+        default_middleware_stack.assert_called_once_with()
+
+    compose_middleware_stack.assert_called_once_with(
         app_with_lifespan.return_value,
+        loaded_installation,
+        exp_stack,
     )
-    app_with_lifespan.assert_called_once_with(
-        curry_lifespan.return_value,
-    )
+    app_with_lifespan.assert_called_once_with(curry_lifespan.return_value)
     curry_lifespan.assert_called_once_with(
-        installation_path=installation_w_session_token,
+        installation_path=i_path,
         no_auth_mode=w_no_auth_mode,
         log_config_file=w_log_config_file,
     )
 
 
-@pytest.mark.parametrize("w_insecure_cookie", [False, True])
 @pytest.mark.parametrize("w_log_config_file", [None, LOG_CONFIG_FILE_PATH])
 @pytest.mark.parametrize("w_no_auth_mode", [False, True])
 @mock.patch("soliplex.main.create_app")
@@ -261,7 +282,6 @@ def test_create_app_from_environment(
     temp_dir,
     w_no_auth_mode,
     w_log_config_file,
-    w_insecure_cookie,
 ):
     i_path = temp_dir / "installation.yaml"
 
@@ -273,17 +293,12 @@ def test_create_app_from_environment(
     if w_log_config_file:
         env_patch["_SOLIPLEX_LOG_CONFIG_FILE"] = w_log_config_file
 
-    if w_insecure_cookie:
-        env_patch["_SOLIPLEX_INSECURE_SESSION_COOKIE"] = "Y"
-
     with mock.patch.dict("os.environ", clear=True, **env_patch):
         found = main.create_app_from_environment()
 
     assert found is create_app.return_value
-
     create_app.assert_called_once_with(
         installation_path=i_path,
         no_auth_mode=w_no_auth_mode,
         log_config_file=w_log_config_file,
-        session_https_only=not w_insecure_cookie,
     )

--- a/zensical.toml
+++ b/zensical.toml
@@ -29,6 +29,7 @@ nav = [
     { "Meta" = "config/meta.md" },
     { "Environment" = "config/environment.md" },
     { "Secrets" = "config/secrets.md" },
+    { "Middleware" = "config/middleware.md" },
     { "Agents" = "config/agents.md" },
     { "Rooms" = "config/rooms.md" },
     { "Completions" = "config/completions.md" },


### PR DESCRIPTION
- 'config.installation.InstallationConfig.middleware_stack' overrides the default stack previously hard-wired into 'main.create_app'.
- Each entry is an instance of 'config.middleware.MiddlewareConfig', taking the 'app_factory' (dotted name of a factory) and an 'extra_params' mapping.
-  Factories which need an 'InstallationConfig' passed to them (e.g., to derive secrets or env vars), must declare 'installation_config' as a keyword-only argument.

Closes #646.

Closes #1123.