### PR TITLE
fix: block room/thread uploads if sandbox skill missing

### DIFF
--- a/src/soliplex/config/rooms.py
+++ b/src/soliplex/config/rooms.py
@@ -171,6 +171,11 @@ class RoomConfig:
         return self.skills.rag_db_paths if self.skills is not None else {}
 
     @property
+    def has_sandbox(self) -> bool:
+        """Does the room have the sandbox skill?"""
+        return self.skills.has_sandbox if self.skills is not None else False
+
+    @property
     def agui_feature_names(self) -> tuple[str]:
         agent_features = set(self.agent_config.agui_feature_names)
         room_features = set(self._agui_feature_names)

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -594,6 +594,15 @@ class RoomSkillsConfig(_SkillConfigModelBase):
         }
 
     @property
+    def has_sandbox(self) -> bool:
+        """Does the room have the sandbox skill?"""
+        return any(
+            skill_config
+            for skill_config in self.skill_configs.values()
+            if isinstance(skill_config, BwrapSandboxSkillConfig)
+        )
+
+    @property
     def skill_preambles(self) -> list[str]:
         preambles = []
 

--- a/src/soliplex/views/room_file_uploads.py
+++ b/src/soliplex/views/room_file_uploads.py
@@ -190,12 +190,20 @@ async def post_uploads_room(
         the_logger=the_logger,
     )
 
+    if not _room_config.has_sandbox:
+        raise fastapi.HTTPException(
+            status_code=405,
+            detail="Sandbox not configured",
+            headers={"Allow": "GET"},
+        )
+
     uploads_path = the_installation.rooms_upload_path
 
     if uploads_path is None:
         raise fastapi.HTTPException(
-            status_code=404,
+            status_code=405,
             detail="Room uploads not configured",
+            headers={"Allow": "GET"},
         )
 
     room_dir = pathlib.Path(uploads_path) / room_id

--- a/src/soliplex/views/thread_file_uploads.py
+++ b/src/soliplex/views/thread_file_uploads.py
@@ -173,6 +173,22 @@ async def post_uploads_room_thread(
         the_logger=the_logger,
     )
 
+    if not _room_config.has_sandbox:
+        raise fastapi.HTTPException(
+            status_code=405,
+            detail="Sandbox not configured",
+            headers={"Allow": "GET"},
+        )
+
+    uploads_path = the_installation.threads_upload_path
+
+    if uploads_path is None:
+        raise fastapi.HTTPException(
+            status_code=405,
+            detail="Thread uploads not configured",
+            headers={"Allow": "GET"},
+        )
+
     try:
         await the_threads.get_thread(
             user_name=user_name,
@@ -184,14 +200,6 @@ async def post_uploads_room_thread(
             status_code=exc.status_code,
             detail=exc.args,
         ) from None
-
-    uploads_path = the_installation.threads_upload_path
-
-    if uploads_path is None:
-        raise fastapi.HTTPException(
-            status_code=404,
-            detail="Thread uploads not configured",
-        )
 
     thread_dir = pathlib.Path(uploads_path) / thread_id
     thread_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -413,8 +413,10 @@ def test_roomconfig_skill_configs_w_hit(installation_config):
     }
 
     room_config_kw = FULL_ROOM_CONFIG_KW.copy()
-    room_config_kw["skills"].entrypoint_skills = []
-    room_config_kw["skills"]._installation_config = installation_config
+    room_config_kw["skills"] = dataclasses.replace(
+        room_config_kw["skills"],
+        _installation_config=installation_config,
+    )
     room_config = config_rooms.RoomConfig(
         **room_config_kw,
         _installation_config=installation_config,
@@ -457,8 +459,10 @@ def test_roomconfig_rag_db_paths_w_hit(temp_dir, installation_config):
     }
 
     room_config_kw = FULL_ROOM_CONFIG_KW.copy()
-    room_config_kw["skills"].entrypoint_skills = []
-    room_config_kw["skills"]._installation_config = installation_config
+    room_config_kw["skills"] = dataclasses.replace(
+        room_config_kw["skills"],
+        _installation_config=installation_config,
+    )
     room_config = config_rooms.RoomConfig(
         **room_config_kw,
         _installation_config=installation_config,
@@ -467,6 +471,48 @@ def test_roomconfig_rag_db_paths_w_hit(temp_dir, installation_config):
     found = room_config.rag_db_paths
 
     assert found == {"test-skill": str(OVERRIDE_PATH)}
+
+
+def test_roomconfig_has_sandbox_bare(installation_config):
+    installation_config.skill_configs = {}
+
+    room_config_kw = BARE_ROOM_CONFIG_KW.copy()
+    room_config = config_rooms.RoomConfig(
+        **room_config_kw,
+        _installation_config=installation_config,
+    )
+
+    room_config.skills = None
+
+    found = room_config.has_sandbox
+
+    assert found is False
+
+
+def test_roomconfig_has_sandbox_w_hit(temp_dir, installation_config):
+    installation_config.skill_configs = {
+        "other_skill": object(),
+    }
+    sandbox_skill_config = config_skills.BwrapSandboxSkillConfig(
+        _installation_config=installation_config,
+    )
+
+    room_config_kw = FULL_ROOM_CONFIG_KW.copy()
+    room_config_kw["skills"] = dataclasses.replace(
+        room_config_kw["skills"],
+        installation_skill_names=list(installation_config.skill_configs),
+        _installation_config=installation_config,
+        _skill_configs={sandbox_skill_config.kind: sandbox_skill_config},
+    )
+
+    room_config = config_rooms.RoomConfig(
+        **room_config_kw,
+        _installation_config=installation_config,
+    )
+
+    found = room_config.has_sandbox
+
+    assert found is True
 
 
 @pytest.fixture

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -1157,31 +1157,68 @@ def test_roomskillsconfig_skills(installation_config):
     assert found == {SKILL_NAME: skill_config.skill}
 
 
+@pytest.mark.parametrize("w_rag_skill", [False, True])
 def test_roomskillsconfig_rag_db_paths(
     installation_config,
     haiku_rag_config,
     lancedb,
     config_path,
+    w_rag_skill,
 ):
-    skill_config = config_skills.HR_RAG_SkillConfig(
+    rag_skill_config = config_skills.HR_RAG_SkillConfig(
         rag_lancedb_override_path=lancedb,
         _haiku_rag_config=haiku_rag_config,
         _config_path=config_path,
         _installation_config=installation_config,
     )
     installation_config.skill_configs = {
-        SKILL_NAME: skill_config,
         "other_skill": object(),
     }
+    if w_rag_skill:
+        installation_config.skill_configs[SKILL_NAME] = rag_skill_config
+        expected = {
+            rag_skill_config.name: str(rag_skill_config.rag_lancedb_path),
+        }
+    else:
+        expected = {}
 
     room_skill_config = config_skills.RoomSkillsConfig(
-        installation_skill_names=[SKILL_NAME, "other_skill"],
+        installation_skill_names=list(installation_config.skill_configs),
         _installation_config=installation_config,
     )
 
     found = room_skill_config.rag_db_paths
 
-    assert found == {skill_config.name: str(skill_config.rag_lancedb_path)}
+    assert found == expected
+
+
+@pytest.mark.parametrize("w_sandbox_skill", [False, True])
+def test_roomskillsconfig_has_sandbox(
+    installation_config,
+    haiku_rag_config,
+    lancedb,
+    config_path,
+    w_sandbox_skill,
+):
+    sandbox_skill_config = config_skills.BwrapSandboxSkillConfig(
+        _config_path=config_path,
+        _installation_config=installation_config,
+    )
+    skill_configs = {
+        "other_skill": object(),
+    }
+    if w_sandbox_skill:
+        skill_configs[sandbox_skill_config.kind] = sandbox_skill_config
+
+    room_skill_config = config_skills.RoomSkillsConfig(
+        installation_skill_names=list(installation_config.skill_configs),
+        _installation_config=installation_config,
+        _skill_configs=skill_configs,
+    )
+
+    found = room_skill_config.has_sandbox
+
+    assert found == w_sandbox_skill
 
 
 def test_roomskillsconfig_skill_preambles(

--- a/tests/unit/views/test_room_file_uploads.py
+++ b/tests/unit/views/test_room_file_uploads.py
@@ -26,9 +26,12 @@ URL_PREFIX = "http://test.example.com/api"
 no_error = contextlib.nullcontext
 
 
-def raises_httpexc(*, match, code) -> pytest.raises:
+def raises_httpexc(*, match, code, headers=None) -> pytest.raises:
     def _check(exc):
-        return exc.status_code == code
+        if headers is not None:
+            return exc.status_code == code and exc.headers == headers
+        else:
+            return exc.status_code == code
 
     return pytest.raises(fastapi.HTTPException, match=match, check=_check)
 
@@ -233,10 +236,27 @@ def test_get_the_room_upload_audit_log(rual_klass):
     ],
 )
 @pytest.mark.parametrize(
-    "w_upload_path, expectation",
+    "w_sandbox, w_upload_path, expectation",
     [
-        (True, no_error(204)),
-        (False, raises_httpexc(code=404, match="Room uploads not configured")),
+        (True, True, no_error(204)),
+        (
+            False,
+            True,
+            raises_httpexc(
+                code=405,
+                match="Sandbox not configured",
+                headers={"Allow": "GET"},
+            ),
+        ),
+        (
+            True,
+            False,
+            raises_httpexc(
+                code=405,
+                match="Room uploads not configured",
+                headers={"Allow": "GET"},
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize("w_admin_access", [False, True])
@@ -245,12 +265,16 @@ async def test_post_uploads_room(
     cuir,
     uploads_path,
     w_admin_access,
+    w_sandbox,
     w_upload_path,
     expectation,
     w_filename,
     exp_filename,
 ):
-    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    room_config = mock.create_autospec(
+        config_rooms.RoomConfig,
+        has_sandbox=w_sandbox,
+    )
     cuir.return_value = room_config
     upload_file = fastapi.UploadFile(
         file=io.BytesIO(TEST_CONTENT),

--- a/tests/unit/views/test_thread_file_uploads.py
+++ b/tests/unit/views/test_thread_file_uploads.py
@@ -29,9 +29,12 @@ URL_PREFIX = "http://test.example.com/api"
 no_error = contextlib.nullcontext
 
 
-def raises_httpexc(*, match, code) -> pytest.raises:
+def raises_httpexc(*, match, code, headers=None) -> pytest.raises:
     def _check(exc):
-        return exc.status_code == code
+        if headers is not None:
+            return exc.status_code == code and exc.headers == headers
+        else:
+            return exc.status_code == code
 
     return pytest.raises(fastapi.HTTPException, match=match, check=_check)
 
@@ -236,18 +239,34 @@ async def test_get_uploads_room_thread_filename(
     ],
 )
 @pytest.mark.parametrize(
-    "tsgt_side_effect, w_upload_path, expectation",
+    "w_sandbox, tsgt_side_effect, w_upload_path, expectation",
     [
-        (None, True, no_error(204)),
+        (True, None, True, no_error(204)),
         (
+            False,
+            None,
+            True,
+            raises_httpexc(
+                code=405,
+                match="Sandbox not configured",
+                headers={"Allow": "GET"},
+            ),
+        ),
+        (
+            True,
+            None,
+            False,
+            raises_httpexc(
+                code=405,
+                match="Thread uploads not configured",
+                headers={"Allow": "GET"},
+            ),
+        ),
+        (
+            True,
             agui.UnknownThread(USER_NAME, str(TEST_THREAD_ID)),
             True,
             raises_httpexc(code=404, match="Unknown thread"),
-        ),
-        (
-            None,
-            False,
-            raises_httpexc(code=404, match="Thread uploads not configured"),
         ),
     ],
 )
@@ -256,13 +275,17 @@ async def test_post_uploads_room_thread(
     cuir,
     uploads_path,
     the_threads,
+    w_sandbox,
     tsgt_side_effect,
     w_upload_path,
     expectation,
     w_filename,
     exp_filename,
 ):
-    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    room_config = mock.create_autospec(
+        config_rooms.RoomConfig,
+        has_sandbox=w_sandbox,
+    )
     cuir.return_value = room_config
     upload_file = fastapi.UploadFile(
         file=io.BytesIO(TEST_CONTENT),
@@ -302,11 +325,14 @@ async def test_post_uploads_room_thread(
         )
         assert exp_file.read_bytes() == TEST_CONTENT
 
-    the_threads.get_thread.assert_called_once_with(
-        user_name=USER_NAME,
-        room_id=TEST_ROOM_ID,
-        thread_id=str(TEST_THREAD_ID),
-    )
+    if w_sandbox and w_upload_path:
+        the_threads.get_thread.assert_called_once_with(
+            user_name=USER_NAME,
+            room_id=TEST_ROOM_ID,
+            thread_id=str(TEST_THREAD_ID),
+        )
+    else:
+        the_threads.get_thread.assert_not_called()
 
     the_logger.debug.assert_called_once_with(
         loggers.UPLOADS_POST_ROOM_THREAD,


### PR DESCRIPTION
  ... return a 405 w/ 'Allowed: GET' header.

feat: 'config.rooms.RoomConfig.has_sandbox' property

feat: 'config.skills.RoomSkillsonfig.has_sandbox' property

Closes #1135.