### PR TITLE
fix: normalize thread upload POST route

### DIFF
--- a/src/soliplex/tui/rest_api.py
+++ b/src/soliplex/tui/rest_api.py
@@ -184,7 +184,7 @@ class TUI_REST_API:
         thread_id: str,
         file_path: pathlib.Path,
     ) -> None:
-        upload_url = f"{self.api_v1_base}/uploads/{room_id}/{thread_id}"
+        upload_url = f"{self.api_v1_base}/uploads/{room_id}/thread/{thread_id}"
 
         with file_path.open("rb") as file_stream:
             files = {

--- a/src/soliplex/views/thread_file_uploads.py
+++ b/src/soliplex/views/thread_file_uploads.py
@@ -27,7 +27,7 @@ depend_the_logger = views.depend_the_logger
     "GET /v1/uploads/{room_id}/thread/{thread_id}",
 )
 @router.get("/v1/uploads/{room_id}/thread/{thread_id}")
-async def get_uploads_room_thread(
+async def get_uploads_room_id_thread_thread_id(
     request: fastapi.Request,
     room_id: str,
     thread_id: pydantic.UUID4,
@@ -66,7 +66,7 @@ async def get_uploads_room_thread(
                 filename = file_or_sub.name
                 filename_urls[filename] = request.url_for(
                     # View function name, not the route path.
-                    "get_uploads_room_thread_filename",
+                    "get_uploads_room_id_thread_thread_id_filename",
                     room_id=room_id,
                     thread_id=thread_id,
                     filename=filename,
@@ -92,7 +92,7 @@ async def get_uploads_room_thread(
     "/v1/uploads/{room_id}/thread/{thread_id}/file/{filename}",
     response_class=responses.FileResponse,
 )
-async def get_uploads_room_thread_filename(
+async def get_uploads_room_id_thread_thread_id_filename(
     room_id: str,
     thread_id: pydantic.UUID4,
     filename: str,
@@ -142,10 +142,15 @@ async def get_uploads_room_thread_filename(
 
 
 @soliplex_views_util.logfire_span(
-    "POST /v1/uploads/{room_id}/{thread_id}/",
+    "POST /v1/uploads/{room_id}/thread/{thread_id}/",
 )
-@router.post("/v1/uploads/{room_id}/{thread_id}", status_code=204)
-async def post_uploads_room_thread(
+@router.post("/v1/uploads/{room_id}/thread/{thread_id}", status_code=204)
+@router.post(
+    "/v1/uploads/{room_id}/{thread_id}",
+    status_code=204,
+    deprecated=True,  # see #1137
+)
+async def post_uploads_room_id_thread_thread_id(
     room_id: str,
     thread_id: pydantic.UUID4,
     upload_file: fastapi.UploadFile,

--- a/tests/unit/views/test_thread_file_uploads.py
+++ b/tests/unit/views/test_thread_file_uploads.py
@@ -73,7 +73,7 @@ def uploads_path(temp_dir):
     ],
 )
 @mock.patch("soliplex.views.agui._check_user_in_room")
-async def test_get_uploads_room_thread_only(
+async def test_get_uploads_room_id_thread_thread_id_only(
     cuir,
     uploads_path,
     w_upload_path,
@@ -85,7 +85,7 @@ async def test_get_uploads_room_thread_only(
     thread_path = thread_uploads_path / str(TEST_THREAD_ID)
     # Note: this is the name of the view function, and not the path
     #       to which it is bound.
-    ROUTE_NAME = "get_uploads_room_thread_filename"
+    ROUTE_NAME = "get_uploads_room_id_thread_thread_id_filename"
 
     def download_url(name, room_id, thread_id, filename):
         assert name == ROUTE_NAME
@@ -122,7 +122,7 @@ async def test_get_uploads_room_thread_only(
     the_logger = mock.create_autospec(loggers.LogWrapper)
 
     with expectation as expected:
-        found = await thread_views.get_uploads_room_thread(
+        found = await thread_views.get_uploads_room_id_thread_thread_id(
             request=request,
             room_id=TEST_ROOM_ID,
             thread_id=TEST_THREAD_ID,
@@ -178,7 +178,7 @@ async def test_get_uploads_room_thread_only(
     ],
 )
 @mock.patch("soliplex.views.agui._check_user_in_room")
-async def test_get_uploads_room_thread_filename(
+async def test_get_uploads_room_id_thread_thread_id_filename(
     cuir,
     uploads_path,
     w_upload_path,
@@ -211,8 +211,10 @@ async def test_get_uploads_room_thread_filename(
     the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
     the_logger = mock.create_autospec(loggers.LogWrapper)
 
+    t_views = thread_views
+
     with expectation as expected:
-        found = await thread_views.get_uploads_room_thread_filename(
+        found = await t_views.get_uploads_room_id_thread_thread_id_filename(
             room_id=TEST_ROOM_ID,
             thread_id=TEST_THREAD_ID,
             filename=TEST_FILENAME,
@@ -271,7 +273,7 @@ async def test_get_uploads_room_thread_filename(
     ],
 )
 @mock.patch("soliplex.views.agui._check_user_in_room")
-async def test_post_uploads_room_thread(
+async def test_post_uploads_room_id_thread_thread_thread_id(
     cuir,
     uploads_path,
     the_threads,
@@ -307,7 +309,7 @@ async def test_post_uploads_room_thread(
     the_threads.get_thread.side_effect = tsgt_side_effect
 
     with expectation as expected:
-        response = await thread_views.post_uploads_room_thread(
+        response = await thread_views.post_uploads_room_id_thread_thread_id(
             room_id=TEST_ROOM_ID,
             thread_id=TEST_THREAD_ID,
             upload_file=upload_file,


### PR DESCRIPTION
  ... to match the GET route.

Leave a deprecated alias route in place, to be removed later.

Closes #1137.