### PR TITLE
Add per-room use_subagents skill config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "fakeredis != 2.35.0",  # brownbag
     "greenlet",
     "haiku.rag-slim >= 0.66, < 0.67",
-    "haiku-skills >= 0.18.0, < 0.19",
+    "haiku-skills >= 0.18.1, < 0.19",
     "idna >= 3.15",
     "itsdangerous",
     "joserfc >= 1.6.7, < 1.7",  # CVE-2026-48990

--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -31,6 +31,10 @@ class SkillToolsetConfig(typing.Protocol):
     @abc.abstractmethod
     def skill_toolset(self) -> hs_agent.SkillToolset: ...
 
+    @property
+    @abc.abstractmethod
+    def use_subagents(self) -> bool: ...
+
 
 @dataclasses.dataclass
 class AgentDependencies:
@@ -110,6 +114,7 @@ def get_default_agent_from_configs(
         instructions = hs_prompts.build_system_prompt(
             preamble=preamble,
             skill_catalog=toolset.skill_catalog,
+            use_subagents=skill_toolset_config.use_subagents,
         )
     else:
         instructions = agent_prompt

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -508,6 +508,12 @@ class RoomSkillsConfig(_SkillConfigModelBase):
     #
     installation_skill_names: list[str] = _default_list_field()
 
+    #
+    # Run skills as isolated sub-agents (the default) or expose their tools
+    # directly to the room's agent.
+    #
+    use_subagents: bool = True
+
     # Set by `from_yaml` factory
     _skill_configs: SkillConfigMap = _default_dict_field()
     _installation_config: InstallationConfig = (  # noqa F821 cycles
@@ -625,6 +631,7 @@ class RoomSkillsConfig(_SkillConfigModelBase):
         return SoliplexSkillToolset(
             skills=skill_map.values(),
             skill_model=self.model_or_name,
+            use_subagents=self.use_subagents,
         )
 
 

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -1157,6 +1157,51 @@ def test_roomskillsconfig_skills(installation_config):
     assert found == {SKILL_NAME: skill_config.skill}
 
 
+@pytest.mark.parametrize(
+    "ctor_kw, expected",
+    [
+        ({}, True),
+        ({"use_subagents": True}, True),
+        ({"use_subagents": False}, False),
+    ],
+)
+def test_roomskillsconfig_skill_toolset_use_subagents(
+    installation_config, ctor_kw, expected
+):
+    skill = mock.create_autospec(hs_models.Skill)
+    skill_config = mock.create_autospec(
+        config_skills._DiscoveredSkillConfigBase, skill=skill
+    )
+    installation_config.skill_configs = {SKILL_NAME: skill_config}
+
+    room_skill_config = config_skills.RoomSkillsConfig(
+        installation_skill_names=[SKILL_NAME],
+        _installation_config=installation_config,
+        **ctor_kw,
+    )
+
+    with mock.patch.object(
+        config_skills, "SoliplexSkillToolset"
+    ) as mock_toolset:
+        _ = room_skill_config.skill_toolset
+
+    assert mock_toolset.call_args.kwargs["use_subagents"] is expected
+
+
+def test_roomskillsconfig_from_yaml_use_subagents(
+    installation_config, config_path
+):
+    config_dict = {"installation_skill_names": [], "use_subagents": False}
+
+    found = config_skills.RoomSkillsConfig.from_yaml(
+        installation_config,
+        config_path,
+        config_dict,
+    )
+
+    assert found.use_subagents is False
+
+
 @pytest.mark.parametrize("w_rag_skill", [False, True])
 def test_roomskillsconfig_rag_db_paths(
     installation_config,

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -266,6 +266,7 @@ def test_get_default_agent_from_configs(
         build_system_prompt.assert_called_once_with(
             preamble=exp_preamble,
             skill_catalog=room_skills.skill_toolset.skill_catalog,
+            use_subagents=room_skills.use_subagents,
         )
     else:
         build_system_prompt.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1146,7 +1146,7 @@ wheels = [
 
 [[package]]
 name = "haiku-skills"
-version = "0.18.0"
+version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -1156,9 +1156,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "skills-ref" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/a4/41cddc90280bea6d4150ed3361fe1cc804a0d110ca11319a78bf9880cfe9/haiku_skills-0.18.0.tar.gz", hash = "sha256:ac7033bafa79059800515a69d5e60a6fb6f0659174694bfceec473308add85b1", size = 189494, upload-time = "2026-06-29T08:00:29.782Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/09/0984a5ac416453ac2d170fde5ea973ed0700a21ed220d13d1d9ca2127b7f/haiku_skills-0.18.1.tar.gz", hash = "sha256:36edd612a91a897459a5218b79c207372e33670b89b312631f3c69bc9b211dc5", size = 190035, upload-time = "2026-07-15T10:24:52.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/b9/33ed400bd24ba0083ccc352053aae536b7a6bdbcd000171b7683bb756fd4/haiku_skills-0.18.0-py3-none-any.whl", hash = "sha256:cfeb0cd2bd8d297ccd607cf9d94f635c1a9d411676bb3ac8516b149d372154a8", size = 34044, upload-time = "2026-06-29T08:00:28.7Z" },
+    { url = "https://files.pythonhosted.org/packages/78/24/280e4d72b09136086b56658b9fb81d620b0365844f4eca50ab5c7e99f74b/haiku_skills-0.18.1-py3-none-any.whl", hash = "sha256:b6f8b31d54a0b3a8dfd54a53b9cdcaa45ddedc65dd0349c8db7ba8a59b0f891e", size = 34572, upload-time = "2026-07-15T10:24:52.086Z" },
 ]
 
 [[package]]
@@ -3325,8 +3325,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3451,7 +3451,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=3.3.0,<3.4" },
     { name = "greenlet" },
     { name = "haiku-rag-slim", specifier = ">=0.66,<0.67" },
-    { name = "haiku-skills", specifier = ">=0.18.0,<0.19" },
+    { name = "haiku-skills", specifier = ">=0.18.1,<0.19" },
     { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous" },
     { name = "joserfc", specifier = ">=1.6.7,<1.7" },


### PR DESCRIPTION
Adds a `use_subagents` flag to a room's `skills:` config (`RoomSkillsConfig`), threaded into `SoliplexSkillToolset`:

```yaml
skills:
  installation_skill_names: ["my-skill"]
  use_subagents: false   # default: true
```

Default is true, so existing rooms are unchanged. Setting false exposes the skill's tools directly to the room's agent instead of running the skill as an isolated sub-agent.
This is useful for skills that need multiple turns to complete (e.g. a form-filling skill) when using small models.
