### PR TITLE
deps: 'haiku-rag-slim >= 0.67.3, < 0.68'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,17 +25,19 @@ dependencies = [
     "fastmcp >= 3.3.0, < 3.4",
     "fakeredis != 2.35.0",  # brownbag
     "greenlet",
-    "haiku.rag-slim >= 0.67, < 0.68",
+    "haiku.rag-slim >= 0.67.3, < 0.68",
     "haiku-skills >= 0.18.1, < 0.19",
     "idna >= 3.15",
     "itsdangerous",
     "joserfc >= 1.6.7, < 1.7",  # CVE-2026-48990
     "jsonpatch",
+    "mcp >= 1.27.2",  # CVE-2026-52870
     "pillow >= 12.3.0, < 12.4",  # PYSEC-2026-225{3,4,5,6,7}
     "python-jsonpath",  # RFC 9535 query support
     "python-multipart >= 0.0.31",  # Multiple CVEs
     "jwcrypto",
     "logfire[fastapi]",
+    "pyasn1 >= 0.6.4",  # PYSEC-2026-3456
     "pydantic-ai-slim[google] >= 1.102.0, < 2.0",  # CVE-2026-48782
     "pydantic-settings >= 2.14.2, < 2.15",  # GHSA-4xgf-cpjx-pc3j
     "pyjwt >= 2.13.0, < 2.14",  # PYSEC-2026-{175,177,178,179}

--- a/uv.lock
+++ b/uv.lock
@@ -1116,7 +1116,7 @@ wheels = [
 
 [[package]]
 name = "haiku-rag-slim"
-version = "0.67.0"
+version = "0.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docling-core" },
@@ -1139,9 +1139,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/00/f983459e8a230b7ba62b288d3762e4ba2580dd057193ce5c3417e8197d53/haiku_rag_slim-0.67.0.tar.gz", hash = "sha256:8067f7d67529b34049c6c130ac572724fbbead5bee42a54cbfe8a0c396b30a09", size = 236272, upload-time = "2026-07-16T11:28:38.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/45/17c292b84487f7ad4e05b6c1ee59737759b192588fbe9afb17d8b204690b/haiku_rag_slim-0.67.3.tar.gz", hash = "sha256:5bb851613ce6f38bce186a85077e64a640d5e59bd20e85be16ccc231cdce5be4", size = 236476, upload-time = "2026-07-23T11:29:26.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/7a/46e201a4b6e04523c79cc51ec92385bf9a0e25350be10f129afb15c97119/haiku_rag_slim-0.67.0-py3-none-any.whl", hash = "sha256:12b744db70e934bfe029576857aa352a2c4d0a6a392023dfb678af272e6c6a2a", size = 314849, upload-time = "2026-07-16T11:28:36.592Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/64/78f6f372d076ca2790c22c077c59fc0b8140fe30e911ee658614b30080e4/haiku_rag_slim-0.67.3-py3-none-any.whl", hash = "sha256:c04d829e918f6c0cf4c067cd05d69104ae1c4b2f48d4e4848eb3f2b51c3b9350", size = 315074, upload-time = "2026-07-23T11:29:25.046Z" },
 ]
 
 [[package]]
@@ -1739,7 +1739,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1757,9 +1757,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -2542,11 +2542,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -3396,7 +3396,9 @@ dependencies = [
     { name = "jsonpatch" },
     { name = "jwcrypto" },
     { name = "logfire", extra = ["fastapi"] },
+    { name = "mcp" },
     { name = "pillow" },
+    { name = "pyasn1" },
     { name = "pydantic-ai-slim", extra = ["google"] },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -3448,7 +3450,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.3.0,<3.4" },
     { name = "greenlet" },
-    { name = "haiku-rag-slim", specifier = ">=0.67,<0.68" },
+    { name = "haiku-rag-slim", specifier = ">=0.67.3,<0.68" },
     { name = "haiku-skills", specifier = ">=0.18.1,<0.19" },
     { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous" },
@@ -3456,7 +3458,9 @@ requires-dist = [
     { name = "jsonpatch" },
     { name = "jwcrypto" },
     { name = "logfire", extras = ["fastapi"] },
+    { name = "mcp", specifier = ">=1.27.2" },
     { name = "pillow", specifier = ">=12.3.0,<12.4" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pydantic-ai-slim", extras = ["google"], specifier = ">=1.102.0,<2.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2,<2.15" },
     { name = "pyjwt", specifier = ">=2.13.0,<2.14" },


### PR DESCRIPTION
includes document meta in SearchResults and Citations.

deps; 'mcp >= 1.27.2' (CVE-2026-52870)

deps 'pyasn1 >= 0.6.4' (PYSEC-2026-3456)