### PR TITLE
ci: harden issue / PR slack notification

### DIFF
--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -1,22 +1,34 @@
 name: Notify Slack on New issue
 
+# `issues` events always run in the context of this repository, so secrets
+# are available here even for issues filed by outside contributors; no
+# `pull_request_target` equivalent is needed (contrast `pr-opened.yaml`).
 on:
   issues:
     types: [opened]
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest
+    env:
+      # A real newline; `toJSON` below escapes it as `\n` in the payload.
+      NEWLINE: "\n"
     steps:
       - name: Send Slack notification when new issue is opened
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_URL }}
           webhook-type: incoming-webhook
+          # The issue title and author login are attacker-controlled. Build
+          # the message with `format` and let `toJSON` emit it as a single,
+          # correctly escaped JSON string instead of splicing raw text into
+          # the payload.
           payload: |
             {
               "channel": "#soliplex",
               "username": "soliplex",
-              "text": ":bell: New issue by *${{ github.event.issue.user.login }}*:\n*${{ github.event.issue.title }}*\n${{ github.event.issue.html_url }}",
+              "text": ${{ toJSON(format(':bell: New issue by *{0}*:{3}*{1}*{3}{2}', github.event.issue.user.login, github.event.issue.title, github.event.issue.html_url, env.NEWLINE)) }},
               "icon_emoji": ":ghost:"
             }

--- a/.github/workflows/pr-opened.yaml
+++ b/.github/workflows/pr-opened.yaml
@@ -1,22 +1,39 @@
 name: Notify Slack on New PR
 
+# Use `pull_request_target` rather than `pull_request` so the run happens in
+# the context of the base repository and can therefore see
+# `secrets.SLACK_NOTIFY_URL`. Fork PRs get no secrets at all under
+# `pull_request`, so this job failed for every external contribution (#1199).
+#
+# That is only safe because this job never checks out or executes any code
+# from the pull request: it reads event metadata and nothing else. Do not add
+# a checkout of `github.event.pull_request.head.sha` here.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
+
+permissions: {}
 
 jobs:
   notify:
     runs-on: ubuntu-latest
+    env:
+      # A real newline; `toJSON` below escapes it as `\n` in the payload.
+      NEWLINE: "\n"
     steps:
       - name: Send Slack notification when new PR is opened
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_URL }}
           webhook-type: incoming-webhook
+          # The PR title and author login are attacker-controlled, and this
+          # job now runs with secrets in scope. Build the message with
+          # `format` and let `toJSON` emit it as a single, correctly escaped
+          # JSON string instead of splicing raw text into the payload.
           payload: |
             {
               "channel": "#soliplex",
               "username": "soliplex",
-              "text": ":bell: New Pull Request by *${{ github.event.pull_request.user.login }}*:\n*${{ github.event.pull_request.title }}*\n${{ github.event.pull_request.html_url }}",
+              "text": ${{ toJSON(format(':bell: New Pull Request by *{0}*:{3}*{1}*{3}{2}', github.event.pull_request.user.login, github.event.pull_request.title, github.event.pull_request.html_url, env.NEWLINE)) }},
               "icon_emoji": ":ghost:"
             }


### PR DESCRIPTION
  ... against hostile metadata (title w/ JSON injection).

ci: submit PRs using 'pull_request_target'

  ... so that it runs with the org secret for slack notification.

Closes #1199.