### PR TITLE
docs: restructure `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,26 @@ most users. To run Soliplex from a checkout of this repository instead, see:
 - [Client Setup](docs/client.md) -- run the Flutter web client.
 - [Docker Deployment](docs/docker.md) -- run the full stack with Docker Compose.
 
+## Documentation
+
+The full documentation set lives in [`docs/`](docs/) and is published as a
+[Zensical site](https://soliplex.github.io/soliplex/):
+
+> **Tip:** the same documentation is also available as the `soliplex-docs`
+> Agent Skill, so a skills-compatible agent can answer questions straight from
+> it -- see the [Quickstart](#quickstart) above.
+
+- [Overview](docs/overview.md)
+- [Prerequisites](docs/prerequisites.md)
+- [Server Setup](docs/server/index.md) and
+  [CLI Reference](docs/server/cli.md)
+- [Client Setup](docs/client.md)
+- [Docker Deployment](docs/docker.md)
+- [RAG Database](docs/rag.md)
+- [Documentation Skill](docs/docs-skill.md)
+- [Configuration](docs/config/)
+- [Usage](docs/usage.md)
+
 ## Configuration
 
 Soliplex is configured by a tree of YAML files rooted at an
@@ -128,26 +148,6 @@ Soliplex is configured by a tree of YAML files rooted at an
 - [Logfire](docs/config/logfire.md),
   [Console logging](docs/config/logging.md),
   [SQLAlchemy DBURIs](docs/config/dburis.md)
-
-## Documentation
-
-The full documentation set lives in [`docs/`](docs/) and is published as a
-[Zensical site](https://soliplex.github.io/soliplex/):
-
-> **Tip:** the same documentation is also available as the `soliplex-docs`
-> Agent Skill, so a skills-compatible agent can answer questions straight from
-> it -- see the [Quickstart](#quickstart) above.
-
-- [Overview](docs/overview.md)
-- [Prerequisites](docs/prerequisites.md)
-- [Server Setup](docs/server/index.md) and
-  [CLI Reference](docs/server/cli.md)
-- [Client Setup](docs/client.md)
-- [Docker Deployment](docs/docker.md)
-- [RAG Database](docs/rag.md)
-- [Documentation Skill](docs/docs-skill.md)
-- [Configuration](docs/config/)
-- [Usage](docs/usage.md)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 An AI-powered Retrieval-Augmented Generation (RAG) system with a modern web interface.
 
+## Overview
+
+Soliplex is a self-hosted, full-stack RAG/AI system: a FastAPI backend
+(a thin configuration and authentication layer around
+[pydantic-ai](https://ai.pydantic.dev/)), a hardened
+[Flutter client](https://github.com/soliplex/frontend), and a terminal UI.
+
+See the [Overview](docs/overview.md) for what Soliplex is, when (and when not)
+to use it, how it compares to alternatives, and the full feature and
+architecture breakdown.
+
 ## Quickstart
 
 The fastest way to stand up and run your own Soliplex is to let a
@@ -78,17 +89,6 @@ and then *"What is a Soliplex installation?"*
 > The remainder of this README covers running Soliplex from a source checkout
 > and developing on the backend itself. If you only want to *use* Soliplex,
 > the two skills above are all you need.
-
-## Overview
-
-Soliplex is a self-hosted, full-stack RAG/AI system: a FastAPI backend
-(a thin configuration and authentication layer around
-[pydantic-ai](https://ai.pydantic.dev/)), a hardened
-[Flutter client](https://github.com/soliplex/frontend), and a terminal UI.
-
-See the [Overview](docs/overview.md) for what Soliplex is, when (and when not)
-to use it, how it compares to alternatives, and the full feature and
-architecture breakdown.
 
 ## Running from source
 


### PR DESCRIPTION
- Move `Overview` section above `Quickstart`;
- Move `Documentation` section above `Configuration`.