### PR TITLE
ci: split slack failure notification from main actions

### DIFF
--- a/.github/workflows/ci-failure-notify.yaml
+++ b/.github/workflows/ci-failure-notify.yaml
@@ -1,0 +1,46 @@
+name: Notify Slack on CI failure
+
+# The workflows listed below check out untrusted pull-request code, so they
+# must never hold `secrets.SLACK_NOTIFY_URL` (#1203). They also see no
+# secrets at all when triggered by a fork PR, which made their inline Slack
+# steps fail rather than notify (#1199).
+#
+# `workflow_run` always runs in the base-repository context with secrets
+# available, whatever repository the triggering run came from, so the
+# notification lives here instead. It links to the failing run; the run's
+# own step summary carries the details.
+on:
+  workflow_run:
+    workflows:
+      - "Gitleaks Secret Scan"
+      - "TruffleHog Secrets Scan"
+      - "Python tests/coverage"
+      - "Python linting"
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  notify:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      # A real newline; `toJSON` below escapes it as `\n` in the payload.
+      NEWLINE: "\n"
+    steps:
+      - name: Send Slack notification for the failed run
+        uses: slackapi/slack-github-action@v3
+        with:
+          webhook: ${{ secrets.SLACK_NOTIFY_URL }}
+          webhook-type: incoming-webhook
+          # The branch name and run title come from the contributor's fork,
+          # so build the message with `format` and let `toJSON` emit it as a
+          # single, correctly escaped JSON string.
+          payload: |
+            {
+              "channel": "#soliplex",
+              "username": "soliplex",
+              "text": ${{ toJSON(format(':x: *{0}* failed on `{1}`:{4}{2}{4}{3}', github.event.workflow_run.name, github.event.workflow_run.head_branch, github.event.workflow_run.display_title, github.event.workflow_run.html_url, env.NEWLINE)) }},
+              "icon_emoji": ":ghost:"
+            }

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,9 +1,20 @@
 name: Gitleaks Secret Scan
 
+# The 'push' and 'pull_request' triggers deliberately overlap: 'push'
+# covers every branch (this repo uses release branches extensively), and
+# 'pull_request' adds fork-generated PRs, whose commits are never pushed to
+# this repository. A same-repo PR branch therefore scans twice; the scan is
+# cheap, so that is preferred over leaving fork PRs unscanned (#1203).
+#
+# 'pull_request' (never 'pull_request_target') is what makes this safe: the
+# job checks out untrusted code, so it must run without secrets and with a
+# read-only token. Do not add secrets to this workflow -- failure
+# notification lives in 'ci-failure-notify.yaml'.
 on:
   push:
     branches:
       - '**'
+  pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -27,29 +38,28 @@ jobs:
         with:
           args: detect --source=/github/workspace --config=/github/workspace/.gitleaks.toml --no-git --verbose --redact --report-format json --report-path /github/workspace/gitleaks-report.json
 
-      - name: Parse Gitleaks report
-        id: parse-report
+      # Slack notification lives in 'ci-failure-notify.yaml', which only
+      # links to this run (see #1203), so record the findings here. The
+      # report is generated with '--redact', and only the location fields
+      # are surfaced, so no secret material reaches the summary.
+      - name: Summarize Gitleaks findings
         if: steps.gitleaks.outcome == 'failure'
         run: |
-          if [ -f gitleaks-report.json ]; then
-            FILES=$(jq -r '[.[].File] | unique | .[]' gitleaks-report.json | head -10 | tr '\n' ', ' | sed 's/,$//')
-            echo "matched_files=$FILES" >> $GITHUB_OUTPUT
-          else
-            echo "matched_files=unknown" >> $GITHUB_OUTPUT
-          fi
+          {
+            echo "## Gitleaks: potential secrets detected"
+            echo
+            if [ -f gitleaks-report.json ]; then
+              echo "| File | Rule | Line |"
+              echo "| --- | --- | --- |"
+              jq -r '.[0:50][] | "| \(.File) | \(.RuleID) | \(.StartLine) |"' \
+                gitleaks-report.json
+              echo
+              echo "Total findings: $(jq -r 'length' gitleaks-report.json)"
+            else
+              echo "No report file was produced; see the job log."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if secrets found
         if: steps.gitleaks.outcome == 'failure'
         run: exit 1
-
-      - name: Notify Slack on failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFY_URL }}
-          SLACK_CHANNEL: soliplex
-          SLACK_USERNAME: gitleaks-ci
-          SLACK_ICON_EMOJI: ':rotating_light:'
-          SLACK_COLOR: danger
-          SLACK_TITLE: Gitleaks Secret Scan Failed
-          SLACK_MESSAGE: 'Potential secrets detected on ${{ github.ref_name }} in: ${{ steps.parse-report.outputs.matched_files }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n $GITHUB_OUTPUT'

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -45,21 +45,32 @@ jobs:
         run: uv sync --frozen --group dev
 
       - name: Check formatting
-        run: uv run ruff format --check
+        run: |
+          set -o pipefail
+          uv run ruff format --check 2>&1 | tee ruff-format.log
 
       - name: Run ruff linter
-        run: uv run ruff check
+        run: |
+          set -o pipefail
+          uv run ruff check 2>&1 | tee ruff-check.log
 
-      - name: Notify Slack on failure
+      # Slack notification lives in 'ci-failure-notify.yaml', which only
+      # links to this run (see #1203), so record what failed here.
+      - name: Summarize failures
         if: failure()
-        uses: slackapi/slack-github-action@v3
-        with:
-          webhook: ${{ secrets.SLACK_NOTIFY_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "channel": "#soliplex",
-              "username": "soliplex",
-              "text": ":x: ${{ github.workflow }} failed on ${{ github.head_ref }}:\n${{ github.event.head_commit.message }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "icon_emoji": ":ghost:"
-            }
+        run: |
+          {
+            echo "## Linting failed"
+            echo
+            for log in ruff-format.log ruff-check.log; do
+              [ -f "$log" ] || continue
+              echo "<details><summary>$log</summary>"
+              echo
+              echo '```'
+              tail -n 100 "$log"
+              echo '```'
+              echo
+              echo "</details>"
+              echo
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -52,24 +52,37 @@ jobs:
       # runners have few cores, so 'auto' is portable here (locally, '-n 8'
       # on a 16-core box is faster -- see README "Running tests").
       - name: Run unit tests with coverage
-        run: uv run py.test -s -n auto ${{ matrix.pytest-args }}
+        run: |
+          set -o pipefail
+          uv run py.test -s -n auto ${{ matrix.pytest-args }} 2>&1 \
+            | tee unit-tests.log
 
       # Functional tests run serially: they share on-disk state (e.g. the
       # 'sandbox/workdirs' tree, keyed by a constant room id) and
       # module-scoped app fixtures, so xdist workers race each other.
       - name: Run functional tests
-        run: uv run py.test -s --no-cov -m "not needs_llm" tests/functional/
+        run: |
+          set -o pipefail
+          uv run py.test -s --no-cov -m "not needs_llm" tests/functional/ 2>&1 \
+            | tee functional-tests.log
 
-      - name: Notify Slack on failure
+      # Slack notification lives in 'ci-failure-notify.yaml', which only
+      # links to this run (see #1203), so record what failed here.
+      - name: Summarize failures
         if: failure()
-        uses: slackapi/slack-github-action@v3
-        with:
-          webhook: ${{ secrets.SLACK_NOTIFY_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "channel": "#soliplex",
-              "username": "soliplex",
-              "text": ":x: ${{ github.workflow }} failed on ${{ github.head_ref }}:\n${{ github.event.head_commit.message }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "icon_emoji": ":ghost:"
-            }
+        run: |
+          {
+            echo "## Python ${{ matrix.python-version }} failed"
+            echo
+            for log in unit-tests.log functional-tests.log; do
+              [ -f "$log" ] || continue
+              echo "<details><summary>$log (last 50 lines)</summary>"
+              echo
+              echo '```'
+              tail -n 50 "$log"
+              echo '```'
+              echo
+              echo "</details>"
+              echo
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -30,9 +30,48 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      # A push that creates a branch carries no usable base ('before' is all
+      # zeros), and the action then scans the whole repository history --
+      # failing CI on pre-existing commits rather than on the change under
+      # review (#1204). Pin the range explicitly instead.
+      #
+      # 'pull_request' and 'workflow_dispatch' skip this step, leaving both
+      # outputs empty: the pull-request path already scans just the diff,
+      # and a manual dispatch keeps the full-history scan for one-off audits.
+      - name: Determine push scan range
+        id: range
+        if: github.event_name == 'push'
+        env:
+          BEFORE: ${{ github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          SHA: ${{ github.sha }}
+        run: |
+          base="$BEFORE"
+          if [ -z "$base" ] \
+             || [ "$base" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            # Newly created branch: scan what it adds over the default.
+            base="origin/$DEFAULT_BRANCH"
+          fi
+          base_sha="$(git rev-parse --verify --quiet "${base}^{commit}" || true)"
+          head_sha="$(git rev-parse --verify "${SHA}^{commit}")"
+          if [ -z "$base_sha" ]; then
+            echo "Could not resolve '$base'; leaving the range unset."
+          elif [ "$base_sha" = "$head_sha" ]; then
+            echo "No new commits relative to '$base'; skipping the scan."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Scanning ${base_sha}..${head_sha}"
+            echo "base=$base_sha" >> "$GITHUB_OUTPUT"
+            echo "head=$head_sha" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: TruffleHog scan
+        if: steps.range.outputs.skip != 'true'
         uses: trufflesecurity/trufflehog@main
         with:
+          base: ${{ steps.range.outputs.base }}
+          head: ${{ steps.range.outputs.head }}
           extra_args: --only-verified
 
       # Slack notification lives in 'ci-failure-notify.yaml', which only

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -1,9 +1,20 @@
 name: TruffleHog Secrets Scan
 
+# The 'push' and 'pull_request' triggers deliberately overlap: 'push'
+# covers every branch (this repo uses release branches extensively), and
+# 'pull_request' adds fork-generated PRs, whose commits are never pushed to
+# this repository. A same-repo PR branch therefore scans twice; the scan is
+# cheap, so that is preferred over leaving fork PRs unscanned (#1203).
+#
+# 'pull_request' (never 'pull_request_target') is what makes this safe: the
+# job checks out untrusted code, so it must run without secrets and with a
+# read-only token. Do not add secrets to this workflow -- failure
+# notification lives in 'ci-failure-notify.yaml'.
 on:
   push:
     branches:
       - '**'
+  pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -24,21 +35,16 @@ jobs:
         with:
           extra_args: --only-verified
 
-  notify-failure:
-    runs-on: ubuntu-latest
-    needs: [trufflehog]
-    if: failure()
-    timeout-minutes: 2
-    steps:
-      - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v3
-        with:
-          webhook: ${{ secrets.SLACK_NOTIFY_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "channel": "#soliplex",
-              "username": "soliplex",
-              "text": ":rotating_light: ${{ github.workflow }} failed on ${{ github.head_ref || github.ref_name }}:\n${{ github.event.head_commit.message }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "icon_emoji": ":ghost:"
-            }
+      # Slack notification lives in 'ci-failure-notify.yaml', which only
+      # links to this run (see #1203). The action reports its findings to
+      # stdout rather than to a file we control, so point at the step log
+      # instead of restating the detectors here.
+      - name: Summarize TruffleHog findings
+        if: failure()
+        run: |
+          {
+            echo "## TruffleHog: verified secrets detected"
+            echo
+            echo "See the **TruffleHog scan** step log in this run for the"
+            echo "matched detectors and their locations."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -66,13 +66,24 @@ jobs:
             echo "head=$head_sha" >> "$GITHUB_OUTPUT"
           fi
 
+      # 'lob' is excluded because its detector reports this project's pytest
+      # function names as verified credentials: a Lob key is '(live|test)_'
+      # plus 35 characters with no entropy check, so any 40-character
+      # 'test_*' identifier matches, and the detector counts HTTP 422/403 as
+      # successful verification. An audit of the full history found 67 such
+      # hits, all in 'tests/unit/**' and all pytest function names; excluding
+      # the detector leaves zero findings, so nothing real is suppressed.
+      # This project has no Lob integration.
+      #
+      # Upstream: trufflesecurity/trufflehog#5184 (duplicated by #5187).
+      # Both were open as of 2026-08-07; drop this flag once they are fixed.
       - name: TruffleHog scan
         if: steps.range.outputs.skip != 'true'
         uses: trufflesecurity/trufflehog@main
         with:
           base: ${{ steps.range.outputs.base }}
           head: ${{ steps.range.outputs.head }}
-          extra_args: --only-verified
+          extra_args: --only-verified --exclude-detectors=lob
 
       # Slack notification lives in 'ci-failure-notify.yaml', which only
       # links to this run (see #1203). The action reports its findings to


### PR DESCRIPTION
Workflow actions which check out potentially-untrusted code (e.g., from fork-generated PRs) must not have access to the 'SLACK_NOTIFY_URL' secret:  therefore, delegate slack notification to a new action, triggered by 'workflow' run and filtering on 'failure'.  That workflow does *not* see untrusted code.

Closes #1203.