### PR TITLE
refactor: 'config.rag.RAGConfigProtocol'

### DIFF
--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -1,7 +1,9 @@
 from __future__ import annotations  # forward refs in typing decls
 
+import abc
 import dataclasses
 import pathlib
+import typing
 
 from haiku.rag import config as hr_config
 
@@ -37,6 +39,23 @@ class RagDbFileNotFound(ValueError):
             f"RAG DB file not found: {rag_db_filename} "
             f"(configured in {_config_path})"
         )
+
+
+@typing.runtime_checkable
+class RAGConfigProtocol(typing.Protocol):
+    """Expose a single haiku-rag configuration and lancedb path"""
+
+    @property
+    @abc.abstractmethod
+    def haiku_rag_config(self) -> hr_config.AppConfig:
+        """Populate a haiku-rag config object w/ room-level overrides"""
+        ...
+
+    @property
+    @abc.abstractmethod
+    def rag_lancedb_path(self) -> pathlib.Path:
+        """Compute the path for the room's RAG rag_lancedb_path database"""
+        ...
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/src/soliplex/config/rooms.py
+++ b/src/soliplex/config/rooms.py
@@ -8,6 +8,7 @@ from . import _utils
 from . import agents as config_agents
 from . import exceptions as config_exc
 from . import quizzes as config_quizzes
+from . import rag as config_rag
 from . import skills as config_skills
 from . import tools as config_tools
 
@@ -279,9 +280,8 @@ class RoomConfig:
         )
 
         for source, cfg in candidates:
-            hr_config = getattr(cfg, "haiku_rag_config", None)
-
-            if hr_config is not None:
+            if isinstance(cfg, config_rag.RAGConfigProtocol):
+                hr_config = getattr(cfg, "haiku_rag_config", None)
                 hrc_kw = {
                     "db_path": cfg.rag_lancedb_path,
                     "config": hr_config,

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -99,6 +99,8 @@ def test__rcb_ctor(
         rcb_config = config_rag._RAGConfigBase(**kw)
 
     if isinstance(ctor_which, str):
+        assert isinstance(rcb_config, config_rag.RAGConfigProtocol)
+
         if ctor_which == "stem":
             expected = from_stem
         else:


### PR DESCRIPTION
  ... specifies that a config type has a 'haiku_rag_config' property,
  returning a single 'hr_config.AppConfig' instance, and an
  accompanying 'rag_lance_db_path' property.

  'config.room.RoomConfig.list_haiku_rag_client_kw' filters candidate
  configs using this protocol.

Closes #1206.