### PR TITLE
refactor: split "has HR config" vs "has a LanceDB" vs "has LanceDBs"

### DIFF
--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -43,13 +43,18 @@ class RagDbFileNotFound(ValueError):
 
 @typing.runtime_checkable
 class RAGConfigProtocol(typing.Protocol):
-    """Expose a single haiku-rag configuration and lancedb path"""
+    """Expose a haiku-rag configuration"""
 
     @property
     @abc.abstractmethod
     def haiku_rag_config(self) -> hr_config.AppConfig:
         """Populate a haiku-rag config object w/ room-level overrides"""
         ...
+
+
+@typing.runtime_checkable
+class SingleRAGDatabaseProtocol(typing.Protocol):
+    """Expose a single lancedb path"""
 
     @property
     @abc.abstractmethod
@@ -58,31 +63,28 @@ class RAGConfigProtocol(typing.Protocol):
         ...
 
 
+@typing.runtime_checkable
+class MultipleRAGDatabasesProtocol(typing.Protocol):
+    """Expose a list of lancedb paths"""
+
+    @property
+    @abc.abstractmethod
+    def rag_lancedb_paths(self) -> list[pathlib.Path]:
+        """Compute the paths for the room's RAG rag_lancedb_path databases"""
+        ...
+
+
 @dataclasses.dataclass(kw_only=True)
 class _RAGConfigBase:
-    # Set in '__post_init__' below
-    _rag_lancedb_path: pathlib.Path = None
+    """Base class for configs which expose a 'haiku_rag_config' property"""
 
-    # One of these two options must be specified
-    rag_lancedb_stem: str = None
-    rag_lancedb_override_path: str = None
+    _haiku_rag_config: hr_config.AppConfig | None = None
 
     # Normally set via subclass 'from_yaml'
     _installation_config: InstallationConfig = (  # noqa F821 cycle
         _utils._no_repr_no_compare_none()
     )
     _config_path: pathlib.Path = None
-    _haiku_rag_config: hr_config.AppConfig | None = None
-
-    def __post_init__(self):
-        exclusive_required = [
-            self.rag_lancedb_stem,
-            self.rag_lancedb_override_path,
-        ]
-        passed = list(filter(None, exclusive_required))
-
-        if len(list(passed)) != 1:
-            raise RagDbExactlyOneOfStemOrOverride(self._config_path)
 
     @property
     def haiku_rag_config(self) -> hr_config.AppConfig:
@@ -116,9 +118,34 @@ class _RAGConfigBase:
 
         return self._haiku_rag_config
 
+
+@dataclasses.dataclass(kw_only=True)
+class _RAGDatabaseBase:
+    """Base class for configs which expose a 'rag_lancedb_path' property"""
+
+    # One of these two options must be specified
+    rag_lancedb_stem: str = None
+    rag_lancedb_override_path: str = None
+
+    # Normally set via subclass 'from_yaml'
+    _installation_config: InstallationConfig = (  # noqa F821 cycle
+        _utils._no_repr_no_compare_none()
+    )
+    _config_path: pathlib.Path = None
+
+    def __post_init__(self):
+        exclusive_required = [
+            self.rag_lancedb_stem,
+            self.rag_lancedb_override_path,
+        ]
+        passed = list(filter(None, exclusive_required))
+
+        if len(list(passed)) != 1:
+            raise RagDbExactlyOneOfStemOrOverride(self._config_path)
+
     @property
     def rag_lancedb_path(self) -> pathlib.Path:
-        """Compute the path for the room's RAG rag_lancedb_path database"""
+        """Compute the path for the database"""
         if self.rag_lancedb_override_path is not None:
             rsop = self.rag_lancedb_override_path
 
@@ -153,3 +180,14 @@ class _RAGConfigBase:
         return {
             "rag_lancedb_path": rag_lancedb_path,
         }
+
+
+@dataclasses.dataclass(kw_only=True)
+class _MultiRAGDatabasesBase:
+    """Base class for configs which expose a 'rag_lancedb_paths' property"""
+
+    db_configs: list[SingleRAGDatabaseProtocol] = _utils._default_list_field()
+
+    @property
+    def rag_lancedb_paths(self):
+        return [cfg.rag_lancedb_path for cfg in self.db_configs]

--- a/src/soliplex/config/rooms.py
+++ b/src/soliplex/config/rooms.py
@@ -281,16 +281,28 @@ class RoomConfig:
 
         for source, cfg in candidates:
             if isinstance(cfg, config_rag.RAGConfigProtocol):
-                hrc_kw = {
-                    "db_path": cfg.rag_lancedb_path,
-                    "config": cfg.haiku_rag_config,
-                    "read_only": True,
-                }
+                haiku_rag_config = cfg.haiku_rag_config
 
-                if include_source:
-                    hrc_kw["source"] = source
+                if isinstance(cfg, config_rag.SingleRAGDatabaseProtocol):
+                    rag_lancedb_paths = [cfg.rag_lancedb_path]
+                elif isinstance(
+                    cfg, config_rag.MultipleRAGDatabasesProtocol
+                ):  # pragma: NO COVER
+                    rag_lancedb_paths = cfg.rag_lancedb_paths
+                else:  # pragma: NO COVER
+                    rag_lancedb_path = ()
 
-                yield hrc_kw
+                for rag_lancedb_path in rag_lancedb_paths:
+                    hrc_kw = {
+                        "db_path": rag_lancedb_path,
+                        "config": haiku_rag_config,
+                        "read_only": True,
+                    }
+
+                    if include_source:
+                        hrc_kw["source"] = source
+
+                    yield hrc_kw
 
 
 RoomConfigMap = dict[str, RoomConfig]

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -192,7 +192,10 @@ class FilesystemSkillConfig:
 
 
 @dataclasses.dataclass(kw_only=True)
-class _HaikuRAGCapabilityConfig(config_rag._RAGConfigBase):
+class _HaikuRAGCapabilityConfig(
+    config_rag._RAGConfigBase,
+    config_rag._RAGDatabaseBase,
+):
     capability_factory: typing.ClassVar[typing.Callable]
     capability_name: typing.ClassVar[str]
     description: typing.ClassVar[str]

--- a/src/soliplex/config/tools.py
+++ b/src/soliplex/config/tools.py
@@ -314,7 +314,11 @@ _, SDTC_TOOL_KIND = SDTC_TOOL_NAME.rsplit(".", 1)
 
 
 @dataclasses.dataclass(kw_only=True)
-class SearchDocumentsToolConfig(ToolConfig, config_rag._RAGConfigBase):
+class SearchDocumentsToolConfig(
+    ToolConfig,
+    config_rag._RAGConfigBase,
+    config_rag._RAGDatabaseBase,
+):
     kind: str = SDTC_TOOL_KIND
     tool_name: str = SDTC_TOOL_NAME
 
@@ -362,7 +366,7 @@ class SearchDocumentsToolConfig(ToolConfig, config_rag._RAGConfigBase):
         }
         return (
             super().get_extra_parameters()
-            | config_rag._RAGConfigBase.get_extra_parameters(self)
+            | config_rag._RAGDatabaseBase.get_extra_parameters(self)
             | local
         )
 

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -42,88 +42,6 @@ def test__deep_merge(base, derived, expected):
 
 
 @pytest.mark.parametrize(
-    "w_config_path, stem, override, ctor_expectation, rlp_expectation",
-    [
-        (False, None, None, rdb_exactly_one, None),
-        (False, "testing", "/dev/null", rdb_exactly_one, None),
-        (False, "bogus", None, ok_stem, rdb_not_found),
-        (False, "testing", None, ok_stem, ok_stem),
-        (False, None, "./override", ok_ovr, rdb_not_found),
-        (True, None, "./override", ok_ovr, ok_ovr),
-    ],
-)
-def test__rcb_ctor(
-    installation_config,
-    temp_dir,
-    w_config_path,
-    stem,
-    override,
-    ctor_expectation,
-    rlp_expectation,
-):
-    db_rag_path = temp_dir / "db" / "rag"
-    db_rag_path.mkdir(parents=True)
-
-    if stem not in (None, "bogus"):
-        from_stem = db_rag_path / f"{stem}.lancedb"
-        from_stem.mkdir()
-    else:
-        from_stem = None
-
-    if override is not None:
-        from_override = temp_dir / "rooms" / "test" / override
-        if not from_override.exists():
-            from_override.mkdir(parents=True)
-    else:
-        from_override = None
-
-    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
-    installation_config.get_environment = ic_environ.get
-
-    kw = {"_installation_config": installation_config}
-
-    if w_config_path:
-        exp_config_path = kw["_config_path"] = (
-            temp_dir / "rooms" / "test" / "room_config.yaml"
-        )
-    else:
-        exp_config_path = None
-
-    if stem is not None:
-        kw["rag_lancedb_stem"] = stem
-
-    if override is not None:
-        kw["rag_lancedb_override_path"] = override
-
-    with ctor_expectation as ctor_which:
-        rcb_config = config_rag._RAGConfigBase(**kw)
-
-    if isinstance(ctor_which, str):
-        assert isinstance(rcb_config, config_rag.RAGConfigProtocol)
-
-        if ctor_which == "stem":
-            expected = from_stem
-        else:
-            expected = from_override
-
-        assert rcb_config._config_path == exp_config_path
-
-        with rlp_expectation as rlp_which:
-            found = rcb_config.rag_lancedb_path
-
-        if isinstance(rlp_which, str):
-            assert found.resolve() == expected.resolve()
-
-            expected_ep = {
-                "rag_lancedb_path": expected.resolve(),
-            }
-            assert rcb_config.get_extra_parameters() == expected_ep
-        else:
-            w_missing = rcb_config.get_extra_parameters()
-            assert w_missing["rag_lancedb_path"].startswith("MISSING:")
-
-
-@pytest.mark.parametrize(
     "w_already, w_config_path, w_hr_yaml",
     [
         (False, False, {}),
@@ -159,10 +77,8 @@ def test__rcb_haiku_rag_config(
         with hr_config_path.open("w") as stream:
             yaml.safe_dump(w_hr_yaml, stream)
 
-    kw = {
-        "rag_lancedb_stem": "stem",
-        "_installation_config": installation_config,
-    }
+    kw = {"_installation_config": installation_config}
+
     if w_already:
         kw["_haiku_rag_config"] = already
 
@@ -173,6 +89,7 @@ def test__rcb_haiku_rag_config(
         exp_room_config_path = None
 
     rcb_config = config_rag._RAGConfigBase(**kw)
+    assert isinstance(rcb_config, config_rag.RAGConfigProtocol)
 
     if w_already:
         assert rcb_config.haiku_rag_config is already
@@ -196,3 +113,110 @@ def test__rcb_haiku_rag_config(
         else:
             with no_config_path:
                 _ = rcb_config.haiku_rag_config
+
+
+@pytest.fixture
+def db_rag_path(temp_dir):
+    result = temp_dir / "db" / "rag"
+    result.mkdir(parents=True)
+    return result
+
+
+@pytest.mark.parametrize(
+    "w_config_path, stem, override, ctor_expectation, rlp_expectation",
+    [
+        (False, None, None, rdb_exactly_one, None),
+        (False, "testing", "/dev/null", rdb_exactly_one, None),
+        (False, "bogus", None, ok_stem, rdb_not_found),
+        (False, "testing", None, ok_stem, ok_stem),
+        (False, None, "./override", ok_ovr, rdb_not_found),
+        (True, None, "./override", ok_ovr, ok_ovr),
+    ],
+)
+def test__rdb_ctor(
+    installation_config,
+    temp_dir,
+    db_rag_path,
+    w_config_path,
+    stem,
+    override,
+    ctor_expectation,
+    rlp_expectation,
+):
+    if stem not in (None, "bogus"):
+        from_stem = db_rag_path / f"{stem}.lancedb"
+        from_stem.mkdir()
+    else:
+        from_stem = None
+
+    if override is not None:
+        from_override = temp_dir / "rooms" / "test" / override
+        if not from_override.exists():
+            from_override.mkdir(parents=True)
+    else:
+        from_override = None
+
+    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
+    installation_config.get_environment = ic_environ.get
+
+    kw = {"_installation_config": installation_config}
+
+    if w_config_path:
+        exp_config_path = kw["_config_path"] = (
+            temp_dir / "rooms" / "test" / "room_config.yaml"
+        )
+    else:
+        exp_config_path = None
+
+    if stem is not None:
+        kw["rag_lancedb_stem"] = stem
+
+    if override is not None:
+        kw["rag_lancedb_override_path"] = override
+
+    with ctor_expectation as ctor_which:
+        rdb_config = config_rag._RAGDatabaseBase(**kw)
+
+    if isinstance(ctor_which, str):
+        assert isinstance(rdb_config, config_rag.SingleRAGDatabaseProtocol)
+
+        if ctor_which == "stem":
+            expected = from_stem
+        else:
+            expected = from_override
+
+        assert rdb_config._config_path == exp_config_path
+
+        with rlp_expectation as rlp_which:
+            found = rdb_config.rag_lancedb_path
+
+        if isinstance(rlp_which, str):
+            assert found.resolve() == expected.resolve()
+
+            expected_ep = {
+                "rag_lancedb_path": expected.resolve(),
+            }
+            assert rdb_config.get_extra_parameters() == expected_ep
+        else:
+            w_missing = rdb_config.get_extra_parameters()
+            assert w_missing["rag_lancedb_path"].startswith("MISSING:")
+
+
+def test__mrdb_ctor_wo_db_configs():
+    mrdb_config = config_rag._MultiRAGDatabasesBase()
+
+    assert isinstance(mrdb_config, config_rag.MultipleRAGDatabasesProtocol)
+    assert mrdb_config.rag_lancedb_paths == []
+
+
+def test__mrdb_ctor_w_db_configs(db_rag_path):
+    db_override_path = db_rag_path / "test.lancedb"
+    db_override_path.mkdir()
+
+    db_config = config_rag._RAGDatabaseBase(
+        rag_lancedb_override_path=db_override_path,
+    )
+    mrdb_config = config_rag._MultiRAGDatabasesBase(db_configs=[db_config])
+
+    assert isinstance(mrdb_config, config_rag.MultipleRAGDatabasesProtocol)
+    assert mrdb_config.rag_lancedb_paths == [db_override_path]


### PR DESCRIPTION
- 'config.rag.RAGConfigProtocol' maps to configs with a 'haiku_rag_config' property.

- (new) 'config.rag.SingleRAGDatabaseProtocol' maps to configs with a 'rag_lancedb_path' property, yielding a single path.

- (new) 'config.rag.MultipleRAGDatabasesProtocol' maps to configs with a 'rag_lancedb_paths' property, yielding list of paths.

- 'config.rag._RAGConfigBase' implements 'RAGConfigProtocol' using 'haiku_rag_path'.

- 'config.rag._RAGDatabaseBase' implements 'SingleRAGDatabaseProtocol' using 'rag_lancedb_stem' xor 'rag_lancedb_override_path'.

- 'config.rag._MultiRAGDatabasesBase' implements 'MulitpleRAGDatabasesProtocol', holding a list of configs which implement 'SingleRAGDatabaseProtocol' and returning a list of their paths.

- 'config.room.Roomconfig.list_haiku_rag_client_kw' distinguishes candidates who implement 'SingleRAGDatabaseProtocol' from those who implement 'MultipleRAGDatabasesProtocol', and builds the list of databases accordingly (coverage omitted until we build the new configs which implement 'MultipleRAGDatabasesProtocol').

Closes #1207.