### PR TITLE
refactor: '*SecretSource.from_yaml' accepts 'kind'

### DIFF
--- a/src/soliplex/config/secrets.py
+++ b/src/soliplex/config/secrets.py
@@ -6,6 +6,7 @@ import re
 import typing
 
 from . import _utils
+from . import exceptions as config_exc
 
 _no_repr_no_compare_none = _utils._no_repr_no_compare_none
 
@@ -29,6 +30,16 @@ class NotASecret(ValueError):
         )
 
 
+class SecretSourceKindMismatch(ValueError):
+    def __init__(self, found_kind, expected_kind):
+        self.found_kind = found_kind
+        self.expected_kind = expected_kind
+        super().__init__(
+            "Secret source kind mismatch: "
+            f"found '{found_kind}', expected '{expected_kind}'"
+        )
+
+
 def strip_secret_prefix(config_str: str) -> str:
     if not config_str.startswith(SECRET_PREFIX):
         raise NotASecret(config_str)
@@ -38,9 +49,24 @@ def strip_secret_prefix(config_str: str) -> str:
 
 class _BaseSecretSource:
     @classmethod
+    def _check_kind(cls, kind):
+        if kind not in (None, cls.kind):
+            raise SecretSourceKindMismatch(kind, cls.kind)
+
+    @classmethod
     def from_yaml(cls, config_path: pathlib.Path, config_dict: dict):
-        config_dict["_config_path"] = config_path
-        return cls(**config_dict)
+        try:
+            kind = config_dict.pop("kind", None)
+            cls._check_kind(kind)
+            config_dict["_config_path"] = config_path
+            return cls(**config_dict)
+
+        except Exception as exc:
+            raise config_exc.FromYamlException(
+                config_path,
+                f"secret_source:{cls.kind}",
+                config_dict,
+            ) from exc
 
     @property
     def as_yaml(self) -> dict:
@@ -56,7 +82,12 @@ class EnvVarSecretSource(_BaseSecretSource):
     kind: typing.ClassVar[str] = "env_var"
     secret_name: str
     env_var_name: str | None = None
+
+    # Set in '_BaseSecretSource.from_yaml' above
     _config_path: pathlib.Path = None
+
+    # Set by `InstallationConfig.__post_init__`, because the IC instance
+    # does not exist yet when our `from_yaml` is called.
     _installation_config: InstallationConfig = (  # noqa F821 cycles
         _no_repr_no_compare_none()
     )
@@ -75,7 +106,12 @@ class FilePathSecretSource(_BaseSecretSource):
     kind: typing.ClassVar[str] = "file_path"
     secret_name: str
     file_path: str
+
+    # Set in '_BaseSecretSource.from_yaml' above
     _config_path: pathlib.Path = None
+
+    # Set by `InstallationConfig.__post_init__`, because the IC instance
+    # does not exist yet when our `from_yaml` is called.
     _installation_config: InstallationConfig = (  # noqa F821 cycles
         _no_repr_no_compare_none()
     )
@@ -91,7 +127,12 @@ class SubprocessSecretSource(_BaseSecretSource):
     secret_name: str
     command: str
     args: list[str] | tuple[str] = ()
+
+    # Set in '_BaseSecretSource.from_yaml' above
     _config_path: pathlib.Path = None
+
+    # Set by `InstallationConfig.__post_init__`, because the IC instance
+    # does not exist yet when our `from_yaml` is called.
     _installation_config: InstallationConfig = (  # noqa F821 cycles
         _no_repr_no_compare_none()
     )
@@ -120,7 +161,12 @@ class RandomCharsSecretSource(_BaseSecretSource):
     kind: typing.ClassVar[str] = "random_chars"
     secret_name: str
     n_chars: int = 32
+
+    # Set in '_BaseSecretSource.from_yaml' above
     _config_path: pathlib.Path = None
+
+    # Set by `InstallationConfig.__post_init__`, because the IC instance
+    # does not exist yet when our `from_yaml` is called.
     _installation_config: InstallationConfig = (  # noqa F821 cycles
         _no_repr_no_compare_none()
     )
@@ -159,9 +205,14 @@ class SecretConfig:
 
     # Set in 'from_yaml' below
     _config_path: pathlib.Path = None
+
+    # Set by `InstallationConfig.__post_init__`, because the IC instance
+    # does not exist yet when our `from_yaml` is called.
     _installation_config: InstallationConfig = (  # noqa F821 cycles
         _no_repr_no_compare_none()
     )
+
+    # Set by 'soliplex.secrets.get_secret'
     _resolved: str = None
 
     def __post_init__(self):
@@ -187,7 +238,7 @@ class SecretConfig:
 
         for source_config in source_configs:
             source_config["secret_name"] = config_dict["secret_name"]
-            source_kind = source_config.pop("kind")
+            source_kind = source_config.get("kind")
             source_klass = SourceClassesByKind[source_kind]
             source_inst = source_klass.from_yaml(config_path, source_config)
             sources.append(source_inst)

--- a/tests/unit/config/test_config_secrets.py
+++ b/tests/unit/config/test_config_secrets.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 
+from soliplex.config import exceptions as config_exc
 from soliplex.config import secrets as config_secrets
 
 NoRaise = contextlib.nullcontext()
@@ -32,24 +33,45 @@ def test_envvarsecretsource_ctor(w_params, exp_env_var_name):
     assert source.extra_arguments == {"env_var_name": exp_env_var_name}
 
 
+@pytest.mark.parametrize(
+    "w_kind_kw, expectation",
+    [
+        ({}, contextlib.nullcontext()),
+        (
+            {"kind": config_secrets.EnvVarSecretSource.kind},
+            contextlib.nullcontext(),
+        ),
+        (
+            {"kind": "BOGUS"},
+            pytest.raises(config_exc.FromYamlException),
+        ),
+    ],
+)
 @pytest.mark.parametrize("yaml_config", [{}, {"env_var_name": ENV_VAR_NAME}])
-def test_envvarsecretsource_from_yaml(temp_dir, yaml_config):
+def test_envvarsecretsource_from_yaml(
+    temp_dir,
+    yaml_config,
+    w_kind_kw,
+    expectation,
+):
     config_path = temp_dir / "installation.yaml"
     yaml_config["secret_name"] = SECRET_NAME
 
-    source = config_secrets.EnvVarSecretSource.from_yaml(
-        config_path, yaml_config
-    )
+    with expectation as expected:
+        source = config_secrets.EnvVarSecretSource.from_yaml(
+            config_path, yaml_config | w_kind_kw
+        )
 
-    assert source._config_path == config_path
-    assert source.secret_name == SECRET_NAME
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert source._config_path == config_path
+        assert source.secret_name == SECRET_NAME
 
-    exp_env_var_name = (
-        ENV_VAR_NAME if "env_var_name" in yaml_config else SECRET_NAME
-    )
+        exp_env_var_name = (
+            ENV_VAR_NAME if "env_var_name" in yaml_config else SECRET_NAME
+        )
 
-    assert source.env_var_name == exp_env_var_name
-    assert source.extra_arguments == {"env_var_name": exp_env_var_name}
+        assert source.env_var_name == exp_env_var_name
+        assert source.extra_arguments == {"env_var_name": exp_env_var_name}
 
 
 @pytest.mark.parametrize("has_ev", [False, True])
@@ -72,19 +94,40 @@ def test_envvarsecretsource_as_yaml(has_ev):
     assert found == expected
 
 
+@pytest.mark.parametrize(
+    "w_kind_kw, expectation",
+    [
+        ({}, contextlib.nullcontext()),
+        (
+            {"kind": config_secrets.FilePathSecretSource.kind},
+            contextlib.nullcontext(),
+        ),
+        (
+            {"kind": "BOGUS"},
+            pytest.raises(config_exc.FromYamlException),
+        ),
+    ],
+)
 @pytest.mark.parametrize("file_path", ["/path/to/file", "./file"])
-def test_filepathsecretsource_from_yaml(temp_dir, file_path):
+def test_filepathsecretsource_from_yaml(
+    temp_dir,
+    file_path,
+    w_kind_kw,
+    expectation,
+):
     config_path = temp_dir / "installation.yaml"
     yaml_config = {"secret_name": SECRET_NAME, "file_path": file_path}
 
-    source = config_secrets.FilePathSecretSource.from_yaml(
-        config_path, yaml_config
-    )
+    with expectation as expected:
+        source = config_secrets.FilePathSecretSource.from_yaml(
+            config_path, yaml_config | w_kind_kw
+        )
 
-    assert source._config_path == config_path
-    assert source.secret_name == SECRET_NAME
-    assert source.file_path == file_path
-    assert source.extra_arguments == {"file_path": file_path}
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert source._config_path == config_path
+        assert source.secret_name == SECRET_NAME
+        assert source.file_path == file_path
+        assert source.extra_arguments == {"file_path": file_path}
 
 
 def test_filepathsecretsource_as_yaml():
@@ -107,20 +150,55 @@ def test_filepathsecretsource_as_yaml():
 
 
 @pytest.mark.parametrize(
-    "w_args, exp_command_line",
+    "w_kind_kw, expectation",
     [
-        ((), COMMAND),
-        (["-a", "foo"], f"{COMMAND} -a foo"),
+        ({}, contextlib.nullcontext()),
+        (
+            {"kind": config_secrets.SubprocessSecretSource.kind},
+            contextlib.nullcontext(),
+        ),
+        (
+            {"kind": "BOGUS"},
+            pytest.raises(config_exc.FromYamlException),
+        ),
     ],
 )
-def test_subprocess_secret_source_command_line(w_args, exp_command_line):
-    source = config_secrets.SubprocessSecretSource(
-        secret_name=SECRET_NAME,
-        command=COMMAND,
-        args=w_args,
-    )
-    assert source.command_line == exp_command_line
-    assert source.extra_arguments == {"command_line": exp_command_line}
+@pytest.mark.parametrize(
+    "command, args",
+    [
+        ("/bin/true", ()),
+        ("/bin/ls", ("-laF",)),
+    ],
+)
+def test_subprocesssecretsource_from_yaml(
+    temp_dir,
+    command,
+    args,
+    w_kind_kw,
+    expectation,
+):
+    config_path = temp_dir / "installation.yaml"
+    yaml_config = {"secret_name": SECRET_NAME, "command": command}
+
+    if args:
+        exp_args = yaml_config["args"] = args
+        exp_command_line = f"{command} {' '.join(args)}"
+    else:
+        exp_args = ()
+        exp_command_line = command
+
+    with expectation as expected:
+        source = config_secrets.SubprocessSecretSource.from_yaml(
+            config_path,
+            yaml_config | w_kind_kw,
+        )
+
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert source._config_path == config_path
+        assert source.secret_name == SECRET_NAME
+        assert source.command == command
+        assert source.args == exp_args
+        assert source.extra_arguments == {"command_line": exp_command_line}
 
 
 @pytest.mark.parametrize(
@@ -152,18 +230,47 @@ def test_subprocesssecretsource_as_yaml(w_args):
 
 
 @pytest.mark.parametrize(
+    "w_kind_kw, expectation",
+    [
+        ({}, contextlib.nullcontext()),
+        (
+            {"kind": config_secrets.RandomCharsSecretSource.kind},
+            contextlib.nullcontext(),
+        ),
+        (
+            {"kind": "BOGUS"},
+            pytest.raises(config_exc.FromYamlException),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
     "kwargs, exp_nc",
     [
         ({}, 32),
         ({"n_chars": 17}, 17),
     ],
 )
-def test_randomcharssecretsource_extra_args(kwargs, exp_nc):
-    source = config_secrets.RandomCharsSecretSource(
-        secret_name=SECRET_NAME, **kwargs
-    )
+def test_randomsharssecretsource_from_yaml(
+    temp_dir,
+    kwargs,
+    exp_nc,
+    w_kind_kw,
+    expectation,
+):
+    config_path = temp_dir / "installation.yaml"
+    yaml_config = {"secret_name": SECRET_NAME} | kwargs
 
-    assert source.extra_arguments == {"n_chars": exp_nc}
+    with expectation as expected:
+        source = config_secrets.RandomCharsSecretSource.from_yaml(
+            config_path,
+            yaml_config | w_kind_kw,
+        )
+
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert source._config_path == config_path
+        assert source.secret_name == SECRET_NAME
+        assert source.n_chars == exp_nc
+        assert source.extra_arguments == {"n_chars": exp_nc}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If present, checks against the class-defined value.

Document how '_installation_config'/'_config_path' are set

Closes #1217.