### PR TITLE
refactor: 'config.routing.{Add,Delete,Clear}AppRouter{,s}.from_yaml'

### DIFF
--- a/src/soliplex/config/installation.py
+++ b/src/soliplex/config/installation.py
@@ -857,13 +857,14 @@ class InstallationConfig:
                 for mwc_yaml in config_dict.get("middleware_stack", ())
             ]
 
-            config_dict["app_router_operations"] = [
-                config_routing.app_router_operation_from_yaml(
-                    config_path,
-                    ar_yaml,
-                )
-                for ar_yaml in config_dict.get("app_router_operations", ())
-            ]
+            aro_klasses_by_kind = config_routing.APP_ROUTER_OPERATIONS_BY_KIND
+            aros, aros_cfg = config_dict.pop("app_router_operations", []), []
+
+            for aro in aros:
+                klass = aro_klasses_by_kind[aro["kind"]]
+                aros_cfg.append(klass.from_yaml(aro, config_path))
+
+            config_dict["app_router_operations"] = aros_cfg
 
             secret_configs = [
                 config_secrets.SecretConfig.from_yaml(

--- a/src/soliplex/config/routing.py
+++ b/src/soliplex/config/routing.py
@@ -30,6 +30,16 @@ class UnknownAppRoutingGroup(KeyError):
         )
 
 
+class AppRouterOperationKindMismatch(ValueError):
+    def __init__(self, found_kind, expected_kind):
+        self.found_kind = found_kind
+        self.expected_kind = expected_kind
+        super().__init__(
+            "App router operation kind mismatch: "
+            f"found '{found_kind}', expected '{expected_kind}'"
+        )
+
+
 @dataclasses.dataclass(kw_only=True)
 class APIRouterKwargs:
     prefix: str | None = "/api"
@@ -60,6 +70,25 @@ class _AppRouterOperationBase:
     kind: typing.ClassVar[str]
     group_name: str
 
+    @classmethod
+    def _check_kind(cls, kind):
+        if kind not in (None, cls.kind):
+            raise AppRouterOperationKindMismatch(kind, cls.kind)
+
+    @classmethod
+    def from_yaml(cls, config_dict, config_path):
+        try:
+            kind = config_dict.pop("kind", None)
+            cls._check_kind(kind)
+            config_dict["_config_path"] = config_path
+            return cls(**config_dict)
+        except Exception as exc:
+            raise config_exc.FromYamlException(
+                config_path,
+                f"app_router_op:{cls.kind}",
+                config_dict,
+            ) from exc
+
     @property
     def as_yaml(self) -> dict[str, typing.Any]:
         return {
@@ -75,6 +104,9 @@ class AddAppRouter(_AppRouterOperationBase, APIRouterKwargs):
     kind: typing.ClassVar[str] = "add"
     router_name: _utils.DottedName  # importable
     replace_existing: bool = False
+
+    # Set in '_AppRouterOperationBase.from_yaml' above
+    _config_path: pathlib.Path = None
 
     @property
     def as_yaml(self) -> dict[str, typing.Any]:
@@ -108,6 +140,9 @@ class DeleteAppRouter(_AppRouterOperationBase):
     kind: typing.ClassVar[str] = "delete"
     require_existing: bool = True
 
+    # Set in '_AppRouterOperationBase.from_yaml' above
+    _config_path: pathlib.Path = None
+
     @property
     def as_yaml(self) -> dict[str, typing.Any]:
         return super().as_yaml | {
@@ -131,6 +166,28 @@ class ClearAppRouters:
 
     kind: typing.ClassVar[str] = "clear"
 
+    # Set in 'from_yaml' below
+    _config_path: pathlib.Path = None
+
+    @classmethod
+    def _check_kind(cls, kind):
+        if kind not in (None, cls.kind):
+            raise AppRouterOperationKindMismatch(kind, cls.kind)
+
+    @classmethod
+    def from_yaml(cls, config_dict, config_path):
+        try:
+            kind = config_dict.pop("kind", None)
+            cls._check_kind(kind)
+            config_dict["_config_path"] = config_path
+            return cls(**config_dict)
+        except Exception as exc:
+            raise config_exc.FromYamlException(
+                config_path,
+                f"app_router_op:{cls.kind}",
+                config_dict,
+            ) from exc
+
     @property
     def as_yaml(self) -> dict[str, typing.Any]:
         return {"kind": self.kind}
@@ -142,40 +199,11 @@ class ClearAppRouters:
 AppRouterOperations = AddAppRouter | DeleteAppRouter | ClearAppRouters
 
 
-def _validate_app_router_operation_kind(config_path, config_dict):
-    kind = config_dict.pop("kind", None)
-    if kind not in ("add", "delete", "clear"):
-        raise config_exc.FromYamlException(
-            config_path,
-            "app_router",
-            config_dict,
-        )
-    return kind
-
-
-def app_router_operation_from_yaml(
-    config_path: pathlib.Path,
-    config_dict: dict,
-):
-    try:
-        kind = _validate_app_router_operation_kind(config_path, config_dict)
-
-        if kind == "add":
-            return AddAppRouter(**config_dict)
-        elif kind == "delete":
-            return DeleteAppRouter(**config_dict)
-        else:  # config_dict["kind"] == "clear":
-            return ClearAppRouters()
-
-    except config_exc.FromYamlException:
-        raise
-
-    except Exception as exc:
-        raise config_exc.FromYamlException(
-            config_path,
-            "app_router",
-            config_dict,
-        ) from exc
+APP_ROUTER_OPERATIONS_BY_KIND = {
+    AddAppRouter.kind: AddAppRouter,
+    DeleteAppRouter.kind: DeleteAppRouter,
+    ClearAppRouters.kind: ClearAppRouters,
+}
 
 
 _DEFAULT_KWARGS = APIRouterKwargs().router_kwargs

--- a/tests/unit/config/test_config_installation.py
+++ b/tests/unit/config/test_config_installation.py
@@ -1865,6 +1865,19 @@ def test_installationconfig_from_yaml(
             _config_path=config_path,
         )
 
+        if "app_router_operations" in expected_kw:
+            exp_ar_ops = [
+                dataclasses.replace(
+                    ar_op,
+                    _config_path=config_path,
+                )
+                for ar_op in expected.app_router_operations
+            ]
+            expected = dataclasses.replace(
+                expected,
+                app_router_operations=exp_ar_ops,
+            )
+
         if "rooms_upload_path" in expected_kw:
             exp_rooms_upload_path = temp_dir / expected_kw["rooms_upload_path"]
         else:
@@ -2072,6 +2085,7 @@ def test_installationconfig_as_yaml(
                 group_name="test-group",
                 router_name="my.package.router",
                 prefix="/prefix",
+                _config_path=config_path,
             )
         ]
 

--- a/tests/unit/config/test_config_routing.py
+++ b/tests/unit/config/test_config_routing.py
@@ -58,6 +58,39 @@ def soliplex_test_router():
 
 
 @pytest.mark.parametrize(
+    "config_dict, expectation",
+    [
+        (
+            {
+                "kind": "add",
+                "group_name": GROUP_NAME,
+                "router_name": ROUTER_NAME,
+            },
+            contextlib.nullcontext(config_routing.AddAppRouter),
+        ),
+        (
+            {
+                "group_name": GROUP_NAME,
+                "router_name": ROUTER_NAME,
+            },
+            contextlib.nullcontext(config_routing.AddAppRouter),
+        ),
+        ({}, pytest.raises(config_exc.FromYamlException)),
+        ({"kind": "bogus"}, pytest.raises(config_exc.FromYamlException)),
+    ],
+)
+def test_addapprouter_from_yaml(temp_dir, config_dict, expectation):
+    with expectation as expected:
+        found = config_routing.AddAppRouter.from_yaml(
+            config_path=temp_dir,
+            config_dict=config_dict,
+        )
+
+    if isinstance(expected, type):
+        assert isinstance(found, expected)
+
+
+@pytest.mark.parametrize(
     "router_kw, exp_router_kw",
     [
         ({}, DEFAULT_KW),
@@ -157,6 +190,32 @@ def test_addapprouter_apply(
 
 
 @pytest.mark.parametrize(
+    "config_dict, expectation",
+    [
+        (
+            {"group_name": GROUP_NAME},
+            contextlib.nullcontext(config_routing.DeleteAppRouter),
+        ),
+        (
+            {"kind": "delete", "group_name": GROUP_NAME},
+            contextlib.nullcontext(config_routing.DeleteAppRouter),
+        ),
+        ({}, pytest.raises(config_exc.FromYamlException)),
+        ({"kind": "bogus"}, pytest.raises(config_exc.FromYamlException)),
+    ],
+)
+def test_deleteapprouter_from_yaml(temp_dir, config_dict, expectation):
+    with expectation as expected:
+        found = config_routing.DeleteAppRouter.from_yaml(
+            config_path=temp_dir,
+            config_dict=config_dict,
+        )
+
+    if isinstance(expected, type):
+        assert isinstance(found, expected)
+
+
+@pytest.mark.parametrize(
     "require_kw, exp_require",
     [
         ({}, {"require_existing": True}),
@@ -218,7 +277,30 @@ def test_deleteapprouter_apply(
         assert GROUP_NAME not in patched_app_routers
 
 
-def test_clearapprouteras_yaml():
+@pytest.mark.parametrize(
+    "config_dict, expectation",
+    [
+        ({}, contextlib.nullcontext(config_routing.ClearAppRouters)),
+        (
+            {"kind": "clear"},
+            contextlib.nullcontext(config_routing.ClearAppRouters),
+        ),
+        ({"nonesuch": True}, pytest.raises(config_exc.FromYamlException)),
+        ({"kind": "bogus"}, pytest.raises(config_exc.FromYamlException)),
+    ],
+)
+def test_clearapprouters_from_yaml(temp_dir, config_dict, expectation):
+    with expectation as expected:
+        found = config_routing.ClearAppRouters.from_yaml(
+            config_path=temp_dir,
+            config_dict=config_dict,
+        )
+
+    if isinstance(expected, type):
+        assert isinstance(found, expected)
+
+
+def test_clearapprouters_as_yaml():
     clear_op = config_routing.ClearAppRouters()
 
     found = clear_op.as_yaml
@@ -236,63 +318,6 @@ def test_clearapprouters_apply(patched_app_routers, w_existing):
     operation.apply()
 
     assert len(patched_app_routers) == 0
-
-
-@pytest.mark.parametrize(
-    "w_kind, expectation",
-    [
-        ("add", contextlib.nullcontext()),
-        ("delete", contextlib.nullcontext()),
-        ("clear", contextlib.nullcontext()),
-        ("bogus", pytest.raises(config_exc.FromYamlException)),
-    ],
-)
-def test__validate_app_router_operation_kind(temp_dir, w_kind, expectation):
-    config_dict = {"kind": w_kind}
-    with expectation as expected:
-        found = config_routing._validate_app_router_operation_kind(
-            config_path=temp_dir,
-            config_dict=config_dict,
-        )
-
-    if expected is None:
-        assert found == w_kind
-
-
-@pytest.mark.parametrize(
-    "config_dict, expectation",
-    [
-        (
-            {
-                "kind": "add",
-                "group_name": GROUP_NAME,
-                "router_name": ROUTER_NAME,
-            },
-            contextlib.nullcontext(config_routing.AddAppRouter),
-        ),
-        (
-            {"kind": "delete", "group_name": GROUP_NAME},
-            contextlib.nullcontext(config_routing.DeleteAppRouter),
-        ),
-        (
-            {"kind": "clear"},
-            contextlib.nullcontext(config_routing.ClearAppRouters),
-        ),
-        ({}, pytest.raises(config_exc.FromYamlException)),
-        ({"kind": "bogus"}, pytest.raises(config_exc.FromYamlException)),
-        ({"kind": "add"}, pytest.raises(config_exc.FromYamlException)),
-        ({"kind": "delete"}, pytest.raises(config_exc.FromYamlException)),
-    ],
-)
-def test_app_router_operation_from_yaml(temp_dir, config_dict, expectation):
-    with expectation as expected:
-        found = config_routing.app_router_operation_from_yaml(
-            config_path=temp_dir,
-            config_dict=config_dict,
-        )
-
-    if isinstance(expected, type):
-        assert isinstance(found, expected)
 
 
 @mock.patch("soliplex.config._utils._from_dotted_name")


### PR DESCRIPTION
  ... replacing 'app_router_operation_from_yaml' with simple dict lookup
  in 'config.installation.InstallationConfig.from_yaml'.

Toward #1181.

Closes #1216.