### PR TITLE
fix: 'config.routing.*AppRouter{,s}.from_yaml'

### DIFF
--- a/src/soliplex/config/installation.py
+++ b/src/soliplex/config/installation.py
@@ -862,7 +862,7 @@ class InstallationConfig:
 
             for aro in aros:
                 klass = aro_klasses_by_kind[aro["kind"]]
-                aros_cfg.append(klass.from_yaml(aro, config_path))
+                aros_cfg.append(klass.from_yaml(config_path, aro))
 
             config_dict["app_router_operations"] = aros_cfg
 

--- a/src/soliplex/config/routing.py
+++ b/src/soliplex/config/routing.py
@@ -76,7 +76,7 @@ class _AppRouterOperationBase:
             raise AppRouterOperationKindMismatch(kind, cls.kind)
 
     @classmethod
-    def from_yaml(cls, config_dict, config_path):
+    def from_yaml(cls, config_path, config_dict):
         try:
             kind = config_dict.pop("kind", None)
             cls._check_kind(kind)
@@ -175,7 +175,7 @@ class ClearAppRouters:
             raise AppRouterOperationKindMismatch(kind, cls.kind)
 
     @classmethod
-    def from_yaml(cls, config_dict, config_path):
+    def from_yaml(cls, config_path, config_dict):
         try:
             kind = config_dict.pop("kind", None)
             cls._check_kind(kind)


### PR DESCRIPTION
  ... make argument order consistent with other config classes.

Closes #1224.