### PR TITLE
fix: '{,Factory}AgentConfig.{from,as}_yaml' w/ 'kind'

### DIFF
--- a/src/soliplex/config/agents.py
+++ b/src/soliplex/config/agents.py
@@ -50,13 +50,29 @@ class UnknownCapability(KeyError):
     def __init__(self, name, _config_path=None):
         self.name = name
         self._config_path = _config_path
-        if _config_path is not None:
-            super().__init__(
-                f"Unknown capability name: {name} "
-                f"(configured in {_config_path})"
-            )
-        else:
-            super().__init__(f"Unknown capability name: {name}")
+
+        super().__init__(
+            f"Unknown capability name: {name} (configured in {_config_path})"
+        )
+
+
+class UnknownAgentConfigKind(KeyError):
+    def __init__(self, kind, _config_path=None):
+        self.kind = kind
+        self._config_path = _config_path
+        super().__init__(
+            f"Unknown agent config kind: {kind} (configured in {_config_path})"
+        )
+
+
+class AgentConfigKindMismatch(ValueError):
+    def __init__(self, found_kind, expected_kind):
+        self.found_kind = found_kind
+        self.expected_kind = expected_kind
+        super().__init__(
+            "Agent config kind mismatch: "
+            f"found '{found_kind}', expected '{expected_kind}'"
+        )
 
 
 class LLMProviderType(enum.StrEnum):
@@ -109,7 +125,7 @@ class AgentCapabilityConfig:
         try:
             cap_klass = AGENT_CAPABILITY_CLASSES_BY_NAME[self.name]
         except KeyError:
-            raise UnknownCapability(self.name) from None
+            raise UnknownCapability(self.name, self._config_path) from None
 
         return cap_klass(**self.kwargs)
 
@@ -178,6 +194,11 @@ class AgentConfig:
             self._system_prompt_text = system_prompt
 
     @classmethod
+    def _check_kind(cls, kind):
+        if kind not in (None, cls.kind):
+            raise AgentConfigKindMismatch(kind, cls.kind)
+
+    @classmethod
     def from_yaml(
         cls,
         installation_config: InstallationConfig,  # noqa F821 cycle
@@ -185,6 +206,9 @@ class AgentConfig:
         config_dict: dict,
     ):
         try:
+            kind = config_dict.pop("kind", None)
+            cls._check_kind(kind)
+
             config_dict["_installation_config"] = installation_config
             config_dict["_config_path"] = config_path
 
@@ -291,6 +315,7 @@ class AgentConfig:
 
         return {
             "id": self.id,
+            "kind": self.kind,
             "model_name": self.model_name,
             "retries": self.retries,
             "system_prompt": prompt,
@@ -343,6 +368,11 @@ class FactoryAgentConfig:
         return self._factory
 
     @classmethod
+    def _check_kind(cls, kind):
+        if kind not in (None, cls.kind):
+            raise AgentConfigKindMismatch(kind, cls.kind)
+
+    @classmethod
     def from_yaml(
         cls,
         installation_config: InstallationConfig,  # noqa F821 cycle
@@ -350,6 +380,9 @@ class FactoryAgentConfig:
         config_dict: dict,
     ):
         try:
+            kind = config_dict.pop("kind", None)
+            cls._check_kind(kind)
+
             config_dict["_installation_config"] = installation_config
             config_dict["_config_path"] = config_path
 
@@ -400,14 +433,17 @@ def extract_agent_config(
     config_path: pathlib.Path,
     config_dict: dict,
 ) -> AgentConfig:  # or subclass
-    agent_kind = config_dict.get("kind")
 
-    if agent_kind is not None:  # kind is a typing.ClassVar
-        config_dict = {
-            key: value for key, value in config_dict.items() if key != "kind"
-        }
+    # YAML not required to specify 'kind'
+    agent_kind = config_dict.get("kind", AgentConfig.kind)
 
-    ac_class = AGENT_CONFIG_CLASSES_BY_KIND.get(agent_kind, AgentConfig)
+    try:
+        ac_class = AGENT_CONFIG_CLASSES_BY_KIND[agent_kind]
+    except KeyError:
+        raise UnknownAgentConfigKind(
+            agent_kind,
+            config_path,
+        ) from None
 
     return ac_class.from_yaml(
         installation_config,

--- a/tests/unit/config/test_config_agents.py
+++ b/tests/unit/config/test_config_agents.py
@@ -37,11 +37,12 @@ MODEL_SETTINGS = {"temperature": 0.875}
 
 BOGUS_AGENT_CONFIG_YAML = ""
 
-W_KIND_AGENT_CONFIG_KW = dict(
-    id=AGENT_ID,
-    model_name=MODEL_NAME,
-    kind="testing",
-)
+BOGUS_KIND_AGENT_CONFIG_YAML = f"""
+id: "{AGENT_ID}"
+kind: "bogus"
+model_name: "{MODEL_NAME}"
+system_prompt: "{SYSTEM_PROMPT}"
+"""
 
 BARE_AGENT_CONFIG_KW = dict(
     id=AGENT_ID,
@@ -50,6 +51,14 @@ BARE_AGENT_CONFIG_KW = dict(
 )
 BARE_AGENT_CONFIG_YAML = f"""
 id: "{AGENT_ID}"
+model_name: "{MODEL_NAME}"
+system_prompt: "{SYSTEM_PROMPT}"
+"""
+
+# -> BARE_AGENT_CONFIG_KW, because 'AgentConfig.from_yaml' strips 'kind'
+W_KIND_AGENT_CONFIG_YAML = f"""
+id: "{AGENT_ID}"
+kind: "{config_agents.AgentConfig.kind}"
 model_name: "{MODEL_NAME}"
 system_prompt: "{SYSTEM_PROMPT}"
 """
@@ -216,6 +225,28 @@ agui_feature_names:
 """
 
 FACTORY_NAME = "soliplex.config.agents.test_factory_wo_config"
+
+BOGUS_KIND_FACTORY_AGENT_CONFIG_YAML = f"""
+id: "{AGENT_ID}"
+kind: "bogus"
+factory_name: "{FACTORY_NAME}"
+"""
+
+BARE_FACTORY_AGENT_CONFIG_KW = dict(
+    id=AGENT_ID,
+    factory_name=FACTORY_NAME,
+)
+BARE_FACTORY_AGENT_CONFIG_YAML = f"""
+id: "{AGENT_ID}"
+factory_name: "{FACTORY_NAME}"
+"""
+
+W_KIND_FACTORY_AGENT_CONFIG_YAML = f"""
+id: "{AGENT_ID}"
+kind: "{config_agents.FactoryAgentConfig.kind}"
+factory_name: "{FACTORY_NAME}"
+"""
+
 WO_CONFIG_FACTORY_AGENT_CONFIG_KW = dict(
     id=AGENT_ID,
     factory_name=FACTORY_NAME,
@@ -285,6 +316,25 @@ template_id: "{W_EXTRA_CONFIG_TEMPLATE_AGENT_ID}"
 extra_config:
   foo: "Bar"
 """
+
+# These mappings are only used in 'test_extract_agent_capability':
+# `*AgentConfig.from_yaml' strips 'kind'.
+TESTING_KIND_AGENT_CONFIG_KW = dict(
+    id=AGENT_ID,
+    model_name=MODEL_NAME,
+    kind="testing",
+)
+W_KIND_AGENT_CONFIG_KW = dict(
+    id=AGENT_ID,
+    kind=config_agents.AgentConfig.kind,
+    model_name=MODEL_NAME,
+    system_prompt=SYSTEM_PROMPT,
+)
+W_KIND_FACTORY_AGENT_CONFIG_KW = dict(
+    id=AGENT_ID,
+    kind=config_agents.FactoryAgentConfig.kind,
+    factory_name=FACTORY_NAME,
+)
 
 
 @pytest.fixture
@@ -459,7 +509,16 @@ def test_agentconfig_ctor(installation_config, kw):
             pytest.raises(config_exc.FromYamlException),
         ),
         (
+            BOGUS_KIND_AGENT_CONFIG_YAML,
+            pytest.raises(config_exc.FromYamlException),
+        ),
+        (
             BARE_AGENT_CONFIG_YAML,
+            contextlib.nullcontext(BARE_AGENT_CONFIG_KW.copy()),
+        ),
+        (
+            W_KIND_AGENT_CONFIG_YAML,
+            # `kind` stripped
             contextlib.nullcontext(BARE_AGENT_CONFIG_KW.copy()),
         ),
         (
@@ -915,6 +974,7 @@ def test_agentconfig_as_yaml(
     model_settings = agent_config_kw.get("model_settings")
     expected = {
         "id": AGENT_ID,
+        "kind": config_agents.AgentConfig.kind,
         "system_prompt": system_prompt,
         "model_name": model_name,
         "model_settings": model_settings,
@@ -996,29 +1056,54 @@ def test_factoryagentconfig_factory(kw, w_existing):
 
 
 @pytest.mark.parametrize(
-    "config_yaml, expected_kw",
+    "config_yaml, expectation",
     [
-        (BOGUS_AGENT_CONFIG_YAML, None),
+        (
+            BOGUS_AGENT_CONFIG_YAML,
+            pytest.raises(config_exc.FromYamlException),
+        ),
+        (
+            BOGUS_KIND_FACTORY_AGENT_CONFIG_YAML,
+            pytest.raises(config_exc.FromYamlException),
+        ),
+        (
+            BARE_FACTORY_AGENT_CONFIG_YAML,
+            contextlib.nullcontext(BARE_FACTORY_AGENT_CONFIG_KW.copy()),
+        ),
         (
             WO_CONFIG_FACTORY_AGENT_CONFIG_YAML,
-            WO_CONFIG_FACTORY_AGENT_CONFIG_KW.copy(),
+            contextlib.nullcontext(WO_CONFIG_FACTORY_AGENT_CONFIG_KW.copy()),
+        ),
+        (
+            W_KIND_FACTORY_AGENT_CONFIG_YAML,
+            # kind stripped
+            contextlib.nullcontext(BARE_FACTORY_AGENT_CONFIG_KW.copy()),
         ),
         (
             W_CONFIG_FACTORY_AGENT_CONFIG_YAML,
-            W_CONFIG_FACTORY_AGENT_CONFIG_KW.copy(),
+            contextlib.nullcontext(W_CONFIG_FACTORY_AGENT_CONFIG_KW.copy()),
         ),
         (
             W_AGUI_FEATURE_NAMES_FACTORY_AGENT_CONFIG_YAML,
-            W_AGUI_FEATURE_NAMES_FACTORY_AGENT_CONFIG_KW.copy(),
+            contextlib.nullcontext(
+                W_AGUI_FEATURE_NAMES_FACTORY_AGENT_CONFIG_KW.copy()
+            ),
         ),
-        (W_BOGUS_TEMPLATE_ID_FACTORY_AGENT_CONFIG_YAML, None),
+        (
+            W_BOGUS_TEMPLATE_ID_FACTORY_AGENT_CONFIG_YAML,
+            pytest.raises(config_exc.FromYamlException),
+        ),
         (
             W_TEMPLATE_ID_FACTORY_AGENT_CONFIG_YAML,
-            W_TEMPLATE_ID_FACTORY_AGENT_CONFIG_KW.copy(),
+            contextlib.nullcontext(
+                W_TEMPLATE_ID_FACTORY_AGENT_CONFIG_KW.copy()
+            ),
         ),
         (
             W_TEMPLATE_ID_W_EXTRA_CONFIG_FACTORY_AGENT_CONFIG_YAML,
-            W_TEMPLATE_ID_W_EXTRA_CONFIG_FACTORY_AGENT_CONFIG_KW.copy(),
+            contextlib.nullcontext(
+                W_TEMPLATE_ID_W_EXTRA_CONFIG_FACTORY_AGENT_CONFIG_KW.copy()
+            ),
         ),
     ],
 )
@@ -1026,7 +1111,7 @@ def test_factoryagentconfig_from_yaml(
     installation_config,
     temp_dir,
     config_yaml,
-    expected_kw,
+    expectation,
 ):
     yaml_file = temp_dir / "test.yaml"
     yaml_file.write_text(config_yaml)
@@ -1051,24 +1136,18 @@ def test_factoryagentconfig_from_yaml(
         template_kw = {}
         installation_config.agent_configs = []
 
-    if expected_kw is None:
-        with pytest.raises(config_exc.FromYamlException):
-            config_agents.FactoryAgentConfig.from_yaml(
-                installation_config,
-                yaml_file,
-                config_dict,
-            )
-    else:
-        expected = config_agents.FactoryAgentConfig(
-            _installation_config=installation_config,
-            _config_path=yaml_file,
-            **(template_kw | expected_kw),
-        )
-
+    with expectation as expected_kw:
         found = config_agents.FactoryAgentConfig.from_yaml(
             installation_config,
             yaml_file,
             config_dict,
+        )
+
+    if isinstance(expected_kw, dict):
+        expected = config_agents.FactoryAgentConfig(
+            _installation_config=installation_config,
+            _config_path=yaml_file,
+            **(template_kw | expected_kw),
         )
 
         assert found == expected
@@ -1078,7 +1157,7 @@ def test_factoryagentconfig_from_yaml(
 
 
 @pytest.mark.parametrize(
-    "kw",
+    "agent_config_kw",
     [
         WO_CONFIG_FACTORY_AGENT_CONFIG_KW.copy(),
         W_CONFIG_FACTORY_AGENT_CONFIG_KW.copy(),
@@ -1086,17 +1165,17 @@ def test_factoryagentconfig_from_yaml(
 )
 def test_factoryagentconfig_as_yaml(
     installation_config,
-    kw,
+    agent_config_kw,
 ):
-    kw = copy.deepcopy(kw)
-    expected = copy.deepcopy(kw) | {
+    agent_config_kw = copy.deepcopy(agent_config_kw)
+    expected = copy.deepcopy(agent_config_kw) | {
         "kind": config_agents.FactoryAgentConfig.kind,
     }
 
     if "extra_config" not in expected:
         expected["extra_config"] = {}
 
-    aconfig = config_agents.FactoryAgentConfig(**kw)
+    aconfig = config_agents.FactoryAgentConfig(**agent_config_kw)
 
     found = aconfig.as_yaml
 
@@ -1104,10 +1183,24 @@ def test_factoryagentconfig_as_yaml(
 
 
 @pytest.mark.parametrize(
-    "agent_config, expected_kw",
+    "agent_config, expectation",
     [
-        (BARE_AGENT_CONFIG_KW.copy(), BARE_AGENT_CONFIG_KW),
-        (W_KIND_AGENT_CONFIG_KW.copy(), W_KIND_AGENT_CONFIG_KW),
+        (
+            {"kind": "bogus"},
+            pytest.raises(config_agents.UnknownAgentConfigKind),
+        ),
+        (
+            W_KIND_AGENT_CONFIG_KW.copy(),
+            contextlib.nullcontext(BARE_AGENT_CONFIG_KW.copy()),
+        ),
+        (
+            W_KIND_FACTORY_AGENT_CONFIG_KW.copy(),
+            contextlib.nullcontext(BARE_FACTORY_AGENT_CONFIG_KW.copy()),
+        ),
+        (
+            TESTING_KIND_AGENT_CONFIG_KW.copy(),
+            contextlib.nullcontext(TESTING_KIND_AGENT_CONFIG_KW.copy()),
+        ),
     ],
 )
 def test_extract_agent_configs(
@@ -1115,7 +1208,7 @@ def test_extract_agent_configs(
     temp_dir,
     patched_agent_configs,
     agent_config,
-    expected_kw,
+    expectation,
 ):
     @dataclasses.dataclass(kw_only=True)
     class TestAgentConfig:
@@ -1127,6 +1220,7 @@ def test_extract_agent_configs(
 
         @classmethod
         def from_yaml(cls, i_config, c_path, c_dict):
+            assert c_dict.pop("kind") == cls.kind
             return cls(
                 _installation_config=i_config,
                 _config_path=c_path,
@@ -1134,29 +1228,48 @@ def test_extract_agent_configs(
             )
 
     # Register our extension agent config
-    patched_agent_configs["testing"] = TestAgentConfig
+    AC = config_agents.AgentConfig
+    FAC = config_agents.FactoryAgentConfig
 
-    if agent_config.get("kind") == "testing":
-        kw_no_kind = {k: v for k, v in expected_kw.items() if k != "kind"}
-        expected = TestAgentConfig(
-            _installation_config=installation_config,
-            _config_path=temp_dir,
-            **kw_no_kind,
-        )
-    else:
-        expected = config_agents.AgentConfig(
-            _installation_config=installation_config,
-            _config_path=temp_dir,
-            **expected_kw,
-        )
-
-    found = config_agents.extract_agent_config(
-        installation_config,
-        temp_dir,
-        agent_config,
+    patched_agent_configs.update(
+        {
+            TestAgentConfig.kind: TestAgentConfig,
+            AC.kind: AC,
+            FAC.kind: FAC,
+        }
     )
 
-    assert found == expected
+    with expectation as expected_kw:
+        found = config_agents.extract_agent_config(
+            installation_config,
+            temp_dir,
+            agent_config.copy(),  # might mutate
+        )
+
+    if isinstance(expected_kw, dict):
+        kind = agent_config["kind"]
+
+        if kind == "testing":
+            kw_no_kind = {k: v for k, v in agent_config.items() if k != "kind"}
+            expected = TestAgentConfig(
+                _installation_config=installation_config,
+                _config_path=temp_dir,
+                **kw_no_kind,
+            )
+        elif kind == config_agents.FactoryAgentConfig.kind:
+            expected = config_agents.FactoryAgentConfig(
+                _installation_config=installation_config,
+                _config_path=temp_dir,
+                **expected_kw,
+            )
+        else:
+            expected = config_agents.AgentConfig(
+                _installation_config=installation_config,
+                _config_path=temp_dir,
+                **expected_kw,
+            )
+
+        assert found == expected
 
 
 @pytest.mark.parametrize("w_model_settings", [None, MODEL_SETTINGS])


### PR DESCRIPTION
Harmonize handling of 'kind':
- 'as_yaml' emits 'kind' in both classes
- 'from_yaml' accepts 'kind' and validates it.
- 'extract_agent_config' does not 'pop' kind from the config dict.

Closes #1184.
Closes #1231.