### PR TITLE
refactor: deprecate 'config.meta.ConfigMeta'

### DIFF
--- a/src/soliplex/config/meta.py
+++ b/src/soliplex/config/meta.py
@@ -3,6 +3,7 @@ from __future__ import annotations  # forward refs in typing decls
 import dataclasses
 import pathlib
 import typing
+import warnings
 
 from soliplex import authz
 
@@ -22,57 +23,37 @@ _default_list_field = _utils._default_list_field
 _default_dict_field = _utils._default_dict_field
 
 
-@dataclasses.dataclass(kw_only=True)
-class AGUI_FeatureConfigMeta:
-    """Registered config class
+CONFIG_META_DEPRECATED = """\
+The 'ConfigMeta' class is deprecated; use one of the specialized meta-config
+types instead.  Support for the form will be removed after 'v0.76'.
+"""
 
-    'model_klass'
-        dotted name of a a class or factory returning an 'agui.AGUI_Feature'
-        when passed the feature name and an instance of this class.
-
-    'source':
-        (optional) one of "client", "server", or "either" (defaults to
-        "either).
-    """
-
-    name: str
-    model_klass: typing.Any
-    source: config_agui.AGUI_FeatureSource = "either"
-
-    @classmethod
-    def from_yaml(cls, yaml_config: dict):
-        model_klass = yaml_config["model_klass"]
-        yaml_config["model_klass"] = _utils._from_dotted_name(model_klass)
-        return cls(**yaml_config)
+FROM_YAML_KEY_DEPRECATED = """\
+The '{field}' key passed to '{klass}.from_yaml' is deprecated,
+and will be removed after 'v0.76'.
+"""
 
 
-@dataclasses.dataclass(kw_only=True)
-class JSONPathFunctionConfigMeta:
-    """Registered JSONPath filter function
+class WrapperForUnknownToolConfig(ValueError):
+    def __init__(self, tool_config_klass, wrapper_klass):
+        self.tool_config_klass = tool_config_klass
+        self.wrapper_klass = wrapper_klass
 
-    'name'
-        the name by which the function is invoked inside a JSONPath
-        filter expression.
+        tck_dotted = _utils._dotted_name(tool_config_klass)
+        wk_dotted = _utils._dotted_name(wrapper_klass)
 
-    'func'
-        dotted name of a callable implementing the filter function. It
-        is registered into 'authz.the_jsonpath_environment' and must
-        conform to python-jsonpath's filter-function protocol.
-    """
-
-    name: str
-    func: typing.Any
-
-    @classmethod
-    def from_yaml(cls, yaml_config: dict):
-        func = yaml_config["func"]
-        yaml_config["func"] = _utils._from_dotted_name(func)
-        return cls(**yaml_config)
+        super().__init__(
+            f"Wrapper class '{wk_dotted}' cannot be "
+            f"registered for unregistered tool config class '{tck_dotted}'"
+        )
 
 
 @dataclasses.dataclass(kw_only=True)
 class ConfigMeta:
-    """Registered config class
+    """(Deprecated) Registered config class
+
+    This class was used for widely different types, and is now
+    deprecated in favor of the more specific meta config types below.
 
     'config_klass'
         a class or factory: returned value must have a 'from_yaml' method
@@ -93,6 +74,13 @@ class ConfigMeta:
 
     @classmethod
     def from_yaml(cls, yaml_config: _utils.DottedName | dict):
+
+        warnings.warn(
+            CONFIG_META_DEPRECATED,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if isinstance(yaml_config, _utils.DottedName):
             config_klass = _utils._from_dotted_name(yaml_config)
             return cls(config_klass=config_klass)
@@ -120,6 +108,316 @@ class ConfigMeta:
 
 
 @dataclasses.dataclass(kw_only=True)
+class AGUI_FeatureConfigMeta:
+    """Registered config class
+
+    'model_klass'
+        dotted name of a a class or factory returning an 'agui.AGUI_Feature'
+        when passed the feature name and an instance of this class.
+
+    'source':
+        (optional) one of "client", "server", or "either" (defaults to
+        "either).
+    """
+
+    name: str
+    model_klass: typing.Any
+    source: config_agui.AGUI_FeatureSource = "either"
+
+    @classmethod
+    def from_yaml(cls, yaml_config: dict):
+        model_klass = yaml_config["model_klass"]
+        yaml_config["model_klass"] = _utils._from_dotted_name(model_klass)
+        return cls(**yaml_config)
+
+
+@dataclasses.dataclass(kw_only=True)
+class _ConfigKlassOnlyMeta:
+    """Base for config meta classes which take only 'config_klass'"""
+
+    config_klass: typing.Any
+
+    @classmethod
+    def from_yaml(cls, yaml_config: _utils.DottedName | dict):
+
+        if isinstance(yaml_config, _utils.DottedName):
+            config_klass = _utils._from_dotted_name(yaml_config)
+        else:
+            config_klass = _utils._from_dotted_name(
+                yaml_config["config_klass"]
+            )
+
+            for field in ("wrapper_klass", "registered_func"):
+                if field in yaml_config:
+                    msg = FROM_YAML_KEY_DEPRECATED.format(
+                        klass=cls.__name__,
+                        field=field,
+                    )
+                    warnings.warn(
+                        msg,
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+
+        return cls(config_klass=config_klass)
+
+
+@dataclasses.dataclass(kw_only=True)
+class ToolConfigMeta(_ConfigKlassOnlyMeta):
+    """Meta-config class for registering tool config classes.
+
+    'config_klass'
+        a class or factory: returned value must have a 'from_yaml' method
+        compatible with the category for which it is used.
+
+        If passed as a string to 'from_yaml', it is resolved via
+        '_utils._from_dotted_name'.
+
+    'wrapper_klass'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+
+    'registered_func'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+    """
+
+    @property
+    def tool_name(self) -> _utils.DottedName:
+        return self.config_klass.tool_name
+
+
+@dataclasses.dataclass(kw_only=True)
+class MCP_ToolsetConfigMeta(_ConfigKlassOnlyMeta):
+    """Meta-config class for registering MCP toolset config classes.
+
+    'config_klass'
+        a class or factory: returned value must have a 'from_yaml' method
+        compatible with the category for which it is used.
+
+        If passed as a string to 'from_yaml', it is resolved via
+        '_utils._from_dotted_name'.
+
+    'wrapper_klass'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+
+    'registered_func'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+    """
+
+    @property
+    def kind(self) -> str:
+        return self.config_klass.kind
+
+
+@dataclasses.dataclass(kw_only=True)
+class MCP_ServerToolWrapperConfigMeta:
+    """Meta-config class for registering wrapper classes for MCP server tools
+
+    'config_klass'
+        a class or factory: returned value must have a 'from_yaml' method
+        compatible with the category for which it is used.
+
+        If passed as a string to 'from_yaml', it is resolved via
+        '_utils._from_dotted_name'.
+
+    'wrapper_klass'
+        a class or factory used to wrap instances of 'config_klass'
+
+        If passed as a string to 'from_yaml', it is resolved via
+        '_utils._from_dotted_name'.
+
+    'registered_func'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+    """
+
+    config_klass: typing.Any
+    wrapper_klass: typing.Any
+
+    @classmethod
+    def from_yaml(cls, yaml_config: _utils.DottedName | dict):
+        config_klass = _utils._from_dotted_name(yaml_config["config_klass"])
+        wrapper_klass = _utils._from_dotted_name(yaml_config["wrapper_klass"])
+
+        if "registered_func" in yaml_config:
+            msg = FROM_YAML_KEY_DEPRECATED.format(
+                klass=cls.__name__,
+                field="registered_func",
+            )
+            warnings.warn(
+                msg,
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return cls(
+            config_klass=config_klass,
+            wrapper_klass=wrapper_klass,
+        )
+
+    @property
+    def tool_name(self) -> _utils.DottedName:
+        return self.config_klass.tool_name
+
+
+@dataclasses.dataclass(kw_only=True)
+class SkillConfigMeta(_ConfigKlassOnlyMeta):
+    """Meta-config class for registering skill config classes
+
+    'config_klass'
+        a class or factory: returned value must have a 'from_yaml' method
+        compatible with the category for which it is used.
+
+        If passed as a string to 'from_yaml', it is resolved via
+        '_utils._from_dotted_name'.
+
+    'wrapper_klass'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+
+    'registered_func'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+    """
+
+    @property
+    def kind(self) -> str:
+        return self.config_klass.kind
+
+
+@dataclasses.dataclass(kw_only=True)
+class AgentCapabilityMeta(_ConfigKlassOnlyMeta):
+    """Meta-config class for registering agent capability classes
+
+    'config_klass'
+        a class or factory: returned value must have a 'from_yaml' method
+        compatible with the category for which it is used.
+
+        If passed as a string to 'from_yaml', it is resolved via
+        '_utils._from_dotted_name'.
+
+    'wrapper_klass'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+
+    'registered_func'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+    """
+
+    @property
+    def capability_name(self) -> _utils.DottedName:
+        return self.config_klass.__name__
+
+
+@dataclasses.dataclass(kw_only=True)
+class AgentConfigMeta(_ConfigKlassOnlyMeta):
+    """Meta-config class for registering agent config classes
+
+    'config_klass'
+        a class or factory: returned value must have a 'from_yaml' method
+        compatible with the category for which it is used.
+
+        If passed as a string to 'from_yaml', it is resolved via
+        '_utils._from_dotted_name'.
+
+    'wrapper_klass'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+
+    'registered_func'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+    """
+
+    @property
+    def kind(self) -> str:
+        return self.config_klass.kind
+
+
+@dataclasses.dataclass(kw_only=True)
+class SecretSourceMeta:
+    """Meta-config class for registering secret source classes
+
+    'config_klass'
+        a class or factory: returned value must have a 'from_yaml' method
+        compatible with the category for which it is used.
+
+        If passed as a string to 'from_yaml', it is resolved via
+        '_utils._from_dotted_name'.
+
+    'registered_func'
+        a callable taking an instance of 'config_klass' and returning
+        a resolved secret, or raising a 'soliplex_secrets.SecretError'
+        on a miss.
+
+        If passed as a string to 'from_yaml', it is resolved via
+        '_utils._from_dotted_name'.
+
+    'wrapper_klass'
+        No-op fossil from 'ConfigMeta'; can only be passed to 'from_yaml',
+        where it is ignored with a deprecation warning.
+    """
+
+    config_klass: typing.Any
+    registered_func: typing.Any = None
+
+    @classmethod
+    def from_yaml(cls, yaml_config: _utils.DottedName | dict):
+        config_klass = _utils._from_dotted_name(yaml_config["config_klass"])
+        registered_func = _utils._from_dotted_name(
+            yaml_config["registered_func"],
+        )
+
+        if "wrapper_klass" in yaml_config:
+            msg = FROM_YAML_KEY_DEPRECATED.format(
+                klass=cls.__name__,
+                field="wrapper_klass",
+            )
+            warnings.warn(
+                msg,
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return cls(
+            config_klass=config_klass,
+            registered_func=registered_func,
+        )
+
+    @property
+    def kind(self) -> str:
+        return self.config_klass.kind
+
+
+@dataclasses.dataclass(kw_only=True)
+class JSONPathFunctionConfigMeta:
+    """Registered JSONPath filter function
+
+    'name'
+        the name by which the function is invoked inside a JSONPath
+        filter expression.
+
+    'func'
+        dotted name of a callable implementing the filter function. It
+        is registered into 'authz.the_jsonpath_environment' and must
+        conform to python-jsonpath's filter-function protocol.
+    """
+
+    name: str
+    func: typing.Any
+
+    @classmethod
+    def from_yaml(cls, yaml_config: dict):
+        func = yaml_config["func"]
+        yaml_config["func"] = _utils._from_dotted_name(func)
+        return cls(**yaml_config)
+
+
+@dataclasses.dataclass(kw_only=True)
 class InstallationConfigMeta:
     """Configuration for pluggable components
 
@@ -129,37 +427,38 @@ class InstallationConfigMeta:
 
     'tool_configs'
         a list consisting of strings (importable dotted names of tool
-        config classes) or `ConfigMeta' mappings, defining the types
+        config classes) or `ToolConfigMeta' mappings, defining the types
         of tools which can be configured.
 
     'mcp_toolset_configs'
         a list consisting of strings (importable dotted names of MCP client
-        toolset config classes) or `ConfigMeta' mappings, defining the types
-        of MCP client toolsets which can be configured.
+        toolset config classes) or `MCP_ToolsetConfigMeta' mappings, defining
+        the types of MCP client toolsets which can be configured.
 
     'mcp_server_tool_wrappers"
-        a list consisting of strings (importable dotted names of MCP
-        server tool wrapper classes) or `ConfigMeta' mappings, defining
+        a list consisting of `MCP_ServerToolWrapperConfigMeta'
+        mappings, defining
         the types of MCP server tool wrappers which can be configured.
 
     'skill_configs'
         a list consisting of strings (importable dotted names of skill
-        config classes) or `ConfigMeta' mappings, defining the types
+        config classes) or `SkillConfigMeta' mappings, defining the types
         of skills which can be configured.
 
     'agent_capability_types'
         a list consisting of strings (importable dotted names of agent
-        capability classes) or `ConfigMeta' mappings, defining additional
-        capability types with which agents can be configured.
+        capability classes) or `AgentCapabilityMeta' mappings,
+        defining additional capability types with which agents can be
+        configured.
 
     'agent_configs'
         a list consisting of strings (importable dotted names of agent
-        config classes) or `ConfigMeta' mappings, defining the
+        config classes) or `AgentConfigMeta' mappings, defining the
         types of agents which can be configured.
 
     'secret_sources'
         a list consisting of  strings (importable dotted names of secret
-        source classes) or `ConfigMeta' mappings, defining the
+        source classes) or `SecretSourceMeta' mappings, defining the
         tyeps of secret sources which can be configured.
 
     'jsonpath_functions'
@@ -173,13 +472,13 @@ class InstallationConfigMeta:
     """
 
     agui_features: list[str | AGUI_FeatureConfigMeta] = ()
-    tool_configs: list[str | ConfigMeta] = ()
-    mcp_toolset_configs: list[str | ConfigMeta] = ()
-    mcp_server_tool_wrappers: list[ConfigMeta] = ()
-    skill_configs: list[str | ConfigMeta] = ()
-    agent_capability_types: list[str | ConfigMeta] = ()
-    agent_configs: list[str | ConfigMeta] = ()
-    secret_sources: list[str | ConfigMeta] = ()
+    tool_configs: list[str | ToolConfigMeta] = ()
+    mcp_toolset_configs: list[str | MCP_ToolsetConfigMeta] = ()
+    mcp_server_tool_wrappers: list[MCP_ServerToolWrapperConfigMeta] = ()
+    skill_configs: list[str | SkillConfigMeta] = ()
+    agent_capability_types: list[str | AgentCapabilityMeta] = ()
+    agent_configs: list[str | AgentConfigMeta] = ()
+    secret_sources: list[str | SecretSourceMeta] = ()
     jsonpath_functions: list[JSONPathFunctionConfigMeta] = ()
 
     # Set by `from_yaml` factory
@@ -199,17 +498,17 @@ class InstallationConfigMeta:
             ]
 
             config_dict["tool_configs"] = [
-                ConfigMeta.from_yaml(tc_yaml)
+                ToolConfigMeta.from_yaml(tc_yaml)
                 for tc_yaml in config_dict.get("tool_configs", ())
             ]
 
             config_dict["mcp_toolset_configs"] = [
-                ConfigMeta.from_yaml(mcp_tc_yaml)
+                MCP_ToolsetConfigMeta.from_yaml(mcp_tc_yaml)
                 for mcp_tc_yaml in config_dict.get("mcp_toolset_configs", ())
             ]
 
             config_dict["mcp_server_tool_wrappers"] = [
-                ConfigMeta.from_yaml(mcp_tc_yaml)
+                MCP_ServerToolWrapperConfigMeta.from_yaml(mcp_tc_yaml)
                 for mcp_tc_yaml in config_dict.get(
                     "mcp_server_tool_wrappers",
                     (),
@@ -217,22 +516,22 @@ class InstallationConfigMeta:
             ]
 
             config_dict["skill_configs"] = [
-                ConfigMeta.from_yaml(sc_yaml)
+                SkillConfigMeta.from_yaml(sc_yaml)
                 for sc_yaml in config_dict.get("skill_configs", ())
             ]
 
             config_dict["agent_capability_types"] = [
-                ConfigMeta.from_yaml(ac_yaml)
+                AgentCapabilityMeta.from_yaml(ac_yaml)
                 for ac_yaml in config_dict.get("agent_capability_types", ())
             ]
 
             config_dict["agent_configs"] = [
-                ConfigMeta.from_yaml(ac_yaml)
+                AgentConfigMeta.from_yaml(ac_yaml)
                 for ac_yaml in config_dict.get("agent_configs", ())
             ]
 
             config_dict["secret_sources"] = [
-                ConfigMeta.from_yaml(ss_yaml)
+                SecretSourceMeta.from_yaml(ss_yaml)
                 for ss_yaml in config_dict.get("secret_sources", ())
             ]
 
@@ -264,48 +563,46 @@ class InstallationConfigMeta:
             )
 
         self.tool_configs = list(self.tool_configs)
+        tc_registry = config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME
         for tc_meta in self.tool_configs:
-            klass = tc_meta.config_klass
-            config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME[klass.tool_name] = (
-                klass
-            )
+            tc_registry[tc_meta.tool_name] = tc_meta.config_klass
 
         self.mcp_toolset_configs = list(self.mcp_toolset_configs)
+        mtc_registry = config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND
         for mtc_meta in self.mcp_toolset_configs:
-            klass = mtc_meta.config_klass
-            config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND[klass.kind] = klass
+            mtc_registry[mtc_meta.kind] = mtc_meta.config_klass
 
         self.mcp_server_tool_wrappers = list(self.mcp_server_tool_wrappers)
+        mstw_registry = config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME
         for mstw_meta in self.mcp_server_tool_wrappers:
-            config_klass = mstw_meta.config_klass
-            tool_name = config_klass.tool_name
-            wrapper_klass = mstw_meta.wrapper_klass
-            config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME[tool_name] = (
-                wrapper_klass
-            )
+            if mstw_meta.tool_name not in tc_registry:
+                raise WrapperForUnknownToolConfig(
+                    tool_config_klass=mstw_meta.config_klass,
+                    wrapper_klass=mstw_meta.wrapper_klass,
+                )
+            mstw_registry[mstw_meta.tool_name] = mstw_meta.wrapper_klass
 
         self.skill_configs = list(self.skill_configs)
+        sc_registry = config_skills.SKILL_CONFIG_CLASSES_BY_KIND
         for sc_meta in self.skill_configs:
-            klass = sc_meta.config_klass
-            config_skills.SKILL_CONFIG_CLASSES_BY_KIND[klass.kind] = klass
+            sc_registry[sc_meta.kind] = sc_meta.config_klass
 
         self.agent_capability_types = list(self.agent_capability_types)
         act_registry = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME
         for act_meta in self.agent_capability_types:
-            klass = act_meta.config_klass
-            act_registry[klass.__name__] = klass
+            act_registry[act_meta.capability_name] = act_meta.config_klass
 
         self.agent_configs = list(self.agent_configs)
+        ac_registry = config_agents.AGENT_CONFIG_CLASSES_BY_KIND
         for ac_meta in self.agent_configs:
-            klass = ac_meta.config_klass
-            config_agents.AGENT_CONFIG_CLASSES_BY_KIND[klass.kind] = klass
+            ac_registry[ac_meta.kind] = ac_meta.config_klass
 
         self.secret_sources = list(self.secret_sources)
-        ss_registry = config_secrets.SECRET_GETTERS_BY_KIND
+        sg_registry = config_secrets.SECRET_GETTERS_BY_KIND
+        ss_registry = config_secrets.SourceClassesByKind
         for ss_meta in self.secret_sources:
-            config_klass = ss_meta.config_klass
-            registered_func = ss_meta.registered_func
-            ss_registry[config_klass.kind] = registered_func
+            sg_registry[ss_meta.kind] = ss_meta.registered_func
+            ss_registry[ss_meta.kind] = ss_meta.config_klass
 
         self.jsonpath_functions = list(self.jsonpath_functions)
         for jf_meta in self.jsonpath_functions:
@@ -323,60 +620,52 @@ class InstallationConfigMeta:
             for feature in agui_feature_registry.values()
         ]
 
-        tool_config_registry = config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME
+        tc_registry = config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME
         tool_config_entries = [
-            _utils._dotted_name(klass)
-            for klass in tool_config_registry.values()
+            _utils._dotted_name(klass) for klass in tc_registry.values()
         ]
 
-        mcp_toolset_config_registry = (
-            config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND
-        )
+        mcptc_registry = config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND
         mcp_toolset_config_entries = [
-            _utils._dotted_name(klass)
-            for klass in mcp_toolset_config_registry.values()
+            _utils._dotted_name(klass) for klass in mcptc_registry.values()
         ]
 
-        mcp_tool_wrapper_registry = (
-            config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME
-        )
+        mcptw_registry = config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME
         mcp_server_tool_wrapper_entries = [
             {
                 "config_klass": _utils._dotted_name(
-                    tool_config_registry[tool_name],
+                    tc_registry[tool_name],
                 ),
                 "wrapper_klass": _utils._dotted_name(wrapper_klass),
             }
-            for tool_name, wrapper_klass in mcp_tool_wrapper_registry.items()
+            for tool_name, wrapper_klass in mcptw_registry.items()
         ]
 
-        skill_config_registry = config_skills.SKILL_CONFIG_CLASSES_BY_KIND
+        sc_registry = config_skills.SKILL_CONFIG_CLASSES_BY_KIND
         skill_config_entries = [
-            _utils._dotted_name(klass)
-            for klass in skill_config_registry.values()
+            _utils._dotted_name(klass) for klass in sc_registry.values()
         ]
 
-        cap_types = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME.values()
+        cap_registry = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME.values()
         capability_type_entries = [
-            _utils._dotted_name(klass) for klass in cap_types
+            _utils._dotted_name(klass) for klass in cap_registry
         ]
 
-        agent_config_registry = config_agents.AGENT_CONFIG_CLASSES_BY_KIND
+        ac_registry = config_agents.AGENT_CONFIG_CLASSES_BY_KIND
         agent_config_entries = [
-            _utils._dotted_name(klass)
-            for klass in agent_config_registry.values()
+            _utils._dotted_name(klass) for klass in ac_registry.values()
         ]
 
-        secret_source_registry = config_secrets.SourceClassesByKind
-        secret_getter_registry = config_secrets.SECRET_GETTERS_BY_KIND
+        ss_registry = config_secrets.SourceClassesByKind
+        sg_registry = config_secrets.SECRET_GETTERS_BY_KIND
         secret_source_entries = [
             {
                 "config_klass": _utils._dotted_name(
-                    secret_source_registry[kind],
+                    ss_registry[kind],
                 ),
                 "registered_func": _utils._dotted_name(r_func),
             }
-            for kind, r_func in secret_getter_registry.items()
+            for kind, r_func in sg_registry.items()
         ]
 
         jsonpath_function_registry = authz.registered_jsonpath_functions()

--- a/tests/unit/_test_metaconfig.py
+++ b/tests/unit/_test_metaconfig.py
@@ -1,0 +1,69 @@
+import typing
+from collections import abc
+
+from soliplex import secrets as soliplex_secrets
+from soliplex.config import skills as config_skills
+from soliplex.config import tools as config_tools
+
+
+class DummyModelClass:
+    pass
+
+
+def dummy_tool(query: str):  # pragma: NO COVER (registered, not called)
+    pass
+
+
+class DummyToolConfig(config_tools.ToolConfig):
+    tool_name = "_test_metaconfig.dummy_tool"
+    kind = "DummyToolConfig"
+
+
+class DummyMCP_ToolsetConfig:
+    kind = "dummy"
+
+
+class DummyMCPWrapper:
+    func: abc.Callable[..., typing.Any]
+    tool_config: config_tools.ToolConfig
+
+    def __call__(
+        self,
+        tweedle: str,
+    ):  # pragma: NO COVER (registered, not called)
+        return self.func(tweedle, tool_config=self.tool_config)
+
+
+class DummySkillConfig(config_skills.SkillConfig):
+    skill_name = "_test_metaconfig.DummySkillConfig"
+    name = "test_skiil"
+    description = "Test Skill"
+    kind = "DummySkillConfig"
+
+
+class DummyAgentCapability:
+    dotted_name = "foo.bar"
+
+
+class DummyAgentConfig:
+    kind = "dummy"
+
+
+def dummy_secret_getter(source):  # pragma: NO COVER (registered, not called)
+    raise soliplex_secrets.UnknownSecret("dummy")
+
+
+class DummySecretSource:
+    kind = "dummy"
+
+
+class DummyConfigClass:
+    pass
+
+
+class DummyWrapperClass:
+    pass
+
+
+def dummy_jsonpath_func():  # pragma: NO COVER (registered, not called)
+    pass

--- a/tests/unit/config/test_config_installation.py
+++ b/tests/unit/config/test_config_installation.py
@@ -5,6 +5,7 @@ import pathlib
 from unittest import mock
 
 import _test_features as agui_features
+import _test_metaconfig
 import _test_middleware
 import pytest
 import yaml
@@ -74,38 +75,45 @@ W_FULL_META_INSTALLATION_CONFIG_KW = {
             ),
         ],
         "tool_configs": [
-            config_meta.ConfigMeta(config_klass=FauxToolConfig),
+            config_meta.ToolConfigMeta(config_klass=FauxToolConfig),
         ],
         "mcp_toolset_configs": [
-            config_meta.ConfigMeta(
+            config_meta.MCP_ToolsetConfigMeta(
                 config_klass=config_tools.Stdio_MCP_ClientToolsetConfig
             ),
-            config_meta.ConfigMeta(
+            config_meta.MCP_ToolsetConfigMeta(
                 config_klass=config_tools.HTTP_MCP_ClientToolsetConfig
             ),
         ],
         "mcp_server_tool_wrappers": [
-            config_meta.ConfigMeta(
+            config_meta.MCP_ServerToolWrapperConfigMeta(
                 config_klass=FauxToolConfig,
                 wrapper_klass=config_tools.NoArgsMCPWrapper,
             ),
         ],
         "skill_configs": [
-            config_meta.ConfigMeta(
+            config_meta.SkillConfigMeta(
                 config_klass=config_skills.HR_RAG_SkillConfig
             ),
-            config_meta.ConfigMeta(
+            config_meta.SkillConfigMeta(
                 config_klass=config_skills.HR_Analysis_SkillConfig
             ),
         ],
+        "agent_capability_types": [
+            config_meta.AgentCapabilityMeta(
+                config_klass=_test_metaconfig.DummyAgentCapability
+            ),
+        ],
         "agent_configs": [
-            config_meta.ConfigMeta(config_klass=config_agents.AgentConfig),
-            config_meta.ConfigMeta(
+            config_meta.AgentConfigMeta(
+                config_klass=config_agents.AgentConfig,
+            ),
+            config_meta.AgentConfigMeta(
                 config_klass=config_agents.FactoryAgentConfig
             ),
         ],
         "secret_sources": [
-            config_meta.ConfigMeta(
+            config_meta.SecretSourceMeta(
                 config_klass=config_secrets.EnvVarSecretSource,
                 registered_func=test_meta.SECRET_SOURCE_FUNC,
             ),
@@ -130,6 +138,8 @@ meta:
   skill_configs:
       - "soliplex.config.skills.HR_RAG_SkillConfig"
       - "soliplex.config.skills.HR_Analysis_SkillConfig"
+  agent_capability_types:
+      - "_test_metaconfig.DummyAgentCapability"
   agent_configs:
       - "soliplex.config.agents.AgentConfig"
       - "soliplex.config.agents.FactoryAgentConfig"
@@ -305,7 +315,7 @@ W_FACTORY_AGENT_CONFIG_INSTALLATION_CONFIG_KW = {
     "id": INSTALLATION_ID,
     "meta": {
         "agent_configs": [
-            config_meta.ConfigMeta(
+            config_meta.AgentConfigMeta(
                 config_klass=config_agents.FactoryAgentConfig,
             ),
         ],

--- a/tests/unit/config/test_config_meta.py
+++ b/tests/unit/config/test_config_meta.py
@@ -1,36 +1,17 @@
 import contextlib
 import copy
-import dataclasses
-import typing
+import warnings
 from unittest import mock
 
 import _test_features as agui_features
+import _test_metaconfig
 import pytest
 import yaml
 
 from soliplex import authz
-from soliplex import secrets
-from soliplex.config import agents as config_agents
+from soliplex.config import _utils
 from soliplex.config import exceptions as config_exc
 from soliplex.config import meta as config_meta
-from soliplex.config import secrets as config_secrets
-from soliplex.config import skills as config_skills
-from soliplex.config import tools as config_tools
-
-NoRaise = contextlib.nullcontext()
-
-
-class FauxToolConfig:
-    tool_name = "faux"
-
-
-class FauxCapability:
-    dotted_name = "foo.bar"
-
-
-def faux_jsonpath_func(value):  # pragma: NO COVER (registered, not called)
-    return value
-
 
 BOGUS_ICMETA_YAML = """\
 meta:
@@ -72,81 +53,87 @@ meta:
 
 W_TOOL_CONFIGS_ICMETA_KW = BARE_ICMETA_KW | {
     "tool_configs": [
-        config_meta.ConfigMeta(config_klass=FauxToolConfig),
+        config_meta.ToolConfigMeta(
+            config_klass=_test_metaconfig.DummyToolConfig,
+        ),
     ],
     "mcp_server_tool_wrappers": [
-        config_meta.ConfigMeta(
-            config_klass=FauxToolConfig,
-            wrapper_klass=config_tools.NoArgsMCPWrapper,
+        config_meta.MCP_ServerToolWrapperConfigMeta(
+            config_klass=_test_metaconfig.DummyToolConfig,
+            wrapper_klass=_test_metaconfig.DummyMCPWrapper,
         ),
     ],
 }
 W_TOOL_CONFIGS_ICMETA_YAML = """\
 meta:
   tool_configs:
-    - "test_config_meta.FauxToolConfig"
+    - "_test_metaconfig.DummyToolConfig"
   mcp_server_tool_wrappers:
-    - config_klass: "test_config_meta.FauxToolConfig"
-      wrapper_klass: "soliplex.config.tools.NoArgsMCPWrapper"
+    - config_klass: "_test_metaconfig.DummyToolConfig"
+      wrapper_klass: "_test_metaconfig.DummyMCPWrapper"
 """
 
 
 W_MCP_TOOLSET_CONFIGS_ICMETA_KW = BARE_ICMETA_KW | {
     "mcp_toolset_configs": [
-        config_meta.ConfigMeta(
-            config_klass=config_tools.Stdio_MCP_ClientToolsetConfig,
+        config_meta.MCP_ToolsetConfigMeta(
+            config_klass=_test_metaconfig.DummyMCP_ToolsetConfig,
         )
     ],
 }
 W_MCP_TOOLSET_CONFIGS_ICMETA_YAML = """\
 meta:
   mcp_toolset_configs:
-    - "soliplex.config.tools.Stdio_MCP_ClientToolsetConfig"
+    - "_test_metaconfig.DummyMCP_ToolsetConfig"
 """
 
 
 W_SKILL_CONFIGS_ICMETA_KW = BARE_ICMETA_KW | {
     "skill_configs": [
-        config_meta.ConfigMeta(config_klass=config_skills.HR_RAG_SkillConfig),
+        config_meta.SkillConfigMeta(
+            config_klass=_test_metaconfig.DummySkillConfig,
+        ),
     ],
 }
 W_SKILL_CONFIGS_ICMETA_YAML = """\
 meta:
   skill_configs:
-    - "soliplex.config.skills.HR_RAG_SkillConfig"
+    - "_test_metaconfig.DummySkillConfig"
 """
 
 
 W_AGENT_CAPABILITY_ICMETA_KW = BARE_ICMETA_KW | {
     "agent_capability_types": [
-        config_meta.ConfigMeta(config_klass=FauxCapability),
+        config_meta.AgentCapabilityMeta(
+            config_klass=_test_metaconfig.DummyAgentCapability
+        ),
     ],
 }
 W_AGENT_CAPABILITY_ICMETA_YAML = """\
 meta:
   agent_capability_types:
-      - "test_config_meta.FauxCapability"
+      - "_test_metaconfig.DummyAgentCapability"
 """
 
 
 W_AGENT_CONFIGS_ICMETA_KW = BARE_ICMETA_KW | {
     "agent_configs": [
-        config_meta.ConfigMeta(config_klass=config_agents.AgentConfig),
-        config_meta.ConfigMeta(config_klass=config_agents.FactoryAgentConfig),
+        config_meta.AgentConfigMeta(
+            config_klass=_test_metaconfig.DummyAgentConfig,
+        ),
     ],
 }
 W_AGENT_CONFIGS_ICMETA_YAML = """\
 meta:
   agent_configs:
-      - "soliplex.config.agents.AgentConfig"
-      - "soliplex.config.agents.FactoryAgentConfig"
+      - "_test_metaconfig.DummyAgentConfig"
 """
 
 SECRET_SOURCE_FUNC = lambda source: "SEEKRIT"  # noqa E731
 W_SECRET_SOURCE_ICMETA_KW = BARE_ICMETA_KW | {
     "secret_sources": [
-        config_meta.ConfigMeta(
-            config_klass=config_secrets.EnvVarSecretSource,
+        config_meta.SecretSourceMeta(
+            config_klass=_test_metaconfig.DummySecretSource,
             registered_func=SECRET_SOURCE_FUNC,
         ),
     ],
@@ -154,7 +141,7 @@ W_SECRET_SOURCE_ICMETA_KW = BARE_ICMETA_KW | {
 W_SECRET_SOURCE_ICMETA_YAML = """\
 meta:
   secret_sources:
-    - "config_klass": "soliplex.config.secrets.EnvVarSecretSource"
+    - "config_klass": "_test_metaconfig.DummySecretSource"
       "registered_func": "soliplex.config.test_secret_func"
 """
 
@@ -164,7 +151,7 @@ W_JSONPATH_FUNCTIONS_ICMETA_KW = BARE_ICMETA_KW | {
     "jsonpath_functions": [
         config_meta.JSONPathFunctionConfigMeta(
             name=JSONPATH_FUNCTION_NAME,
-            func=faux_jsonpath_func,
+            func=_test_metaconfig.dummy_jsonpath_func,
         ),
     ],
 }
@@ -172,7 +159,7 @@ W_JSONPATH_FUNCTIONS_ICMETA_YAML = f"""\
 meta:
   jsonpath_functions:
       - name: "{JSONPATH_FUNCTION_NAME}"
-        func: "test_config_meta.faux_jsonpath_func"
+        func: "_test_metaconfig.dummy_jsonpath_func"
 """
 
 
@@ -185,42 +172,46 @@ FULL_ICMETA_KW = {
         ),
     ],
     "tool_configs": [
-        config_meta.ConfigMeta(config_klass=FauxToolConfig),
+        config_meta.ToolConfigMeta(
+            config_klass=_test_metaconfig.DummyToolConfig,
+        ),
     ],
     "mcp_toolset_configs": [
-        config_meta.ConfigMeta(
-            config_klass=config_tools.Stdio_MCP_ClientToolsetConfig
-        ),
-        config_meta.ConfigMeta(
-            config_klass=config_tools.HTTP_MCP_ClientToolsetConfig
+        config_meta.MCP_ToolsetConfigMeta(
+            config_klass=_test_metaconfig.DummyMCP_ToolsetConfig,
         ),
     ],
     "mcp_server_tool_wrappers": [
-        config_meta.ConfigMeta(
-            config_klass=FauxToolConfig,
-            wrapper_klass=config_tools.NoArgsMCPWrapper,
+        config_meta.MCP_ServerToolWrapperConfigMeta(
+            config_klass=_test_metaconfig.DummyToolConfig,
+            wrapper_klass=_test_metaconfig.DummyMCPWrapper,
         ),
     ],
     "skill_configs": [
-        config_meta.ConfigMeta(config_klass=config_skills.HR_RAG_SkillConfig),
-        config_meta.ConfigMeta(
-            config_klass=config_skills.HR_Analysis_SkillConfig
+        config_meta.SkillConfigMeta(
+            config_klass=_test_metaconfig.DummySkillConfig,
+        ),
+    ],
+    "agent_capability_types": [
+        config_meta.AgentCapabilityMeta(
+            config_klass=_test_metaconfig.DummyAgentCapability,
         ),
     ],
     "agent_configs": [
-        config_meta.ConfigMeta(config_klass=config_agents.AgentConfig),
-        config_meta.ConfigMeta(config_klass=config_agents.FactoryAgentConfig),
+        config_meta.AgentConfigMeta(
+            config_klass=_test_metaconfig.DummyAgentConfig,
+        ),
     ],
     "secret_sources": [
-        config_meta.ConfigMeta(
-            config_klass=config_secrets.EnvVarSecretSource,
+        config_meta.SecretSourceMeta(
+            config_klass=_test_metaconfig.DummySecretSource,
             registered_func=SECRET_SOURCE_FUNC,
         ),
     ],
     "jsonpath_functions": [
         config_meta.JSONPathFunctionConfigMeta(
             name=JSONPATH_FUNCTION_NAME,
-            func=faux_jsonpath_func,
+            func=_test_metaconfig.dummy_jsonpath_func,
         ),
     ],
 }
@@ -231,85 +222,60 @@ meta:
         model_klass: "_test_features.EmptyFeatureModel"
         source: "server"
   tool_configs:
-    - "test_config_meta.FauxToolConfig"
+    - "_test_metaconfig.DummyToolConfig"
   mcp_toolset_configs:
-      - "soliplex.config.tools.Stdio_MCP_ClientToolsetConfig"
-      - "soliplex.config.tools.HTTP_MCP_ClientToolsetConfig"
+      - "_test_metaconfig.DummyMCP_ToolsetConfig"
   mcp_server_tool_wrappers:
-    - config_klass: "test_config_meta.FauxToolConfig"
-      wrapper_klass: "soliplex.config.tools.NoArgsMCPWrapper"
+    - config_klass: "_test_metaconfig.DummyToolConfig"
+      wrapper_klass: "_test_metaconfig.DummyMCPWrapper"
   skill_configs:
-      - "soliplex.config.skills.HR_RAG_SkillConfig"
-      - "soliplex.config.skills.HR_Analysis_SkillConfig"
+      - "_test_metaconfig.DummySkillConfig"
+  agent_capability_types:
+      - "_test_metaconfig.DummyAgentCapability"
   agent_configs:
-      - "soliplex.config.agents.AgentConfig"
-      - "soliplex.config.agents.FactoryAgentConfig"
+      - "_test_metaconfig.DummyAgentConfig"
   secret_sources:
-    - "config_klass": "soliplex.config.secrets.EnvVarSecretSource"
+    - "config_klass": "_test_metaconfig.DummySecretSource"
       "registered_func": "soliplex.config.test_secret_func"
   jsonpath_functions:
       - name: "{JSONPATH_FUNCTION_NAME}"
-        func: "test_config_meta.faux_jsonpath_func"
+        func: "_test_metaconfig.dummy_jsonpath_func"
 """
 
-
-def test_jsonpathfunctionconfigmeta_from_yaml():
-    with mock.patch.dict("sys.modules", dummy=mock.Mock()):
-        import dummy
-
-        dummy.the_func = func = mock.Mock()
-
-        meta = config_meta.JSONPathFunctionConfigMeta.from_yaml(
-            {"name": "is_admin", "func": "dummy.the_func"}
-        )
-
-    assert meta.name == "is_admin"
-    assert meta.func is func
+NoRaise = contextlib.nullcontext()
 
 
-@mock.patch("importlib.import_module")
-def test_configmeta_from_yaml_w_importable_name(im):
-    config_yaml = "somemodule.SomeClass"
+def test_configmeta_from_yaml_w_importable_name():
+    config_yaml = "_test_metaconfig.DummyConfigClass"
 
-    faux_module = im.return_value = mock.Mock()
+    with warnings.catch_warnings(record=True) as warned:
+        meta = config_meta.ConfigMeta.from_yaml(config_yaml)
 
-    meta = config_meta.ConfigMeta.from_yaml(config_yaml)
+    assert meta.config_klass is _test_metaconfig.DummyConfigClass
+    assert meta.wrapper_klass is None
+    assert meta.registered_func is None
 
-    assert meta.config_klass is faux_module.SomeClass
+    (warning,) = warned
+    assert str(warning.message) == config_meta.CONFIG_META_DEPRECATED
+    assert warning.category is DeprecationWarning
 
 
+@pytest.mark.parametrize("w_regfunc", [False, True])
 @pytest.mark.parametrize("w_wrapper", [False, True])
-def test_configmeta_from_yaml_w_dict(w_wrapper):
+def test_configmeta_from_yaml_w_dict(w_wrapper, w_regfunc):
     config_klass = mock.Mock()
     wrapper_klass = mock.Mock()
+    registered_func = mock.Mock()
 
     config_yaml = {"config_klass": config_klass}
 
     if w_wrapper:
         config_yaml["wrapper_klass"] = wrapper_klass
 
-    meta = config_meta.ConfigMeta.from_yaml(config_yaml)
+    if w_regfunc:
+        config_yaml["registered_func"] = registered_func
 
-    assert meta.config_klass is config_klass
-
-    if w_wrapper:
-        assert meta.wrapper_klass is wrapper_klass
-    else:
-        assert meta.wrapper_klass is None
-
-
-@pytest.mark.parametrize("w_wrapper", [False, True])
-def test_configmeta_from_yaml_w_dict_w_names(w_wrapper):
-    dummy_module = mock.Mock()
-    config_klass = dummy_module.ConfigClass = mock.Mock()
-    wrapper_klass = dummy_module.WrapperClass = mock.Mock()
-
-    config_yaml = {"config_klass": "dummy.ConfigClass"}
-
-    if w_wrapper:
-        config_yaml["wrapper_klass"] = "dummy.WrapperClass"
-
-    with mock.patch.dict("sys.modules", dummy=dummy_module):
+    with warnings.catch_warnings(record=True) as warned:
         meta = config_meta.ConfigMeta.from_yaml(config_yaml)
 
     assert meta.config_klass is config_klass
@@ -318,6 +284,358 @@ def test_configmeta_from_yaml_w_dict_w_names(w_wrapper):
         assert meta.wrapper_klass is wrapper_klass
     else:
         assert meta.wrapper_klass is None
+
+    if w_regfunc:
+        assert meta.registered_func is registered_func
+    else:
+        assert meta.registered_func is None
+
+    (warning,) = warned
+    assert str(warning.message) == config_meta.CONFIG_META_DEPRECATED
+    assert warning.category is DeprecationWarning
+
+
+@pytest.mark.parametrize("w_regfunc", [False, True])
+@pytest.mark.parametrize("w_wrapper", [False, True])
+def test_configmeta_from_yaml_w_dict_w_names(
+    w_wrapper,
+    w_regfunc,
+):
+    config_yaml = {"config_klass": "_test_metaconfig.DummyConfigClass"}
+
+    if w_wrapper:
+        config_yaml["wrapper_klass"] = "_test_metaconfig.DummyWrapperClass"
+
+    if w_regfunc:
+        config_yaml["registered_func"] = "_test_metaconfig.dummy_jsonpath_func"
+
+    with warnings.catch_warnings(record=True) as warned:
+        meta = config_meta.ConfigMeta.from_yaml(config_yaml)
+
+    assert meta.config_klass is _test_metaconfig.DummyConfigClass
+
+    if w_wrapper:
+        assert meta.wrapper_klass is _test_metaconfig.DummyWrapperClass
+    else:
+        assert meta.wrapper_klass is None
+
+    if w_regfunc:
+        assert meta.registered_func is _test_metaconfig.dummy_jsonpath_func
+    else:
+        assert meta.registered_func is None
+
+    (warning,) = warned
+    assert str(warning.message) == config_meta.CONFIG_META_DEPRECATED
+    assert warning.category is DeprecationWarning
+
+
+@pytest.mark.parametrize(
+    "w_source_kw, exp_source",
+    [
+        ({}, "either"),
+        ({"source": "either"}, "either"),
+        ({"source": "server"}, "server"),
+        ({"source": "client"}, "client"),
+    ],
+)
+def test_agui_featureconfigmeta_from_yaml(w_source_kw, exp_source):
+
+    meta = config_meta.AGUI_FeatureConfigMeta.from_yaml(
+        {
+            "name": "my_feature",
+            "model_klass": "_test_metaconfig.DummyModelClass",
+        }
+        | w_source_kw
+    )
+
+    assert meta.name == "my_feature"
+    assert meta.model_klass is _test_metaconfig.DummyModelClass
+    assert meta.source == exp_source
+
+
+@pytest.mark.parametrize(
+    "w_depr_kw",
+    [
+        {},
+        {"wrapper_klass": "dummy.nonesuch_wrapper"},
+        {"registered_func": "dummy.nonesuch_func"},
+        {
+            "wrapper_klass": "dummy.nonesuch_wrapper",
+            "registered_func": "dummy.nonesuch_func",
+        },
+    ],
+)
+@pytest.mark.parametrize("w_bare_str", [False, True])
+def test_toolconfigmeta_from_yaml(w_bare_str, w_depr_kw):
+    tool_config_klassname = "_test_metaconfig.DummyToolConfig"
+
+    if w_bare_str:
+        yaml_config = tool_config_klassname
+    else:
+        yaml_config = {
+            "config_klass": tool_config_klassname,
+        } | w_depr_kw
+
+    with warnings.catch_warnings(record=True) as warned:
+        found = config_meta.ToolConfigMeta.from_yaml(yaml_config)
+
+    assert found.config_klass is _test_metaconfig.DummyToolConfig
+    assert found.tool_name == _test_metaconfig.DummyToolConfig.tool_name
+
+    if not w_bare_str:
+        assert len(warned) == len(w_depr_kw)
+
+        messages = []
+        for warning in warned:
+            assert warning.category is DeprecationWarning
+            messages.append(str(warning.message))
+
+        for key in w_depr_kw:
+            assert any(key in message for message in messages)
+
+
+@pytest.mark.parametrize(
+    "w_depr_kw",
+    [
+        {},
+        {"wrapper_klass": "dummy.nonesuch_wrapper"},
+        {"registered_func": "dummy.nonesuch_func"},
+        {
+            "wrapper_klass": "dummy.nonesuch_wrapper",
+            "registered_func": "dummy.nonesuch_func",
+        },
+    ],
+)
+@pytest.mark.parametrize("w_bare_str", [False, True])
+def test_mcp_toolsetconfigmeta_from_yaml(w_bare_str, w_depr_kw):
+    tool_config_klassname = "_test_metaconfig.DummyToolConfig"
+
+    if w_bare_str:
+        yaml_config = tool_config_klassname
+    else:
+        yaml_config = {
+            "config_klass": tool_config_klassname,
+        } | w_depr_kw
+
+    with warnings.catch_warnings(record=True) as warned:
+        found = config_meta.MCP_ToolsetConfigMeta.from_yaml(yaml_config)
+
+    assert found.config_klass is _test_metaconfig.DummyToolConfig
+    assert found.kind == _test_metaconfig.DummyToolConfig.kind
+
+    if not w_bare_str:
+        assert len(warned) == len(w_depr_kw)
+
+        messages = []
+        for warning in warned:
+            assert warning.category is DeprecationWarning
+            messages.append(str(warning.message))
+
+        for key in w_depr_kw:
+            assert any(key in message for message in messages)
+
+
+@pytest.mark.parametrize(
+    "w_depr_kw",
+    [
+        {},
+        {"registered_func": "dummy.nonesuch_func"},
+    ],
+)
+def test_mcp_servertoolwrapperconfigmeta_from_yaml(w_depr_kw):
+    tool_config_klassname = "_test_metaconfig.DummyToolConfig"
+    wrapper_klassname = "_test_metaconfig.DummyMCPWrapper"
+
+    yaml_config = {
+        "config_klass": tool_config_klassname,
+        "wrapper_klass": wrapper_klassname,
+    } | w_depr_kw
+
+    with warnings.catch_warnings(record=True) as warned:
+        found = config_meta.MCP_ServerToolWrapperConfigMeta.from_yaml(
+            yaml_config,
+        )
+
+    assert found.config_klass is _test_metaconfig.DummyToolConfig
+    assert found.wrapper_klass is _test_metaconfig.DummyMCPWrapper
+    assert found.tool_name == _test_metaconfig.DummyToolConfig.tool_name
+
+    assert len(warned) == len(w_depr_kw)
+
+    messages = []
+    for warning in warned:
+        assert warning.category is DeprecationWarning
+        messages.append(str(warning.message))
+
+    for key in w_depr_kw:
+        assert any(key in message for message in messages)
+
+
+@pytest.mark.parametrize(
+    "w_depr_kw",
+    [
+        {},
+        {"wrapper_klass": "dummy.nonesuch_wrapper"},
+        {"registered_func": "dummy.nonesuch_func"},
+        {
+            "wrapper_klass": "dummy.nonesuch_wrapper",
+            "registered_func": "dummy.nonesuch_func",
+        },
+    ],
+)
+@pytest.mark.parametrize("w_bare_str", [False, True])
+def test_skillconfigmeta_from_yaml(w_bare_str, w_depr_kw):
+    skill_config_klassname = "_test_metaconfig.DummySkillConfig"
+
+    if w_bare_str:
+        yaml_config = skill_config_klassname
+    else:
+        yaml_config = {
+            "config_klass": skill_config_klassname,
+        } | w_depr_kw
+
+    with warnings.catch_warnings(record=True) as warned:
+        found = config_meta.SkillConfigMeta.from_yaml(yaml_config)
+
+    assert found.config_klass is _test_metaconfig.DummySkillConfig
+    assert found.kind == _test_metaconfig.DummySkillConfig.kind
+
+    if not w_bare_str:
+        assert len(warned) == len(w_depr_kw)
+
+        messages = []
+        for warning in warned:
+            assert warning.category is DeprecationWarning
+            messages.append(str(warning.message))
+
+        for key in w_depr_kw:
+            assert any(key in message for message in messages)
+
+
+@pytest.mark.parametrize(
+    "w_depr_kw",
+    [
+        {},
+        {"wrapper_klass": "dummy.nonesuch_wrapper"},
+        {"registered_func": "dummy.nonesuch_func"},
+        {
+            "wrapper_klass": "dummy.nonesuch_wrapper",
+            "registered_func": "dummy.nonesuch_func",
+        },
+    ],
+)
+@pytest.mark.parametrize("w_bare_str", [False, True])
+def test_agentcapabilityconfigmeta_from_yaml(w_bare_str, w_depr_kw):
+    capability_klassname = "_test_metaconfig.DummyAgentCapability"
+    exp_cap_klass = _test_metaconfig.DummyAgentCapability
+
+    if w_bare_str:
+        yaml_config = capability_klassname
+    else:
+        yaml_config = {
+            "config_klass": capability_klassname,
+        } | w_depr_kw
+
+    with warnings.catch_warnings(record=True) as warned:
+        found = config_meta.AgentCapabilityMeta.from_yaml(yaml_config)
+
+    assert found.config_klass is exp_cap_klass
+    assert found.capability_name == exp_cap_klass.__name__
+
+    if not w_bare_str:
+        assert len(warned) == len(w_depr_kw)
+
+        messages = []
+        for warning in warned:
+            assert warning.category is DeprecationWarning
+            messages.append(str(warning.message))
+
+        for key in w_depr_kw:
+            assert any(key in message for message in messages)
+
+
+@pytest.mark.parametrize(
+    "w_depr_kw",
+    [
+        {},
+        {"wrapper_klass": "dummy.nonesuch_wrapper"},
+        {"registered_func": "dummy.nonesuch_func"},
+        {
+            "wrapper_klass": "dummy.nonesuch_wrapper",
+            "registered_func": "dummy.nonesuch_func",
+        },
+    ],
+)
+@pytest.mark.parametrize("w_bare_str", [False, True])
+def test_agentconfigmeta_from_yaml(w_bare_str, w_depr_kw):
+    agent_config_klassname = "_test_metaconfig.DummyAgentConfig"
+
+    if w_bare_str:
+        yaml_config = agent_config_klassname
+    else:
+        yaml_config = {
+            "config_klass": agent_config_klassname,
+        } | w_depr_kw
+
+    with warnings.catch_warnings(record=True) as warned:
+        found = config_meta.AgentConfigMeta.from_yaml(yaml_config)
+
+    assert found.config_klass is _test_metaconfig.DummyAgentConfig
+    assert found.kind == _test_metaconfig.DummyAgentConfig.kind
+
+    if not w_bare_str:
+        assert len(warned) == len(w_depr_kw)
+
+        messages = []
+        for warning in warned:
+            assert warning.category is DeprecationWarning
+            messages.append(str(warning.message))
+
+        for key in w_depr_kw:
+            assert any(key in message for message in messages)
+
+
+@pytest.mark.parametrize(
+    "w_depr_kw",
+    [
+        {},
+        {"wrapper_klass": "dummy.nonesuch_wrapper"},
+    ],
+)
+def test_secretsourcemeta_from_yaml(w_depr_kw):
+    secret_source_klassname = "_test_metaconfig.DummySecretSource"
+    registered_funcname = "_test_metaconfig.dummy_secret_getter"
+
+    yaml_config = {
+        "config_klass": secret_source_klassname,
+        "registered_func": registered_funcname,
+    } | w_depr_kw
+
+    with warnings.catch_warnings(record=True) as warned:
+        found = config_meta.SecretSourceMeta.from_yaml(yaml_config)
+
+    assert found.config_klass is _test_metaconfig.DummySecretSource
+    assert found.registered_func is _test_metaconfig.dummy_secret_getter
+    assert found.kind == _test_metaconfig.DummySecretSource.kind
+
+    assert len(warned) == len(w_depr_kw)
+
+    messages = []
+    for warning in warned:
+        assert warning.category is DeprecationWarning
+        messages.append(str(warning.message))
+
+    for key in w_depr_kw:
+        assert any(key in message for message in messages)
+
+
+def test_jsonpathfunctionconfigmeta_from_yaml():
+    meta = config_meta.JSONPathFunctionConfigMeta.from_yaml(
+        {"name": "is_admin", "func": "_test_metaconfig.dummy_jsonpath_func"}
+    )
+
+    assert meta.name == "is_admin"
+    assert meta.func is _test_metaconfig.dummy_jsonpath_func
 
 
 @pytest.mark.parametrize(
@@ -349,6 +667,7 @@ def test_installationconfigmeta_from_yaml(
     patched_agent_capabilities,
     patched_agent_configs,
     patched_secret_getters,
+    patched_secret_sources,
     patched_agui_features,
     patched_app_routers,
     patched_tool_configs,
@@ -432,10 +751,13 @@ def test_installationconfigmeta_from_yaml(
                 for klass in patched_mcp_tool_wrappers.values()
             }
             for meta_kw in config_dict_meta["mcp_server_tool_wrappers"]:
-                wrapper_klass_name = meta_kw["wrapper_klass"]
+                tool_config_klass = _utils._from_dotted_name(
+                    meta_kw["config_klass"]
+                )
+                wrapper_klassname = meta_kw["wrapper_klass"]
                 assert (
-                    patched_mcp_tool_wrappers["faux"]
-                    == mcptcp_by_class_name[wrapper_klass_name]
+                    patched_mcp_tool_wrappers[tool_config_klass.tool_name]
+                    == mcptcp_by_class_name[wrapper_klassname]
                 )
 
         if config_dict_meta and "agent_capability_types" in config_dict_meta:
@@ -457,17 +779,19 @@ def test_installationconfigmeta_from_yaml(
                 assert kind in patched_agent_configs
 
         if config_dict_meta and "secret_sources" in config_dict_meta:
+            ss_klass = _test_metaconfig.DummySecretSource
             assert patched_secret_getters == {
-                config_secrets.EnvVarSecretSource.kind: SECRET_SOURCE_FUNC
+                ss_klass.kind: SECRET_SOURCE_FUNC
             }
+            assert patched_secret_sources == {ss_klass.kind: ss_klass}
 
         if config_dict_meta and "jsonpath_functions" in config_dict_meta:
             assert authz.registered_jsonpath_functions() == {
-                JSONPATH_FUNCTION_NAME: faux_jsonpath_func
+                JSONPATH_FUNCTION_NAME: _test_metaconfig.dummy_jsonpath_func
             }
             assert (
                 patched_jsonpath_functions[JSONPATH_FUNCTION_NAME]
-                is faux_jsonpath_func
+                is _test_metaconfig.dummy_jsonpath_func
             )
 
 
@@ -484,6 +808,7 @@ def test_installationconfigmeta_as_yaml(
     patched_agent_capabilities,
     patched_skill_configs,
     patched_secret_getters,
+    patched_secret_sources,
     patched_agui_features,
     patched_app_routers,
     patched_tool_configs,
@@ -503,67 +828,69 @@ def test_installationconfigmeta_as_yaml(
     expected = copy.deepcopy(BARE_ICMETA_KW)
 
     if w_tools:
-        klass = FauxToolConfig
+        klass = _test_metaconfig.DummyToolConfig
         patched_tool_configs[klass.tool_name] = klass
         expected["tool_configs"].append(
-            "test_config_meta.FauxToolConfig",
+            "_test_metaconfig.DummyToolConfig",
         )
-        wrapper_klass = config_tools.NoArgsMCPWrapper
+        wrapper_klass = _test_metaconfig.DummyMCPWrapper
         patched_mcp_tool_wrappers[klass.tool_name] = wrapper_klass
         expected["mcp_server_tool_wrappers"].append(
             {
-                "config_klass": "test_config_meta.FauxToolConfig",
-                "wrapper_klass": "soliplex.config.tools.NoArgsMCPWrapper",
+                "config_klass": "_test_metaconfig.DummyToolConfig",
+                "wrapper_klass": "_test_metaconfig.DummyMCPWrapper",
             }
         )
 
     if w_mcp_toolsets:
-        klass = config_tools.Stdio_MCP_ClientToolsetConfig
+        klass = _test_metaconfig.DummyMCP_ToolsetConfig
         patched_mcp_toolset_configs[klass.kind] = klass
         expected["mcp_toolset_configs"].append(
-            "soliplex.config.tools.Stdio_MCP_ClientToolsetConfig",
+            "_test_metaconfig.DummyMCP_ToolsetConfig",
         )
 
     if w_skills:
-        klass = config_skills.HR_RAG_SkillConfig
+        klass = _test_metaconfig.DummySkillConfig
         patched_skill_configs[klass.kind] = klass
         expected["skill_configs"].append(
-            "soliplex.config.skills.HR_RAG_SkillConfig",
+            "_test_metaconfig.DummySkillConfig",
         )
 
     if w_capability:
-        klass = FauxCapability
+        klass = _test_metaconfig.DummyAgentCapability
         patched_agent_capabilities[klass.__name__] = klass
         expected["agent_capability_types"].append(
-            "test_config_meta.FauxCapability",
+            "_test_metaconfig.DummyAgentCapability",
         )
 
     if w_agent:
-        klass = config_agents.AgentConfig
+        klass = _test_metaconfig.DummyAgentConfig
         patched_agent_configs[klass.kind] = klass
         expected["agent_configs"].append(
-            "soliplex.config.agents.AgentConfig",
+            "_test_metaconfig.DummyAgentConfig",
         )
 
     if w_secret_reg:
-        klass = config_secrets.EnvVarSecretSource
-        registered_func = secrets.get_env_var_secret
+        klass = _test_metaconfig.DummySecretSource
+        registered_func = _test_metaconfig.dummy_secret_getter
         patched_secret_getters[klass.kind] = registered_func
+        patched_secret_sources[klass.kind] = klass
+
         expected["secret_sources"].append(
             {
-                "config_klass": "soliplex.config.secrets.EnvVarSecretSource",
-                "registered_func": "soliplex.secrets.get_env_var_secret",
+                "config_klass": "_test_metaconfig.DummySecretSource",
+                "registered_func": "_test_metaconfig.dummy_secret_getter",
             }
         )
 
     if w_jsonpath:
         authz.register_jsonpath_function(
-            JSONPATH_FUNCTION_NAME, faux_jsonpath_func
+            JSONPATH_FUNCTION_NAME, _test_metaconfig.dummy_jsonpath_func
         )
         expected["jsonpath_functions"].append(
             {
                 "name": JSONPATH_FUNCTION_NAME,
-                "func": "test_config_meta.faux_jsonpath_func",
+                "func": "_test_metaconfig.dummy_jsonpath_func",
             }
         )
 
@@ -577,49 +904,117 @@ def test_installationconfigmeta_as_yaml(
 def test_installationconfigmeta_postinit_registers_tool_configs(
     patched_tool_configs,
 ):
-    @dataclasses.dataclass(kw_only=True)
-    class _DummyToolConfig(config_tools.ToolConfig):
-        tool_name: str = "tests.unit.test_config.dummy_tool"
+    tc_klass = _test_metaconfig.DummyToolConfig
+    tc_meta = config_meta.ToolConfigMeta(config_klass=tc_klass)
 
-    tc_meta = config_meta.ConfigMeta(config_klass=_DummyToolConfig)
     config_meta.InstallationConfigMeta(tool_configs=[tc_meta])
 
-    assert patched_tool_configs[_DummyToolConfig.tool_name] is _DummyToolConfig
+    assert patched_tool_configs[tc_klass.tool_name] is tc_klass
 
 
-def test_installationconfigmeta_postinit_registers_mcp_tool_wrappers(
-    patched_mcp_tool_wrappers,
+def test_installationconfigmeta_postinit_registers_mcp_toolset_configs(
+    patched_mcp_toolset_configs,
 ):
-    @dataclasses.dataclass(kw_only=True)
-    class _DummyToolConfig(config_tools.ToolConfig):
-        tool_name: str = "tests.unit.test_config.dummy_tool"
+    mtc_klass = _test_metaconfig.DummyMCP_ToolsetConfig
+    mtc_meta = config_meta.MCP_ToolsetConfigMeta(config_klass=mtc_klass)
 
-    @dataclasses.dataclass(kw_only=True)
-    class _DummyWrapper:
-        func: typing.Any
-        tool_config: config_tools.ToolConfig
+    config_meta.InstallationConfigMeta(mcp_toolset_configs=[mtc_meta])
 
-    mstw_meta = config_meta.ConfigMeta(
-        config_klass=_DummyToolConfig,
-        wrapper_klass=_DummyWrapper,
+    assert patched_mcp_toolset_configs[mtc_klass.kind] is mtc_klass
+
+
+@pytest.mark.parametrize(
+    "w_tc_registered, expectation",
+    [
+        (False, pytest.raises(config_meta.WrapperForUnknownToolConfig)),
+        (True, contextlib.nullcontext()),
+    ],
+)
+def test_installationconfigmeta_postinit_registers_mcp_tool_wrappers(
+    patched_tool_configs,
+    patched_mcp_tool_wrappers,
+    w_tc_registered,
+    expectation,
+):
+    cfg_klass = _test_metaconfig.DummyToolConfig
+    if w_tc_registered:
+        patched_tool_configs[cfg_klass.tool_name] = cfg_klass
+
+    wrp_klass = _test_metaconfig.DummyMCPWrapper
+    mstw_meta = config_meta.MCP_ServerToolWrapperConfigMeta(
+        config_klass=cfg_klass,
+        wrapper_klass=wrp_klass,
     )
-    config_meta.InstallationConfigMeta(mcp_server_tool_wrappers=[mstw_meta])
 
-    assert (
-        patched_mcp_tool_wrappers[_DummyToolConfig.tool_name] is _DummyWrapper
+    with expectation as expected:
+        config_meta.InstallationConfigMeta(
+            mcp_server_tool_wrappers=[mstw_meta],
+        )
+
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert patched_mcp_tool_wrappers[cfg_klass.tool_name] is wrp_klass
+
+
+def test_installationconfigmeta_postinit_registers_skill_configs(
+    patched_skill_configs,
+):
+    sc_klass = _test_metaconfig.DummySkillConfig
+    sc_meta = config_meta.SkillConfigMeta(config_klass=sc_klass)
+
+    config_meta.InstallationConfigMeta(skill_configs=[sc_meta])
+
+    assert patched_skill_configs[sc_klass.kind] is sc_klass
+
+
+def test_installationconfigmeta_postinit_registers_agent_capabilities(
+    patched_agent_capabilities,
+):
+    cap_klass = _test_metaconfig.DummyAgentCapability
+    ac_meta = config_meta.AgentCapabilityMeta(config_klass=cap_klass)
+
+    config_meta.InstallationConfigMeta(agent_capability_types=[ac_meta])
+
+    assert patched_agent_capabilities[cap_klass.__name__] is cap_klass
+
+
+def test_installationconfigmeta_postinit_registers_agent_configs(
+    patched_agent_configs,
+):
+    ac_klass = _test_metaconfig.DummyAgentConfig
+    ac_meta = config_meta.AgentConfigMeta(config_klass=ac_klass)
+
+    config_meta.InstallationConfigMeta(agent_configs=[ac_meta])
+
+    assert patched_agent_configs[ac_klass.kind] is ac_klass
+
+
+def test_installationconfigmeta_postinit_registers_secret_sources(
+    patched_secret_getters,
+    patched_secret_sources,
+):
+    ss_klass = _test_metaconfig.DummySecretSource
+    ss_getter = _test_metaconfig.dummy_secret_getter
+    ss_meta = config_meta.SecretSourceMeta(
+        config_klass=ss_klass,
+        registered_func=ss_getter,
     )
+
+    config_meta.InstallationConfigMeta(secret_sources=[ss_meta])
+
+    assert patched_secret_getters[ss_klass.kind] is ss_getter
+    assert patched_secret_sources[ss_klass.kind] is ss_klass
 
 
 def test_installationconfigmeta_postinit_registers_jsonpath_functions(
     patched_jsonpath_functions,
 ):
+    jp_func = _test_metaconfig.dummy_jsonpath_func
     jf_meta = config_meta.JSONPathFunctionConfigMeta(
         name=JSONPATH_FUNCTION_NAME,
-        func=faux_jsonpath_func,
+        func=jp_func,
     )
+
     config_meta.InstallationConfigMeta(jsonpath_functions=[jf_meta])
 
     env = authz.the_jsonpath_environment
-    assert (
-        env.function_extensions[JSONPATH_FUNCTION_NAME] is faux_jsonpath_func
-    )
+    assert env.function_extensions[JSONPATH_FUNCTION_NAME] is jp_func

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -213,6 +213,14 @@ def patched_agent_configs():
 
 
 @pytest.fixture
+def patched_secret_sources():
+    with mock.patch.dict(config_secrets.__dict__) as patched:
+        result = patched["SourceClassesByKind"] = {}
+
+        yield result
+
+
+@pytest.fixture
 def patched_secret_getters():
     with mock.patch.dict(config_secrets.__dict__) as patched:
         result = patched["SECRET_GETTERS_BY_KIND"] = {}


### PR DESCRIPTION
Replacements:

- 'config.meta.ToolConfigMeta' preserves 'config_klass', deprecates 'wrapper_klass' / 'registered_func'.

- 'config.meta.MCP_ToolsetConfigMeta' preserves 'config_klass', deprecates 'wrapper_klass' / 'registered_func'.

- 'config.meta.MCP_ServerToolWrapperConfigMeta' preserves 'config_klass' and 'wrapper_klass', deprecateds 'registered_func'

- 'config.meta.SkillConfigMeta' preserves 'config_klass', deprecates 'wrapper_klass' / 'registered_func'.

- 'config.meta.AgentCapabiltyMeta' preserves 'config_klass', deprecates 'wrapper_klass' / 'registered_func'.

- 'config.meta.AgentConfigMeta' preserves 'config_klass', deprecates 'wrapper_klass' / 'registered_func'.

- 'config.meta.SecretSourceMeta' preserves 'config_klass' and 'registered_func'.  deprecates 'wrapper_klass'

Normalize test fixtures using 'tests/unit/_test_metaconfig' entities, versus local fustures and/or "real" entities.

'config.meta.InstallationConfigMeta.__post_init__' now rejects registering a wrapper for an unregistered tool config class (which is the b0rken config which forms the basis of #1229).

Closes #1229.
Closes #1240.