### PR TITLE
tests: verify 'from_yaml'/'as_yaml' roundtrips state

### DIFF
--- a/src/soliplex/config/tools.py
+++ b/src/soliplex/config/tools.py
@@ -603,7 +603,7 @@ def extract_mcp_client_toolset_configs(
     for mcp_name, mcp_client_toolset_config in config_dict.pop(
         "mcp_client_toolsets", {}
     ).items():
-        kind = mcp_client_toolset_config.pop("kind")
+        kind = mcp_client_toolset_config["kind"]
         mcp_config_klass = MCP_TOOLSET_CONFIG_CLASSES_BY_KIND[kind]
         mcp_client_toolset_configs[mcp_name] = mcp_config_klass.from_yaml(
             installation_config=installation_config,

--- a/tests/unit/config/test_config_agents.py
+++ b/tests/unit/config/test_config_agents.py
@@ -516,6 +516,48 @@ def test_agentcapabilityconfig_as_yaml(ctor_kwargs, expected):
     assert found == expected
 
 
+def _round_trip_agent_capability_config(config_path, config_dict_or_str):
+    """Reload an 'AgentCapabilityConfig' from its own dump."""
+    klass = config_agents.AgentCapabilityConfig
+    original = klass.from_yaml(config_path, copy.deepcopy(config_dict_or_str))
+    reloaded = klass.from_yaml(config_path, copy.deepcopy(original.as_yaml))
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "cap_config, deprecated",
+    [
+        # bare-string shorthand
+        ("testing", False),
+        ({"name": "testing"}, False),
+        ({"name": "testing", "kwargs": {"dotted_name": "foo.bar"}}, False),
+        # deprecated single-key mapping spelling
+        ({"testing": {"dotted_name": "foo.bar"}}, True),
+    ],
+)
+def test_agentcapabilityconfig_as_yaml_round_trips(
+    temp_dir,
+    extra_agent_capability,
+    cap_config,
+    deprecated,
+):
+    # Neither the shorthand nor the deprecated spelling dumps back to the
+    # form it was written in -- 'as_yaml' always emits the canonical
+    # '{"name": ..., "kwargs": ...}' -- but all three reach the same
+    # state, which is the invariant under test. Reloading the dump must
+    # not re-warn, since the dump is canonical.
+    with warnings.catch_warnings(record=True) as warned:
+        warnings.simplefilter("always")
+        original, reloaded = _round_trip_agent_capability_config(
+            temp_dir / "config.yaml",
+            cap_config,
+        )
+
+    assert reloaded == original
+    assert len(warned) == (1 if deprecated else 0)
+
+
 @pytest.mark.parametrize(
     "name, kwargs, expectation",
     [
@@ -1080,6 +1122,64 @@ def test_agentconfig_as_yaml(
     installation_config.get_secret.assert_not_called()
 
 
+def _round_trip_agent_config(installation_config, config_path, config_dict):
+    """Reload an 'AgentConfig' from its own dump.
+
+    'from_yaml' drains 'kind', 'system_prompt', 'model_settings',
+    'capabilities' and 'agui_feature_names' out of the mapping it is
+    handed, hence the copies.
+    """
+    klass = config_agents.AgentConfig
+    original = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_AGENT_CONFIG_YAML,
+        W_KIND_AGENT_CONFIG_YAML,
+        W_PROVIDER_KW_AGENT_CONFIG_YAML,
+        W_RETRIES_AGENT_CONFIG_YAML,
+        W_MODEL_SETTINGS_AGENT_CONFIG_YAML,
+        W_MULTIMODAL_AGENT_CONFIG_YAML,
+        W_PROMPT_FILE_AGENT_CONFIG_YAML,
+        W_AGUI_FEATURE_NAMES_AGENT_CONFIG_YAML,
+        W_CAPABILITIES_AGENT_CONFIG_YAML,
+        # deprecated capability spelling: dumps canonical, same state
+        W_CAPABILITIES_BBB_AGENT_CONFIG_YAML,
+    ],
+)
+def test_agentconfig_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    # No 'extra_agent_capability' here: it swaps the registry for one
+    # holding only 'testing', which would hide the real capability names
+    # these configs reference.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        original, reloaded = _round_trip_agent_config(
+            installation_config,
+            temp_dir / "room_config.yaml",
+            yaml.safe_load(config_yaml),
+        )
+
+    assert reloaded == original
+
+
 @pytest.mark.parametrize(
     "kw",
     [
@@ -1265,6 +1365,54 @@ def test_factoryagentconfig_as_yaml(
     found = aconfig.as_yaml
 
     assert found == expected
+
+
+def _round_trip_factory_agent_config(
+    installation_config,
+    config_path,
+    config_dict,
+):
+    """Reload a 'FactoryAgentConfig' from its own dump.
+
+    'from_yaml' drains 'kind' and 'agui_feature_names' out of the mapping
+    it is handed, hence the copies.
+    """
+    klass = config_agents.FactoryAgentConfig
+    original = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_FACTORY_AGENT_CONFIG_YAML,
+        W_KIND_FACTORY_AGENT_CONFIG_YAML,
+        W_CONFIG_FACTORY_AGENT_CONFIG_YAML,
+        W_AGUI_FEATURE_NAMES_FACTORY_AGENT_CONFIG_YAML,
+    ],
+)
+def test_factoryagentconfig_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    original, reloaded = _round_trip_factory_agent_config(
+        installation_config,
+        temp_dir / "room_config.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/config/test_config_authsystem.py
+++ b/tests/unit/config/test_config_authsystem.py
@@ -1,3 +1,4 @@
+import copy
 import dataclasses
 import pathlib
 import ssl
@@ -261,6 +262,50 @@ def test_authsystem_from_yaml_w_oid_cpp(
     )
 
     assert found == expected
+
+
+@pytest.mark.xfail(strict=True, reason="#1188")
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_AUTHSYSTEM_CONFIG_YAML,
+        W_SCOPE_AUTHSYSTEM_CONFIG_YAML,
+        # 'oidc_client_pem_path' is absolutized against the config dir on
+        # load; re-joining an absolute path is idempotent, so a dump of
+        # the resolved path should still round-trip.
+        W_PEM_AUTHSYSTEM_CONFIG_YAML,
+        W_OIDC_CPP_REL_CONFIG_YAML,
+        # 'client_secret' holds a marker, not a resolved value, so the
+        # dump must emit the marker rather than 'oauth_client_kwargs''
+        # resolved secret.
+        W_CLIENT_SECRET_SECRET_AUTHSYSTEM_CONFIG_YAML,
+    ],
+)
+def test_authsystem_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    # 'OIDCAuthSystemConfig' has no 'as_yaml' at all, so the dump below
+    # raises 'AttributeError'. That makes the round trip the last
+    # executable statement in the test: anything after it would go
+    # uncovered while the xfail stands.
+    config_path = temp_dir / "config.yaml"
+    klass = config_authsystem.OIDCAuthSystemConfig
+    original = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(yaml.safe_load(config_yaml)),
+    )
+
+    assert (
+        klass.from_yaml(
+            installation_config,
+            config_path,
+            copy.deepcopy(original.as_yaml),
+        )
+        == original
+    )
 
 
 def test_authsystem_server_metadata_url():

--- a/tests/unit/config/test_config_completions.py
+++ b/tests/unit/config/test_config_completions.py
@@ -1,3 +1,4 @@
+import copy
 import dataclasses
 
 import pytest
@@ -151,3 +152,38 @@ def test_completionconfig_from_yaml(
     )
 
     assert found == expected
+
+
+@pytest.mark.xfail(strict=True, reason="#1187")
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_COMPLETION_CONFIG_YAML,
+        FULL_COMPLETION_CONFIG_YAML,
+    ],
+)
+def test_completionconfig_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    # 'CompletionConfig' has no 'as_yaml' at all, so the dump below
+    # raises 'AttributeError'. That makes the round trip the last
+    # executable statement in the test: anything after it would go
+    # uncovered while the xfail stands.
+    yaml_file = temp_dir / "test.yaml"
+    klass = config_completions.CompletionConfig
+    original = klass.from_yaml(
+        installation_config,
+        yaml_file,
+        copy.deepcopy(yaml.safe_load(config_yaml)),
+    )
+
+    assert (
+        klass.from_yaml(
+            installation_config,
+            yaml_file,
+            copy.deepcopy(original.as_yaml),
+        )
+        == original
+    )

--- a/tests/unit/config/test_config_installation.py
+++ b/tests/unit/config/test_config_installation.py
@@ -1,6 +1,7 @@
 import contextlib
 import copy
 import dataclasses
+import operator
 import pathlib
 from unittest import mock
 
@@ -115,7 +116,7 @@ W_FULL_META_INSTALLATION_CONFIG_KW = {
         "secret_sources": [
             config_meta.SecretSourceMeta(
                 config_klass=config_secrets.EnvVarSecretSource,
-                registered_func=test_meta.SECRET_SOURCE_FUNC,
+                registered_func=test_meta.secret_source_func,
             ),
         ],
     },
@@ -836,6 +837,78 @@ def test_sandboxconfig_as_yaml(temp_dir, w_kw):
     found = inst.as_yaml
 
     assert found == expected
+
+
+def _round_trip_sandbox_config(config_path, config_dict, reload_path=None):
+    """Reload a 'SandboxConfig' from its own dump.
+
+    'from_yaml' renames the public keys onto the underscore-prefixed
+    fields it stores them in, hence the copies.
+
+    'reload_path' defaults to 'config_path'; pass a path in a different
+    directory to check that the dump is location-independent, which is
+    the whole reason 'as_yaml' emits resolved absolute paths.
+    """
+    klass = config_installation.SandboxConfig
+    original = klass.from_yaml(config_path, copy.deepcopy(config_dict))
+
+    if reload_path is None:
+        reload_path = config_path
+
+    reloaded = klass.from_yaml(reload_path, copy.deepcopy(original.as_yaml))
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        WO_WORKDIRS_PATH_SANDBOX_CONFIG_YAML,
+        W_WORKDIRS_PATH_SANDBOX_CONFIG_YAML,
+        W_TRANSCRIPTS_PATH_SANDBOX_CONFIG_YAML,
+    ],
+)
+def test_sandboxconfig_as_yaml_round_trips(temp_dir, config_yaml):
+    original, reloaded = _round_trip_sandbox_config(
+        temp_dir / "installation.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    # Deliberately not 'reloaded == original': 'as_yaml' emits *resolved
+    # absolute* paths where the original holds the relative strings a
+    # human wrote, so all three underscore-prefixed fields differ.
+    # Re-joining an absolute path against the config dir is idempotent,
+    # so the properties that actually drive behavior are equal.
+    assert reloaded.environments_path == original.environments_path
+    assert reloaded.workdirs_path == original.workdirs_path
+    assert reloaded.transcripts_path == original.transcripts_path
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        WO_WORKDIRS_PATH_SANDBOX_CONFIG_YAML,
+        W_WORKDIRS_PATH_SANDBOX_CONFIG_YAML,
+        W_TRANSCRIPTS_PATH_SANDBOX_CONFIG_YAML,
+    ],
+)
+def test_sandboxconfig_as_yaml_round_trips_from_other_dir(
+    temp_dir,
+    config_yaml,
+):
+    # Reloading in place cannot tell a resolved dump from an unresolved
+    # one -- both re-resolve against the same directory. Reloading from
+    # somewhere else is what pins down why 'as_yaml' resolves at all:
+    # the dumped config must still name the original directories.
+    original, reloaded = _round_trip_sandbox_config(
+        temp_dir / "installation.yaml",
+        yaml.safe_load(config_yaml),
+        temp_dir / "elsewhere" / "installation.yaml",
+    )
+
+    assert reloaded.environments_path == original.environments_path
+    assert reloaded.workdirs_path == original.workdirs_path
+    assert reloaded.transcripts_path == original.transcripts_path
 
 
 @pytest.mark.parametrize("w_config_path", [False, True])
@@ -1831,7 +1904,7 @@ def test_installationconfig_from_yaml(
     config_yaml,
     expected_kw,
 ):
-    patched_soliplex_config["test_secret_func"] = test_meta.SECRET_SOURCE_FUNC
+    patched_soliplex_config["test_secret_func"] = test_meta.secret_source_func
     config_path = temp_dir / "installation.yaml"
     config_path.write_text(config_yaml)
 
@@ -2193,6 +2266,168 @@ def test_installationconfig_as_yaml(
     found = installation_config.as_yaml
 
     assert found == expected
+
+
+def _round_trip_installation_config(config_path, config_dict):
+    """Reload an 'InstallationConfig' from its own dump.
+
+    'from_yaml' drains most of its nested stanzas out of the mapping it
+    is handed, hence the copies.
+    """
+    klass = config_installation.InstallationConfig
+    original = klass.from_yaml(config_path, copy.deepcopy(config_dict))
+    reloaded = klass.from_yaml(config_path, copy.deepcopy(original.as_yaml))
+
+    return original, reloaded
+
+
+# Everything 'as_yaml' currently round-trips correctly. Excluded on
+# purpose:
+#
+# - 'meta', because 'InstallationConfigMeta.as_yaml' deliberately dumps
+#   registry state rather than the 'meta:' stanza; covered by
+#   'test_config_meta.py'.
+# - 'sandbox_config', whose raw fields differ by design (resolved paths);
+#   covered below and by the 'SandboxConfig' tests above.
+# - everything the round trip currently loses, which is listed in the
+#   xfail below.
+INSTALLATION_STATE_ATTRS = (
+    "id",
+    "environment",
+    "filesystem_skills_paths",
+    "oidc_paths",
+    "room_paths",
+    "completion_paths",
+    "quizzes_paths",
+    "rooms_upload_path",
+    "threads_upload_path",
+    "title_agent_config_id",
+    "app_router_operations",
+    "agent_configs",
+    "secrets",
+    "logfire_config",
+)
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_INSTALLATION_CONFIG_YAML,
+        W_BARE_META_INSTALLATION_CONFIG_YAML,
+        W_SECRETS_INSTALLATION_CONFIG_YAML,
+        W_ENVIRONMENT_LIST_INSTALLATION_CONFIG_YAML,
+        W_ENVIRONMENT_MAPPING_INSTALLATION_CONFIG_YAML,
+        W_HR_CONFIG_FILE_INSTALLATION_CONFIG_YAML,
+        W_AGENT_CONFIG_INSTALLATION_CONFIG_YAML,
+        W_FACTORY_AGENT_CONFIG_INSTALLATION_CONFIG_YAML,
+        W_SKILLS_PATHS_INSTALLATION_CONFIG_YAML,
+        W_OIDC_PATHS_INSTALLATION_CONFIG_YAML,
+        W_ROOM_PATHS_INSTALLATION_CONFIG_YAML,
+        W_COMPLETION_PATHS_INSTALLATION_CONFIG_YAML,
+        W_QUIZZES_PATHS_INSTALLATION_CONFIG_YAML,
+        W_ROOMS_UPLOAD_PATH_INSTALLATION_CONFIG_YAML,
+        W_THREADS_UPLOAD_PATH_INSTALLATION_CONFIG_YAML,
+        W_UPLOAD_PATH_INSTALLATION_CONFIG_YAML,
+        W_APP_ROUTER_OPERATIONS_INSTALLATION_CONFIG_YAML,
+        W_LOGFIRE_CONFIG_INSTALLATION_CONFIG_YAML,
+        W_LOGGING_CONFIG_FILE_INSTALLATION_CONFIG_YAML,
+        W_TP_DBURI_INSTALLATION_CONFIG_YAML,
+        W_RA_DBURI_INSTALLATION_CONFIG_YAML,
+    ],
+)
+def test_installationconfig_as_yaml_round_trips(
+    temp_dir,
+    patched_soliplex_config,
+    patched_tool_registries,
+    patched_mcp_toolset_configs,
+    patched_mcp_tool_wrappers,
+    patched_skill_configs,
+    patched_secret_getters,
+    patched_app_routers,
+    config_yaml,
+):
+    patched_soliplex_config["test_secret_func"] = test_meta.secret_source_func
+    get_state = operator.attrgetter(*INSTALLATION_STATE_ATTRS)
+
+    original, reloaded = _round_trip_installation_config(
+        temp_dir / "installation.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    assert get_state(reloaded) == get_state(original)
+
+
+def test_installationconfig_as_yaml_round_trips_sandbox_config(temp_dir):
+    # The nested 'SandboxConfig' compares unequal field-for-field, since
+    # its 'as_yaml' resolves the paths; the state that drives behavior is
+    # the resolved properties.
+    original, reloaded = _round_trip_installation_config(
+        temp_dir / "installation.yaml",
+        yaml.safe_load(W_SANDBOX_INSTALLATION_CONFIG_YAML),
+    )
+
+    found = reloaded.sandbox_config
+    expected = original.sandbox_config
+
+    assert found.environments_path == expected.environments_path
+    assert found.workdirs_path == expected.workdirs_path
+    assert found.transcripts_path == expected.transcripts_path
+
+
+@pytest.mark.xfail(strict=True, reason="#1186")
+@pytest.mark.parametrize(
+    "config_yaml, state_attrs",
+    [
+        # Both DB URIs fall through to the in-memory SQLite defaults, so
+        # a round-tripped installation silently stops persisting.
+        (
+            W_TP_DBURI_INSTALLATION_CONFIG_YAML,
+            (
+                "thread_persistence_dburi_sync",
+                "thread_persistence_dburi_async",
+            ),
+        ),
+        (
+            W_RA_DBURI_INSTALLATION_CONFIG_YAML,
+            ("authorization_dburi_sync", "authorization_dburi_async"),
+        ),
+        # 'logging_config_file' is stringified unconditionally, so an
+        # unset one dumps as the literal "None" and reloads as a path.
+        (BARE_INSTALLATION_CONFIG_YAML, ("logging_config_file",)),
+        (
+            W_LOGGING_CONFIG_FILE_INSTALLATION_CONFIG_YAML,
+            ("logging_headers_map", "logging_claims_map"),
+        ),
+        # The whole ASGI middleware stack is dropped, because
+        # 'MiddlewareConfig' has no 'as_yaml' to render the elements
+        # with (companion issue #1189).
+        (
+            W_MIDDLEWARE_STACK_INSTALLATION_CONFIG_YAML,
+            ("middleware_stack",),
+        ),
+    ],
+)
+def test_installationconfig_as_yaml_round_trips_w_lost_state(
+    temp_dir,
+    patched_soliplex_config,
+    patched_tool_registries,
+    patched_mcp_toolset_configs,
+    patched_mcp_tool_wrappers,
+    patched_skill_configs,
+    patched_secret_getters,
+    config_yaml,
+    state_attrs,
+):
+    # 'attrgetter' rather than a loop of asserts: these all fail today,
+    # and a loop that never completes leaves its exit branch uncovered.
+    get_state = operator.attrgetter(*state_attrs)
+
+    original, reloaded = _round_trip_installation_config(
+        temp_dir / "installation.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    assert get_state(reloaded) == get_state(original)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/config/test_config_logfire.py
+++ b/tests/unit/config/test_config_logfire.py
@@ -1,3 +1,4 @@
+import copy
 import dataclasses
 
 import pytest
@@ -403,6 +404,38 @@ def test_lfipydai_as_yaml(init_kw, expected):
     assert found == expected
 
 
+# 'from_yaml' splats its argument, so an empty *document* raises; the
+# minimal round-trippable input is an explicit empty mapping.
+EMPTY_MAPPING_YAML = "{}"
+
+
+def _round_trip_lfipydai(config_path, config_dict):
+    """Reload a 'LogfireInstrumentPydanticAI' from its own dump."""
+    klass = config_logfire.LogfireInstrumentPydanticAI
+    original = klass.from_yaml(config_path, copy.deepcopy(config_dict))
+    reloaded = klass.from_yaml(config_path, copy.deepcopy(original.as_yaml))
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        EMPTY_MAPPING_YAML,
+        W_VALUES_LFIPYDAI_CONFIG_YAML,
+    ],
+)
+def test_lfipydai_as_yaml_round_trips(temp_dir, config_yaml):
+    yaml_file = temp_dir / "test.yaml"
+
+    original, reloaded = _round_trip_lfipydai(
+        yaml_file,
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
+
+
 @pytest.mark.parametrize(
     "config_yaml, expected_kw",
     [
@@ -474,6 +507,33 @@ def test_lfifapi_as_yaml(init_kw, expected):
     found = ipydai_config.as_yaml
 
     assert found == expected
+
+
+def _round_trip_lfifapi(config_path, config_dict):
+    """Reload a 'LogfireInstrumentFastAPI' from its own dump."""
+    klass = config_logfire.LogfireInstrumentFastAPI
+    original = klass.from_yaml(config_path, copy.deepcopy(config_dict))
+    reloaded = klass.from_yaml(config_path, copy.deepcopy(original.as_yaml))
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        EMPTY_MAPPING_YAML,
+        W_VALUES_LFIFAPI_CONFIG_YAML,
+    ],
+)
+def test_lfifapi_as_yaml_round_trips(temp_dir, config_yaml):
+    yaml_file = temp_dir / "test.yaml"
+
+    original, reloaded = _round_trip_lfifapi(
+        yaml_file,
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
 
 
 @pytest.mark.parametrize(
@@ -632,6 +692,70 @@ def test_logfireconfig_logfire_as_yaml(
     found = lf_config.as_yaml
 
     assert found == expected
+
+
+ROUND_TRIP_IC_SECRETS = TEST_LOGFIRE_IC_DEFAULT_SECRETS
+ROUND_TRIP_IC_ENV = TEST_LOGFIRE_IC_DEFAULT_ENV | {
+    "LOGFIRE_BASE_URL": TEST_LOGFIRE_BASE_URL,
+}
+
+
+def _round_trip_logfire_config(installation_config, config_path, config_dict):
+    """Reload a 'LogfireConfig' from its own dump.
+
+    'from_yaml' pops the 'instrument_*' keys out of the mapping it is
+    handed, hence the copies.
+    """
+    klass = config_logfire.LogfireConfig
+    original = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        W_SEND_TO_LOGFIRE_FALSE_LOGFIRE_CONFIG_YAML,
+        W_TOKEN_ONLY_LOGFIRE_CONFIG_YAML,
+        W_SOME_SCALARS_LOGFIRE_CONFIG_YAML,
+        W_SCALARS_LOGFIRE_CONFIG_YAML,
+        W_BASE_URL_LOGFIRE_CONFIG_YAML,
+        W_SCRUBBING_LOGFIRE_CONFIG_YAML,
+        W_IPYDAI_LOGFIRE_CONFIG_YAML,
+        W_IFAPI_LOGFIRE_CONFIG_YAML,
+    ],
+)
+def test_logfireconfig_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    installation_config.get_secret.side_effect = ROUND_TRIP_IC_SECRETS.get
+    installation_config.get_environment.side_effect = ROUND_TRIP_IC_ENV.get
+    yaml_file = temp_dir / "test.yaml"
+
+    original, reloaded = _round_trip_logfire_config(
+        installation_config,
+        yaml_file,
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
+
+    # 'logfire_config_kwargs' is what gets splatted into
+    # 'logfire.configure()'. Comparing it too proves the 'env:' /
+    # 'secret:' markers survived as markers, since resolution happens on
+    # the way out.
+    assert reloaded.logfire_config_kwargs == original.logfire_config_kwargs
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/config/test_config_meta.py
+++ b/tests/unit/config/test_config_meta.py
@@ -10,8 +10,13 @@ import yaml
 
 from soliplex import authz
 from soliplex.config import _utils
+from soliplex.config import agents as config_agents
+from soliplex.config import agui as config_agui
 from soliplex.config import exceptions as config_exc
 from soliplex.config import meta as config_meta
+from soliplex.config import secrets as config_secrets
+from soliplex.config import skills as config_skills
+from soliplex.config import tools as config_tools
 
 BOGUS_ICMETA_YAML = """\
 meta:
@@ -129,12 +134,16 @@ meta:
       - "_test_metaconfig.DummyAgentConfig"
 """
 
-SECRET_SOURCE_FUNC = lambda source: "SEEKRIT"  # noqa E731
+
+def secret_source_func(source):  # pragma: NO COVER (registered, not called)
+    return "SEEKRIT"
+
+
 W_SECRET_SOURCE_ICMETA_KW = BARE_ICMETA_KW | {
     "secret_sources": [
         config_meta.SecretSourceMeta(
             config_klass=_test_metaconfig.DummySecretSource,
-            registered_func=SECRET_SOURCE_FUNC,
+            registered_func=secret_source_func,
         ),
     ],
 }
@@ -205,7 +214,7 @@ FULL_ICMETA_KW = {
     "secret_sources": [
         config_meta.SecretSourceMeta(
             config_klass=_test_metaconfig.DummySecretSource,
-            registered_func=SECRET_SOURCE_FUNC,
+            registered_func=secret_source_func,
         ),
     ],
     "jsonpath_functions": [
@@ -677,7 +686,7 @@ def test_installationconfigmeta_from_yaml(
     config_yaml,
     expected_kw,
 ):
-    patched_soliplex_config["test_secret_func"] = SECRET_SOURCE_FUNC
+    patched_soliplex_config["test_secret_func"] = secret_source_func
     expected_kw = copy.deepcopy(expected_kw)
 
     yaml_file = temp_dir / "config.yaml"
@@ -781,7 +790,7 @@ def test_installationconfigmeta_from_yaml(
         if config_dict_meta and "secret_sources" in config_dict_meta:
             ss_klass = _test_metaconfig.DummySecretSource
             assert patched_secret_getters == {
-                ss_klass.kind: SECRET_SOURCE_FUNC
+                ss_klass.kind: secret_source_func
             }
             assert patched_secret_sources == {ss_klass.kind: ss_klass}
 
@@ -823,7 +832,7 @@ def test_installationconfigmeta_as_yaml(
     w_secret_reg,
     w_jsonpath,
 ):
-    patched_soliplex_config["test_secret_func"] = SECRET_SOURCE_FUNC
+    patched_soliplex_config["test_secret_func"] = secret_source_func
 
     expected = copy.deepcopy(BARE_ICMETA_KW)
 
@@ -899,6 +908,132 @@ def test_installationconfigmeta_as_yaml(
     found = icmeta.as_yaml
 
     assert found == expected
+
+
+def _registry_snapshot():
+    """Copy every registry 'InstallationConfigMeta' writes into."""
+    return {
+        "agui_features": dict(config_agui.AGUI_FEATURES_BY_NAME),
+        "tool_configs": dict(
+            config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME,
+        ),
+        "mcp_toolset_configs": dict(
+            config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND,
+        ),
+        "mcp_tool_wrappers": dict(
+            config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME,
+        ),
+        "skill_configs": dict(config_skills.SKILL_CONFIG_CLASSES_BY_KIND),
+        "agent_capabilities": dict(
+            config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME,
+        ),
+        "agent_configs": dict(config_agents.AGENT_CONFIG_CLASSES_BY_KIND),
+        "secret_getters": dict(config_secrets.SECRET_GETTERS_BY_KIND),
+        "jsonpath_functions": dict(authz.registered_jsonpath_functions()),
+    }
+
+
+def _clear_registries():
+    """Empty every registry 'InstallationConfigMeta' writes into.
+
+    Registration is purely additive, so without this a dump that dropped
+    a whole category would still appear to round-trip: the entries from
+    the first load would still be sitting in the registry. Clearing
+    between the dump and the reload is what makes the assertion mean
+    "'as_yaml' emitted everything needed to rebuild the registries".
+    """
+    config_agui.AGUI_FEATURES_BY_NAME.clear()
+    config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME.clear()
+    config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND.clear()
+    config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME.clear()
+    config_skills.SKILL_CONFIG_CLASSES_BY_KIND.clear()
+    config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME.clear()
+    config_agents.AGENT_CONFIG_CLASSES_BY_KIND.clear()
+    config_secrets.SECRET_GETTERS_BY_KIND.clear()
+
+    # Drop only the config-supplied filters, leaving the RFC 9535
+    # built-ins the environment needs.
+    function_extensions = authz.the_jsonpath_environment.function_extensions
+    for name in authz.registered_jsonpath_functions():
+        del function_extensions[name]
+
+
+def _round_trip_icmeta_registries(config_path, config_dict):
+    """Round-trip a metaconfig, snapshotting the registries each time.
+
+    Unlike every other config class, the state under test here is the
+    *global registries*, not the instance fields: 'as_yaml' deliberately
+    dumps the software-level registry contents rather than the (possibly
+    empty) 'meta:' stanza it was loaded from. That asymmetry is correct
+    under the "same application state" criterion, so what has to hold is
+    that reloading a dump into empty registries rebuilds them exactly --
+    and that a second cycle changes nothing further.
+
+    'from_yaml' mutates the mapping it is handed, hence the copies.
+    """
+    klass = config_meta.InstallationConfigMeta
+
+    original = klass.from_yaml(config_path, copy.deepcopy(config_dict))
+    after_load = _registry_snapshot()
+    dumped = copy.deepcopy(original.as_yaml)
+
+    _clear_registries()
+    reloaded = klass.from_yaml(config_path, dumped)
+    after_first = _registry_snapshot()
+    dumped_again = copy.deepcopy(reloaded.as_yaml)
+
+    _clear_registries()
+    klass.from_yaml(config_path, dumped_again)
+    after_second = _registry_snapshot()
+
+    return after_load, after_first, after_second
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_ICMETA_YAML,
+        W_AGUI_FEATURES_ICMETA_YAML,
+        W_TOOL_CONFIGS_ICMETA_YAML,
+        W_MCP_TOOLSET_CONFIGS_ICMETA_YAML,
+        W_SKILL_CONFIGS_ICMETA_YAML,
+        W_AGENT_CAPABILITY_ICMETA_YAML,
+        W_AGENT_CONFIGS_ICMETA_YAML,
+        W_SECRET_SOURCE_ICMETA_YAML,
+        W_JSONPATH_FUNCTIONS_ICMETA_YAML,
+        FULL_ICMETA_YAML,
+    ],
+)
+def test_installationconfigmeta_as_yaml_round_trips_registries(
+    patched_soliplex_config,
+    patched_agui_features,
+    patched_tool_configs,
+    patched_mcp_toolset_configs,
+    patched_mcp_tool_wrappers,
+    patched_skill_configs,
+    patched_agent_capabilities,
+    patched_agent_configs,
+    patched_secret_getters,
+    patched_jsonpath_functions,
+    temp_dir,
+    config_yaml,
+):
+    # The dumped dotted name for the getter is not the one the YAML was
+    # written with -- 'as_yaml' renders it from the function's own
+    # '__module__' / '__name__', so 'soliplex.config.test_secret_func'
+    # comes back as 'test_config_meta.secret_source_func'. Both resolve
+    # to the same object, which is exactly the "same application state,
+    # not identical mapping" criterion.
+    patched_soliplex_config["test_secret_func"] = secret_source_func
+    config_dict = yaml.safe_load(config_yaml)["meta"]
+
+    after_load, after_first, after_second = _round_trip_icmeta_registries(
+        temp_dir / "installation.yaml",
+        config_dict,
+    )
+
+    assert after_first == after_load
+    assert after_second == after_first
 
 
 def test_installationconfigmeta_postinit_registers_tool_configs(

--- a/tests/unit/config/test_config_middleware.py
+++ b/tests/unit/config/test_config_middleware.py
@@ -78,6 +78,30 @@ def test_middlewareconfig_from_yaml(
         assert found == expected
 
 
+@pytest.mark.xfail(strict=True, reason="#1189")
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_MWCONFIG_YAML,
+        W_NEEDS_ICONFIG_MWCONFIG_YAML,
+        W_EXTRA_PARAMS_MWCONFIG_YAML,
+    ],
+)
+def test_middlewareconfig_as_yaml_round_trips(config_yaml):
+    # 'MiddlewareConfig' has no 'as_yaml' at all, so the dump below
+    # raises 'AttributeError'. That makes the round trip the last
+    # executable statement in the test: anything after it would go
+    # uncovered while the xfail stands.
+    #
+    # When it lands, 'as_yaml' has to reverse '_from_dotted_name':
+    # 'from_yaml' resolves 'app_factory' to the callable itself, so the
+    # dump must render it back to a dotted name via '_utils._dotted_name'.
+    klass = config_middleware.MiddlewareConfig
+    original = klass.from_yaml(copy.deepcopy(yaml.safe_load(config_yaml)))
+
+    assert klass.from_yaml(copy.deepcopy(original.as_yaml)) == original
+
+
 @pytest.mark.parametrize(
     "config_kw, expected",
     [

--- a/tests/unit/config/test_config_quizzes.py
+++ b/tests/unit/config/test_config_quizzes.py
@@ -1,6 +1,8 @@
 import contextlib
+import copy
 import dataclasses
 import json
+import operator
 import pathlib
 from unittest import mock
 
@@ -314,6 +316,79 @@ def test_quizconfig_as_yaml(temp_dir, installation_config, w_kw):
     found = inst.as_yaml
 
     assert found == expected
+
+
+def _round_trip_quiz_config(installation_config, config_path, config_dict):
+    """Reload a 'QuizConfig' from its own dump.
+
+    'from_yaml' drains 'judge_agent' out of the mapping it is handed,
+    hence the copies.
+    """
+    klass = config_quizzes.QuizConfig
+    original = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+def test_quizconfig_as_yaml_round_trips_w_judge_agent(
+    temp_dir,
+    installation_config,
+):
+    installation_config.get_environment.side_effect = {
+        "OLLAMA_BASE_URL": OLLAMA_BASE_URL,
+    }.get
+
+    original, reloaded = _round_trip_quiz_config(
+        installation_config,
+        temp_dir / "test.yaml",
+        yaml.safe_load(TEST_QUIZ_W_STEM_YAML),
+    )
+
+    assert reloaded == original
+
+
+QUIZ_STATE_ATTRS = (
+    "id",
+    "title",
+    "randomize",
+    "max_questions",
+    "_question_file_stem",
+    "_question_file_path_override",
+)
+
+
+def test_quizconfig_as_yaml_round_trips_wo_judge_agent(
+    temp_dir,
+    installation_config,
+):
+    installation_config.get_environment.side_effect = {
+        "OLLAMA_BASE_URL": OLLAMA_BASE_URL,
+    }.get
+    get_state = operator.attrgetter(*QUIZ_STATE_ATTRS)
+
+    original, reloaded = _round_trip_quiz_config(
+        installation_config,
+        temp_dir / "test.yaml",
+        yaml.safe_load(TEST_QUIZ_W_OVR_YAML),
+    )
+
+    assert get_state(reloaded) == get_state(original)
+
+    # Not 'reloaded == original': '__post_init__' synthesizes the default
+    # judge without a '_config_path', where the reloaded one comes back
+    # through 'from_yaml' and has one. That field only resolves a
+    # relative system-prompt path, which the synthesized judge never has,
+    # so the judges are compared by their dumps.
+    assert reloaded.judge_agent.as_yaml == original.judge_agent.as_yaml
 
 
 def test_quizconfig__load_questions_file_miss_w_stem(

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import dataclasses
 import pathlib
 from unittest import mock
@@ -428,6 +429,77 @@ def test_roomconfig_as_yaml(temp_dir, installation_config, w_kw):
     found = inst.as_yaml
 
     assert found == expected
+
+
+def _round_trip_room_config(installation_config, config_path, config_dict):
+    """Reload a 'RoomConfig' from its own dump.
+
+    'from_yaml' drains 'agent', 'tools', 'mcp_client_toolsets', 'skills'
+    and 'quizzes' out of the mapping it is handed, hence the copies.
+    """
+    klass = config_rooms.RoomConfig
+    original = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_ROOM_CONFIG_YAML,
+        W__ORDER_ROOM_CONFIG_YAML,
+        W_NON_HR_SKILLS_ROOM_CONFIG_YAML,
+        W_HR_SKILLS_ROOM_CONFIG_YAML,
+        W_NON_HR_TOOLS_ROOM_CONFIG_YAML,
+    ],
+)
+def test_roomconfig_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    installation_config.skill_configs = {
+        test_skills.SKILL_NAME: mock.create_autospec(
+            config_skills.FilesystemSkillConfig,
+        ),
+        "other_skill": object(),
+    }
+
+    original, reloaded = _round_trip_room_config(
+        installation_config,
+        temp_dir / "test.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
+
+
+def test_roomconfig_as_yaml_round_trips_w_agent_agui_feature_names(
+    installation_config,
+    temp_dir,
+):
+    installation_config.skill_configs = {
+        test_skills.SKILL_NAME: mock.create_autospec(
+            config_skills.FilesystemSkillConfig,
+        ),
+    }
+
+    original, reloaded = _round_trip_room_config(
+        installation_config,
+        temp_dir / "test.yaml",
+        yaml.safe_load(FULL_ROOM_CONFIG_YAML),
+    )
+
+    assert reloaded == original
 
 
 @pytest.mark.parametrize("w_order", [False, True])

--- a/tests/unit/config/test_config_routing.py
+++ b/tests/unit/config/test_config_routing.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 from unittest import mock
 
 import fastapi
@@ -145,6 +146,67 @@ def test_addapprouter_as_yaml(
     assert found == expected
 
 
+def _round_trip_app_router_op(op_class, config_path, config_dict):
+    """Reload an app-router operation from its own dump.
+
+    'from_yaml' pops 'kind' out of the mapping it is handed, hence the
+    copies.
+    """
+    original = op_class.from_yaml(config_path, copy.deepcopy(config_dict))
+    reloaded = op_class.from_yaml(
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+ADD_ROUTER_CONFIG = {
+    "kind": "add",
+    "group_name": GROUP_NAME,
+    "router_name": ROUTER_NAME,
+}
+
+
+@pytest.mark.parametrize(
+    "extra_config",
+    [
+        {},
+        {"replace_existing": True},
+        # 'prefix: null' means "mount at the root" -- it differs from the
+        # '/api' default, so 'as_yaml' has to emit it rather than filter
+        # it out as 'router_kwargs' does (#1215).
+        {"prefix": None},
+        {"prefix": PREFIX},
+        {"tags": TAGS},
+        {"dependencies": DEPENDENCIES},
+        {"default_response_class": DEFAULT_RESPONSE_CLASS},
+        {"deprecated": DEPRECATED},
+        {
+            "replace_existing": True,
+            "prefix": None,
+            "tags": TAGS,
+            "dependencies": DEPENDENCIES,
+            "default_response_class": DEFAULT_RESPONSE_CLASS,
+            "deprecated": DEPRECATED,
+        },
+    ],
+)
+def test_addapprouter_as_yaml_round_trips(temp_dir, extra_config):
+    original, reloaded = _round_trip_app_router_op(
+        config_routing.AddAppRouter,
+        temp_dir / "installation.yaml",
+        ADD_ROUTER_CONFIG | extra_config,
+    )
+
+    assert reloaded == original
+
+    # 'router_kwargs' is the state that matters: 'add_registered_routers'
+    # splats it into 'app.include_router', so it decides where the
+    # group's routes actually mount.
+    assert reloaded.router_kwargs == original.router_kwargs
+
+
 @pytest.mark.parametrize(
     "w_existing, w_replace, expectation",
     [
@@ -243,6 +305,30 @@ def test_deleteapprouter_as_yaml(
     assert found == expected
 
 
+DELETE_ROUTER_CONFIG = {
+    "kind": "delete",
+    "group_name": GROUP_NAME,
+}
+
+
+@pytest.mark.parametrize(
+    "extra_config",
+    [
+        {},
+        {"require_existing": False},
+        {"require_existing": True},
+    ],
+)
+def test_deleteapprouter_as_yaml_round_trips(temp_dir, extra_config):
+    original, reloaded = _round_trip_app_router_op(
+        config_routing.DeleteAppRouter,
+        temp_dir / "installation.yaml",
+        DELETE_ROUTER_CONFIG | extra_config,
+    )
+
+    assert reloaded == original
+
+
 @pytest.mark.parametrize(
     "w_existing, w_require, expectation",
     [
@@ -307,6 +393,16 @@ def test_clearapprouters_as_yaml():
     found = clear_op.as_yaml
 
     assert found == {"kind": "clear"}
+
+
+def test_clearapprouters_as_yaml_round_trips(temp_dir):
+    original, reloaded = _round_trip_app_router_op(
+        config_routing.ClearAppRouters,
+        temp_dir / "installation.yaml",
+        {"kind": "clear"},
+    )
+
+    assert reloaded == original
 
 
 @pytest.mark.parametrize("w_existing", [False, True])

--- a/tests/unit/config/test_config_secrets.py
+++ b/tests/unit/config/test_config_secrets.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 from unittest import mock
 
 import pytest
@@ -94,6 +95,37 @@ def test_envvarsecretsource_as_yaml(has_ev):
     assert found == expected
 
 
+def _round_trip_secret_source(source_class, config_path, config_dict):
+    """Reload a secret source from its own dump.
+
+    'from_yaml' pops 'kind' out of the mapping it is handed, hence the
+    copies.
+    """
+    original = source_class.from_yaml(
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = source_class.from_yaml(
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize("w_params", [{}, {"env_var_name": ENV_VAR_NAME}])
+def test_envvarsecretsource_as_yaml_round_trips(temp_dir, w_params):
+    config_dict = {"secret_name": SECRET_NAME} | w_params
+
+    original, reloaded = _round_trip_secret_source(
+        config_secrets.EnvVarSecretSource,
+        temp_dir / "installation.yaml",
+        config_dict,
+    )
+
+    assert reloaded == original
+
+
 @pytest.mark.parametrize(
     "w_kind_kw, expectation",
     [
@@ -147,6 +179,19 @@ def test_filepathsecretsource_as_yaml():
     found = source.as_yaml
 
     assert found == expected
+
+
+@pytest.mark.parametrize("file_path", ["/path/to/file", "./file"])
+def test_filepathsecretsource_as_yaml_round_trips(temp_dir, file_path):
+    config_dict = {"secret_name": SECRET_NAME, "file_path": file_path}
+
+    original, reloaded = _round_trip_secret_source(
+        config_secrets.FilePathSecretSource,
+        temp_dir / "installation.yaml",
+        config_dict,
+    )
+
+    assert reloaded == original
 
 
 @pytest.mark.parametrize(
@@ -229,6 +274,29 @@ def test_subprocesssecretsource_as_yaml(w_args):
     assert found == expected
 
 
+@pytest.mark.parametrize("w_args", [None, [], ["-a", "foo"]])
+def test_subprocesssecretsource_as_yaml_round_trips(temp_dir, w_args):
+    config_dict = {"secret_name": SECRET_NAME, "command": COMMAND}
+
+    if w_args is not None:
+        config_dict["args"] = w_args
+
+    original, reloaded = _round_trip_secret_source(
+        config_secrets.SubprocessSecretSource,
+        temp_dir / "installation.yaml",
+        config_dict,
+    )
+
+    # Not 'reloaded == original': 'as_yaml' emits 'list(self.args)', so a
+    # defaulted '()' comes back as '[]'. 'get_subprocess_secret' only ever
+    # splats it ('[source.command, *source.args]'), so 'command_line' is
+    # the state that matters, and it is equal either way.
+    assert reloaded.secret_name == original.secret_name
+    assert reloaded.command == original.command
+    assert reloaded.command_line == original.command_line
+    assert reloaded.extra_arguments == original.extra_arguments
+
+
 @pytest.mark.parametrize(
     "w_kind_kw, expectation",
     [
@@ -296,6 +364,19 @@ def test_randomcharssecretsource_as_yaml(kwargs, exp_nc):
     assert found == expected
 
 
+@pytest.mark.parametrize("w_params", [{}, {"n_chars": 17}])
+def test_randomcharssecretsource_as_yaml_round_trips(temp_dir, w_params):
+    config_dict = {"secret_name": SECRET_NAME} | w_params
+
+    original, reloaded = _round_trip_secret_source(
+        config_secrets.RandomCharsSecretSource,
+        temp_dir / "installation.yaml",
+        config_dict,
+    )
+
+    assert reloaded == original
+
+
 @pytest.mark.parametrize(
     "w_sources, exp_sources",
     [
@@ -341,6 +422,52 @@ def test_secretconfig_as_yaml():
     found = secret.as_yaml
 
     assert found == expected
+
+
+def _round_trip_secret_config(config_path, config):
+    """Reload a 'SecretConfig' from its own dump.
+
+    'from_yaml' drains 'sources' out of the mapping it is handed, hence
+    the copies.
+    """
+    klass = config_secrets.SecretConfig
+    original = klass.from_yaml(config_path, copy.deepcopy(config))
+    reloaded = klass.from_yaml(config_path, copy.deepcopy(original.as_yaml))
+
+    return original, reloaded
+
+
+# 'args' is spelled explicitly so the whole-object comparison is fair: a
+# defaulted '()' would dump as '[]' (see the subprocess round-trip above).
+FULL_SECRET_CONFIG = {
+    "secret_name": SECRET_NAME,
+    "sources": [
+        {"kind": "env_var", "env_var_name": ENV_VAR_NAME},
+        {"kind": "file_path", "file_path": SECRET_FILE_PATH},
+        {"kind": "subprocess", "command": COMMAND, "args": ["-a", "foo"]},
+        {"kind": "random_chars", "n_chars": 17},
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        # the bare-string shorthand
+        SECRET_NAME,
+        {"secret_name": SECRET_NAME, "sources": [{"kind": "env_var"}]},
+        FULL_SECRET_CONFIG,
+    ],
+)
+def test_secretconfig_as_yaml_round_trips(temp_dir, config):
+    # The string shorthand does not dump back to a string, but it does
+    # reach the same state: one 'env_var' source named for the secret.
+    original, reloaded = _round_trip_secret_config(
+        temp_dir / "installation.yaml",
+        config,
+    )
+
+    assert reloaded == original
 
 
 def test_secretconfig_resolved():

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -1,3 +1,4 @@
+import copy
 import importlib.metadata
 import types
 from unittest import mock
@@ -158,6 +159,63 @@ def test_haiku_rag_capability_config_with_stem(
     }
 
 
+def _round_trip_hr_skill(
+    config_class,
+    installation_config,
+    config_path,
+    config_dict,
+):
+    """Reload a haiku.rag skill config from its own dump."""
+    original = config_class.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = config_class.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_class",
+    [
+        config_skills.HR_RAG_SkillConfig,
+        config_skills.HR_Analysis_SkillConfig,
+    ],
+)
+@pytest.mark.parametrize("w_stem", [False, True])
+def test_haiku_rag_capability_config_as_yaml_round_trips(
+    temp_dir,
+    installation_config,
+    config_class,
+    w_stem,
+):
+    db_path = temp_dir / "example.lancedb"
+    db_path.mkdir()
+    config_dict = {"kind": config_class.kind}
+
+    if w_stem:
+        config_dict["rag_lancedb_stem"] = "example"
+    else:
+        # 'from_yaml' parses this into a 'pathlib.Path' and 'as_yaml'
+        # stringifies it again.
+        config_dict["rag_lancedb_override_path"] = str(db_path)
+
+    original, reloaded = _round_trip_hr_skill(
+        config_class,
+        installation_config,
+        temp_dir / "room.yaml",
+        config_dict,
+    )
+
+    assert reloaded == original
+    assert reloaded.rag_lancedb_path == original.rag_lancedb_path
+
+
 def test_haiku_rag_capability_config_wraps_yaml_errors(
     installation_config,
     temp_dir,
@@ -225,6 +283,55 @@ def test_bwrap_sandbox_config_minimal(installation_config):
         "default_environment": "bare",
     }
     assert config.extra_parameters == {"default_environment": "bare"}
+
+
+def _round_trip_bwrap_skill(installation_config, config_path, config_dict):
+    """Reload a 'BwrapSandboxSkillConfig' from its own dump."""
+    klass = config_skills.BwrapSandboxSkillConfig
+    original = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize("w_full", [False, True])
+def test_bwrap_sandbox_config_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    w_full,
+):
+    config_dict = {"kind": bwrap_sandbox.CAPABILITY_NAME}
+
+    if w_full:
+        config_dict |= {
+            "id": "sandbox-id",
+            "default_environment": "python",
+            "allowed_environments": ["python"],
+            "sandbox_config": {"max_output_chars": 1234},
+            "volumes": {
+                "data": {
+                    "host_path": str(temp_dir / "volume"),
+                    "writable": False,
+                },
+            },
+        }
+
+    original, reloaded = _round_trip_bwrap_skill(
+        installation_config,
+        temp_dir / "room.yaml",
+        config_dict,
+    )
+
+    assert reloaded == original
+    assert reloaded.extra_parameters == original.extra_parameters
 
 
 def test_bwrap_sandbox_config_wraps_yaml_errors(
@@ -344,6 +451,64 @@ def test_empty_room_skills_config(installation_config):
     assert config.has_sandbox is False
 
 
+def _round_trip_room_skills(installation_config, config_path, config_dict):
+    """Reload a 'RoomSkillsConfig' from its own dump.
+
+    'from_yaml' drains 'skill_configs' out of the mapping it is handed
+    (via 'extract_skill_configs'), hence the copies.
+    """
+    klass = config_skills.RoomSkillsConfig
+    original = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize("w_installation_skills", [False, True])
+def test_room_skills_config_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    w_installation_skills,
+):
+    filesystem = config_skills.FilesystemSkillConfig.from_capability(
+        _filesystem_capability(temp_dir / SKILL_NAME)
+    )
+    installation_config.skill_configs = {SKILL_NAME: filesystem}
+    db_path = temp_dir / "rag.lancedb"
+    db_path.mkdir()
+    config_dict = {
+        "skill_configs": [
+            {
+                "kind": config_skills.HR_RAG_SkillConfig.kind,
+                "rag_lancedb_override_path": str(db_path),
+            },
+            {"kind": bwrap_sandbox.CAPABILITY_NAME},
+        ],
+    }
+
+    if w_installation_skills:
+        config_dict["installation_skill_names"] = [SKILL_NAME]
+
+    original, reloaded = _round_trip_room_skills(
+        installation_config,
+        temp_dir / "room.yaml",
+        config_dict,
+    )
+
+    assert reloaded == original
+    assert reloaded.skill_configs == original.skill_configs
+    assert reloaded.rag_db_paths == original.rag_db_paths
+    assert reloaded.has_sandbox == original.has_sandbox
+
+
 class _FakeEntryPoint:
     def __init__(self, name, target):
         self.name = name
@@ -439,6 +604,47 @@ def test_entrypoint_capability_config_stateless(
     assert config.agui_feature_names == ()
     assert config.extra_parameters == {}
     assert config.capability == {"defer_loading": True, "params": {}}
+
+
+def _round_trip_entrypoint_skill(
+    installation_config,
+    config_path,
+    config_dict,
+):
+    """Reload an 'EntrypointCapabilityConfig' from its own dump."""
+    klass = config_skills.EntrypointCapabilityConfig
+    original = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = klass.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize("w_params", [{}, {"foo": "bar"}])
+def test_entrypoint_capability_config_as_yaml_round_trips(
+    monkeypatch,
+    installation_config,
+    temp_dir,
+    w_params,
+):
+    _patch_entry_points(monkeypatch, {"my-cap": _stateful_module()})
+    config_dict = {"kind": "entrypoint", "name": "my-cap"} | w_params
+
+    original, reloaded = _round_trip_entrypoint_skill(
+        installation_config,
+        temp_dir / "room.yaml",
+        config_dict,
+    )
+
+    assert reloaded == original
+    assert reloaded.extra_parameters == original.extra_parameters
 
 
 def test_entrypoint_capability_config_unknown_entry_point(

--- a/tests/unit/config/test_config_tools.py
+++ b/tests/unit/config/test_config_tools.py
@@ -392,6 +392,38 @@ def test_aitp_as_yaml(ctor_kwargs):
     assert found == expected
 
 
+def _round_trip_aitp(config_path, config_dict):
+    """Reload an 'AIToolParams' from its own dump.
+
+    'from_yaml' pops the dotted-name keys ('prepare', 'args_validator',
+    ...) out of the mapping it is handed, storing them under their
+    underscore-prefixed fields, hence the copies.
+    """
+    klass = config_tools.AIToolParams
+    original = klass.from_yaml(config_path, copy.deepcopy(config_dict))
+    reloaded = klass.from_yaml(config_path, copy.deepcopy(original.as_yaml))
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_AI_TOOL_PARAMS_YAML,
+        FULL_AI_TOOL_PARAMS_YAML,
+    ],
+)
+def test_aitp_as_yaml_round_trips(temp_dir, config_yaml):
+    config_path = temp_dir / "room_config.yaml"
+
+    original, reloaded = _round_trip_aitp(
+        config_path,
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
+
+
 @pytest.mark.parametrize(
     "ctor_kwargs",
     [
@@ -515,6 +547,56 @@ def test_toolconfig_as_yaml(
     found = inst.as_yaml
 
     assert found == expected
+
+
+def _round_trip_config(
+    config_class,
+    installation_config,
+    config_path,
+    config_dict,
+):
+    """Reload an installation-scoped tool config from its own dump.
+
+    Shared by 'ToolConfig' / 'SearchDocumentsToolConfig' (whose
+    'from_yaml' pops 'agui_feature_names' and 'ai_tool_params') and by
+    the MCP toolset configs (whose 'from_yaml' pops 'kind'), hence the
+    copies.
+    """
+    original = config_class.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_dict),
+    )
+    reloaded = config_class.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(original.as_yaml),
+    )
+
+    return original, reloaded
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_TOOL_CONFIG_PARAMS_YAML,
+        W_AGUI_FEATURE_NAME_TOOL_CONFIG_PARAMS_YAML,
+        W_AI_TOOL_PARAMS_TOOL_CONFIG_PARAMS_YAML,
+    ],
+)
+def test_toolconfig_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    original, reloaded = _round_trip_config(
+        config_tools.ToolConfig,
+        installation_config,
+        temp_dir / "room_config.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
 
 
 def test_toolconfig_kind():
@@ -896,6 +978,30 @@ def test_sdtc_as_yaml(temp_dir, installation_config, w_kw):
 
 
 @pytest.mark.parametrize(
+    "config_yaml",
+    [
+        W_STEM_SDTC_CONFIG_YAML,
+        W_OVERRIDE_SDTC_CONFIG_YAML,
+        W_AGUI_FEATURE_NAME_SDTC_CONFIG_YAML,
+        W_AI_TOOL_PARAMS_SDTC_CONFIG_YAML,
+    ],
+)
+def test_sdtc_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    original, reloaded = _round_trip_config(
+        config_tools.SearchDocumentsToolConfig,
+        installation_config,
+        temp_dir / "room_config.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
+
+
+@pytest.mark.parametrize(
     "stem, override, which",
     [
         ("testing", None, "stem"),
@@ -1003,6 +1109,29 @@ def test_stdio_mctc_as_yaml(w_env):
     assert found["args"] == stdio_mctc.args
     assert found["env"] == stdio_mctc.env
     assert found["allowed_tools"] == stdio_mctc.allowed_tools
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_STDIO_MCTC_CONFIG_YAML,
+        FULL_STDIO_MCTC_CONFIG_YAML,
+    ],
+)
+def test_stdio_mctc_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    original, reloaded = _round_trip_config(
+        config_tools.Stdio_MCP_ClientToolsetConfig,
+        installation_config,
+        temp_dir / "installation.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
+    assert reloaded.toolset_params == original.toolset_params
 
 
 @pytest.mark.parametrize("w_env", [{}, {"foo": "bar"}])
@@ -1118,6 +1247,29 @@ def test_http_mctc_as_yaml(w_query_params, w_headers):
     assert found["query_params"] == http_mctc.query_params
     assert found["headers"] == http_mctc.headers
     assert found["allowed_tools"] == http_mctc.allowed_tools
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_HTTP_MCTC_CONFIG_YAML,
+        FULL_HTTP_MCTC_CONFIG_YAML,
+    ],
+)
+def test_http_mctc_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    original, reloaded = _round_trip_config(
+        config_tools.HTTP_MCP_ClientToolsetConfig,
+        installation_config,
+        temp_dir / "installation.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
+    assert reloaded.toolset_params == original.toolset_params
 
 
 @pytest.mark.parametrize("w_headers", [{}, HTTP_MCP_AUTH_HEADER])
@@ -1254,6 +1406,29 @@ def test_sse_mctc_as_yaml(w_query_params, w_headers):
     assert found["query_params"] == sse_mctc.query_params
     assert found["headers"] == sse_mctc.headers
     assert found["allowed_tools"] == sse_mctc.allowed_tools
+
+
+@pytest.mark.parametrize(
+    "config_yaml",
+    [
+        BARE_SSE_MCTC_CONFIG_YAML,
+        FULL_SSE_MCTC_CONFIG_YAML,
+    ],
+)
+def test_sse_mctc_as_yaml_round_trips(
+    installation_config,
+    temp_dir,
+    config_yaml,
+):
+    original, reloaded = _round_trip_config(
+        config_tools.SSE_MCP_ClientToolsetConfig,
+        installation_config,
+        temp_dir / "installation.yaml",
+        yaml.safe_load(config_yaml),
+    )
+
+    assert reloaded == original
+    assert reloaded.toolset_params == original.toolset_params
 
 
 @pytest.mark.parametrize("w_headers", [{}, HTTP_MCP_AUTH_HEADER])


### PR DESCRIPTION
Modules covered:

- 'soliplex.config.agents'
- 'soliplex.config.authsystem' [xfail: #1188]
- 'soliplex.config.completions' [xfail: #1187]
- 'soliplex.config.installation' [xfail: #1186]
- 'soliplex.config.logfire'
- 'soliplex.config.meta'
- 'soliplex.config.middleware' [xfail: #1189]
- 'soliplex.config.quizzes'
- 'soliplex.config.rooms'
- 'soliplex.config.routing'
- 'soliplex.config.secrets'
- 'soliplex.config.skills'
- 'soliplex.config.tools'

Closes #1190.