### PR TITLE
fix: 'config.middleware.Middleware.as_yaml'

### DIFF
--- a/src/soliplex/config/middleware.py
+++ b/src/soliplex/config/middleware.py
@@ -78,16 +78,28 @@ class MiddlewareConfig:
     app_factory: MiddlewareFactory
     extra_params: dict[str, typing.Any] = _default_dict_field()
 
-    @property
-    def needs_iconfig(self):
-        argspec = inspect.getfullargspec(self.app_factory)
-        return "installation_config" in argspec.kwonlyargs
-
     @classmethod
     def from_yaml(cls, yaml_config: dict):
         app_factory = yaml_config["app_factory"]
         yaml_config["app_factory"] = _utils._from_dotted_name(app_factory)
         return cls(**yaml_config)
+
+    @property
+    def as_yaml(self):
+        result = {
+            "name": self.name,
+            "app_factory": _utils._dotted_name(self.app_factory),
+        }
+
+        if self.extra_params:
+            result["extra_params"] = self.extra_params
+
+        return result
+
+    @property
+    def needs_iconfig(self):
+        argspec = inspect.getfullargspec(self.app_factory)
+        return "installation_config" in argspec.kwonlyargs
 
 
 def compose_middleware_stack(

--- a/tests/unit/config/test_config_middleware.py
+++ b/tests/unit/config/test_config_middleware.py
@@ -78,7 +78,29 @@ def test_middlewareconfig_from_yaml(
         assert found == expected
 
 
-@pytest.mark.xfail(strict=True, reason="#1189")
+@pytest.mark.parametrize("w_extra_params", [{}, {"foo": "bar"}])
+def test_middlewareconfig_as_yaml(w_extra_params):
+    if w_extra_params:
+        ep_kwargs = {"extra_params": w_extra_params}
+    else:
+        ep_kwargs = {}
+
+    mwc = config_middleware.MiddlewareConfig(
+        name="test-as_yaml",
+        app_factory=_test_middleware.null_app_factory,
+        **ep_kwargs,
+    )
+
+    found = mwc.as_yaml
+
+    assert found["app_factory"] == "_test_middleware.null_app_factory"
+
+    if w_extra_params:
+        assert found["extra_params"] == w_extra_params
+    else:
+        assert "extra_params" not in found
+
+
 @pytest.mark.parametrize(
     "config_yaml",
     [
@@ -88,18 +110,11 @@ def test_middlewareconfig_from_yaml(
     ],
 )
 def test_middlewareconfig_as_yaml_round_trips(config_yaml):
-    # 'MiddlewareConfig' has no 'as_yaml' at all, so the dump below
-    # raises 'AttributeError'. That makes the round trip the last
-    # executable statement in the test: anything after it would go
-    # uncovered while the xfail stands.
-    #
-    # When it lands, 'as_yaml' has to reverse '_from_dotted_name':
-    # 'from_yaml' resolves 'app_factory' to the callable itself, so the
-    # dump must render it back to a dotted name via '_utils._dotted_name'.
     klass = config_middleware.MiddlewareConfig
     original = klass.from_yaml(copy.deepcopy(yaml.safe_load(config_yaml)))
+    reloaded = klass.from_yaml(copy.deepcopy(original.as_yaml))
 
-    assert klass.from_yaml(copy.deepcopy(original.as_yaml)) == original
+    assert reloaded == original
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Round-trips with 'from_yaml'.

Closes #1189.