### PR TITLE
fix windows coverage errors

### DIFF
--- a/tests/_dburi.py
+++ b/tests/_dburi.py
@@ -1,0 +1,28 @@
+"""Database-URI helpers shared by 'tests/unit' and 'tests/functional'.
+
+A plain module rather than a 'conftest.py' because both suites need the
+*function*, and importing one conftest from another risks pytest holding
+a second, separate instance of that module. 'tests/' is importable as a
+namespace package thanks to 'pythonpath = ["."]' in 'pyproject.toml'.
+
+The fixture wrappers ('authz_dburi_sync' / 'authz_dburi_async') live in
+'tests/conftest.py'.
+"""
+
+import pathlib
+
+
+def sqlite_dburi(db_path: pathlib.Path, driver: str = "") -> str:
+    """Build an absolute 'sqlite[<driver>]:///<abs>' URI for 'db_path'.
+
+    An absolute URI (four leading slashes once the leading '/' of a POSIX
+    path is included) keeps the database independent of the process
+    working directory.
+
+    The path is spelled POSIX-style because these URIs get written into a
+    double-quoted YAML scalar, where a Windows path's backslashes are
+    escape sequences: 'C:\\Users\\...' fails to parse ('\\U' wants eight
+    hex digits) and e.g. '\\t' would silently become a tab. SQLAlchemy's
+    sqlite dialect accepts 'sqlite:///C:/...' on Windows.
+    """
+    return f"sqlite{driver}:///{db_path.as_posix()}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Fixtures shared by 'tests/unit' and 'tests/functional'.
+
+pytest loads the 'conftest.py' of every parent directory of a test, so
+definitions here reach both suites. Definitions in
+'tests/unit/conftest.py' reach only 'tests/unit' and below.
+
+These are function-scoped, because 'tmp_path' is. A module- or
+session-scoped fixture cannot request them (pytest raises
+'ScopeMismatch'); such a fixture should build its own path from
+'tmp_path_factory' and call 'tests._dburi.sqlite_dburi' directly, as
+'tests/unit/cli/conftest.py' does.
+"""
+
+import pytest
+
+from tests._dburi import sqlite_dburi
+
+
+@pytest.fixture
+def authz_db_path(tmp_path):
+    """The scratch authz sqlite file an installation is repointed at.
+
+    Derived from the per-test 'tmp_path', so a fixture that rewrites a
+    config and a test that seeds rows directly resolve to the same file
+    -- letting a test create state the CLI cannot (e.g. an ACL entry
+    whose stored 'json_path' no longer compiles).
+    """
+    return tmp_path / "authz.sqlite"
+
+
+@pytest.fixture
+def authz_dburi_sync(authz_db_path):
+    """Synchronous 'sqlite:///' URI for 'authz_db_path'."""
+    return sqlite_dburi(authz_db_path)
+
+
+@pytest.fixture
+def authz_dburi_async(authz_db_path):
+    """Asynchronous 'sqlite+aiosqlite:///' URI for 'authz_db_path'."""
+    return sqlite_dburi(authz_db_path, "+aiosqlite")

--- a/tests/functional/test_cli_smoketest.py
+++ b/tests/functional/test_cli_smoketest.py
@@ -50,6 +50,18 @@ STALE_ACL_MARKER = "stale_filter_func"
 ROOM = "faux"
 
 
+def _sqlite_dburi(db_path: pathlib.Path, driver: str = "") -> str:
+    """Build an absolute 'sqlite:///<abs>' URI for 'db_path'.
+
+    The path is spelled POSIX-style because these URIs are written into a
+    double-quoted YAML scalar, where a Windows path's backslashes are
+    escape sequences: 'C:\\Users\\...' fails to parse ('\\U' wants eight
+    hex digits) and e.g. '\\t' would silently become a tab. SQLAlchemy's
+    sqlite dialect accepts 'sqlite:///C:/...' on Windows.
+    """
+    return f"sqlite{driver}:///{db_path.as_posix()}"
+
+
 @pytest.fixture
 def scratch_installation(tmp_path):
     """A copy of 'example/minimal.yaml' backed by a fresh, empty authz DB."""
@@ -59,10 +71,15 @@ def scratch_installation(tmp_path):
     db_path = tmp_path / "authz.sqlite"
 
     text = config_path.read_text()
-    text, n_db = _AUTHZ_DBURI_RE.subn(
+    # Passed as a callable because 're.sub' expands backslash escapes in a
+    # replacement *string*, which a Windows 'tmp_path' would trip over.
+    authz_replacement = (
         "authorization_dburi:\n"
-        f'  sync: "sqlite:///{db_path}"\n'
-        f'  async: "sqlite+aiosqlite:///{db_path}"',
+        f'  sync: "{_sqlite_dburi(db_path)}"\n'
+        f'  async: "{_sqlite_dburi(db_path, "+aiosqlite")}"'
+    )
+    text, n_db = _AUTHZ_DBURI_RE.subn(
+        lambda _: authz_replacement,
         text,
     )
     assert n_db == 1, f"expected one authz_dburi stanza, found {n_db}"
@@ -162,7 +179,7 @@ def _seed_stale_acl_entry(db_path, room_id):
     'list_room_policies' read.
     """
     session = authz_schema.get_session(
-        engine_url=f"sqlite:///{db_path}",
+        engine_url=_sqlite_dburi(db_path),
         init_schema=True,
     )
     with session:

--- a/tests/functional/test_cli_smoketest.py
+++ b/tests/functional/test_cli_smoketest.py
@@ -21,6 +21,7 @@ import yaml
 
 from soliplex import authz
 from soliplex.authz import schema as authz_schema
+from tests._dburi import sqlite_dburi
 
 # 'tests/functional/test_cli_smoketest.py' -> parents[2] is the repo root.
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -50,33 +51,20 @@ STALE_ACL_MARKER = "stale_filter_func"
 ROOM = "faux"
 
 
-def _sqlite_dburi(db_path: pathlib.Path, driver: str = "") -> str:
-    """Build an absolute 'sqlite:///<abs>' URI for 'db_path'.
-
-    The path is spelled POSIX-style because these URIs are written into a
-    double-quoted YAML scalar, where a Windows path's backslashes are
-    escape sequences: 'C:\\Users\\...' fails to parse ('\\U' wants eight
-    hex digits) and e.g. '\\t' would silently become a tab. SQLAlchemy's
-    sqlite dialect accepts 'sqlite:///C:/...' on Windows.
-    """
-    return f"sqlite{driver}:///{db_path.as_posix()}"
-
-
 @pytest.fixture
-def scratch_installation(tmp_path):
+def scratch_installation(tmp_path, authz_dburi_sync, authz_dburi_async):
     """A copy of 'example/minimal.yaml' backed by a fresh, empty authz DB."""
     dst = tmp_path / "example"
     shutil.copytree(_EXAMPLE_DIR, dst)
     config_path = dst / "minimal.yaml"
-    db_path = tmp_path / "authz.sqlite"
 
     text = config_path.read_text()
     # Passed as a callable because 're.sub' expands backslash escapes in a
     # replacement *string*, which a Windows 'tmp_path' would trip over.
     authz_replacement = (
         "authorization_dburi:\n"
-        f'  sync: "{_sqlite_dburi(db_path)}"\n'
-        f'  async: "{_sqlite_dburi(db_path, "+aiosqlite")}"'
+        f'  sync: "{authz_dburi_sync}"\n'
+        f'  async: "{authz_dburi_async}"'
     )
     text, n_db = _AUTHZ_DBURI_RE.subn(
         lambda _: authz_replacement,
@@ -91,18 +79,6 @@ def scratch_installation(tmp_path):
     config_path.write_text(text)
 
     return config_path
-
-
-@pytest.fixture
-def authz_db_path(tmp_path):
-    """The scratch authz sqlite file that 'scratch_installation' points at.
-
-    Shares the per-test 'tmp_path', so it resolves to the same file the
-    repointed 'authorization_dburi' uses -- letting a test seed rows the
-    CLI cannot create on its own (e.g. an ACL entry whose stored
-    'json_path' no longer compiles).
-    """
-    return tmp_path / "authz.sqlite"
 
 
 def _run(config_path, group, subcommand, *rest, input_text=None):
@@ -179,7 +155,7 @@ def _seed_stale_acl_entry(db_path, room_id):
     'list_room_policies' read.
     """
     session = authz_schema.get_session(
-        engine_url=_sqlite_dburi(db_path),
+        engine_url=sqlite_dburi(db_path),
         init_schema=True,
     )
     with session:

--- a/tests/unit/capabilities/test_filesystem_cap.py
+++ b/tests/unit/capabilities/test_filesystem_cap.py
@@ -234,7 +234,9 @@ async def test_run_script_returns_stdout(temp_dir):
         "scripts/echo.py", "stanza jabberwocky --stanza 3"
     )
 
-    assert output == "stanza jabberwocky --stanza 3\n"
+    # 'run_script' hands back the script's stdout verbatim, and a child
+    # Python on Windows newline-translates 'print' to '\r\n'.
+    assert output.replace("\r\n", "\n") == "stanza jabberwocky --stanza 3\n"
 
 
 @pytest.mark.anyio

--- a/tests/unit/capabilities/test_filesystem_cap.py
+++ b/tests/unit/capabilities/test_filesystem_cap.py
@@ -234,8 +234,11 @@ async def test_run_script_returns_stdout(temp_dir):
         "scripts/echo.py", "stanza jabberwocky --stanza 3"
     )
 
-    # 'run_script' hands back the script's stdout verbatim, and a child
-    # Python on Windows newline-translates 'print' to '\r\n'.
+    # On Windows the child Python's own text-mode stdout writes '\r\n'
+    # onto the pipe. Universal newlines does not undo that here: it is a
+    # *text-mode* feature, and 'anyio.run_process' has no text mode --
+    # it hands back bytes, which 'run_script' turns into str with
+    # '.decode()', a codec call that leaves newlines untouched.
     assert output.replace("\r\n", "\n") == "stanza jabberwocky --stanza 3\n"
 
 

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -49,20 +49,35 @@ class ScratchInstallation:
         )
 
 
+def _sqlite_dburi(db_path: pathlib.Path, driver: str = "") -> str:
+    """Build an absolute 'sqlite:///<abs>' URI for 'db_path'.
+
+    An absolute URI (four leading slashes once the leading '/' of a POSIX
+    path is included) keeps the database independent of the process
+    working directory.
+
+    The path is spelled POSIX-style because these URIs are written into a
+    double-quoted YAML scalar, where a Windows path's backslashes are
+    escape sequences: 'C:\\Users\\...' fails to parse ('\\U' wants eight
+    hex digits) and e.g. '\\t' would silently become a tab. SQLAlchemy's
+    sqlite dialect accepts 'sqlite:///C:/...' on Windows.
+    """
+    return f"sqlite{driver}:///{db_path.as_posix()}"
+
+
 def _point_authz_db(config_path: pathlib.Path, db_path: pathlib.Path) -> None:
     """Repoint a copied installation's authz DB at an absolute scratch file.
 
-    An absolute 'sqlite:///<abs>' URI (four leading slashes once the
-    leading '/' of the path is included) keeps the database independent
-    of the process working directory.
+    The replacement is passed to 'subn' as a callable because 're.sub'
+    expands backslash escapes in a replacement *string*.
     """
     text = config_path.read_text()
     replacement = (
         "authorization_dburi:\n"
-        f'  sync: "sqlite:///{db_path}"\n'
-        f'  async: "sqlite+aiosqlite:///{db_path}"'
+        f'  sync: "{_sqlite_dburi(db_path)}"\n'
+        f'  async: "{_sqlite_dburi(db_path, "+aiosqlite")}"'
     )
-    text, n_subs = _AUTHZ_DBURI_RE.subn(replacement, text)
+    text, n_subs = _AUTHZ_DBURI_RE.subn(lambda _: replacement, text)
     # Fail loudly if the example config's shape drifts out from under us.
     assert n_subs == 1, f"expected one authz_dburi stanza, found {n_subs}"
     config_path.write_text(text)
@@ -117,7 +132,7 @@ def scratch_installation(_installation_template) -> ScratchInstallation:
     db_path.unlink(missing_ok=True)
     return ScratchInstallation(
         path=config_path,
-        dburi=f"sqlite:///{db_path}",
+        dburi=_sqlite_dburi(db_path),
         db_path=db_path,
     )
 

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from soliplex.authz import schema as authz_schema
+from tests._dburi import sqlite_dburi
 
 # 'tests/unit/cli/conftest.py' -> parents[3] is the repo root.
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
@@ -49,33 +50,22 @@ class ScratchInstallation:
         )
 
 
-def _sqlite_dburi(db_path: pathlib.Path, driver: str = "") -> str:
-    """Build an absolute 'sqlite:///<abs>' URI for 'db_path'.
-
-    An absolute URI (four leading slashes once the leading '/' of a POSIX
-    path is included) keeps the database independent of the process
-    working directory.
-
-    The path is spelled POSIX-style because these URIs are written into a
-    double-quoted YAML scalar, where a Windows path's backslashes are
-    escape sequences: 'C:\\Users\\...' fails to parse ('\\U' wants eight
-    hex digits) and e.g. '\\t' would silently become a tab. SQLAlchemy's
-    sqlite dialect accepts 'sqlite:///C:/...' on Windows.
-    """
-    return f"sqlite{driver}:///{db_path.as_posix()}"
-
-
 def _point_authz_db(config_path: pathlib.Path, db_path: pathlib.Path) -> None:
     """Repoint a copied installation's authz DB at an absolute scratch file.
 
     The replacement is passed to 'subn' as a callable because 're.sub'
     expands backslash escapes in a replacement *string*.
+
+    Builds the URIs directly rather than via the 'authz_dburi_*' fixtures
+    in 'tests/conftest.py': those derive from the function-scoped
+    'tmp_path', and the caller here is the module-scoped
+    '_installation_template', which cannot request them.
     """
     text = config_path.read_text()
     replacement = (
         "authorization_dburi:\n"
-        f'  sync: "{_sqlite_dburi(db_path)}"\n'
-        f'  async: "{_sqlite_dburi(db_path, "+aiosqlite")}"'
+        f'  sync: "{sqlite_dburi(db_path)}"\n'
+        f'  async: "{sqlite_dburi(db_path, "+aiosqlite")}"'
     )
     text, n_subs = _AUTHZ_DBURI_RE.subn(lambda _: replacement, text)
     # Fail loudly if the example config's shape drifts out from under us.
@@ -132,7 +122,7 @@ def scratch_installation(_installation_template) -> ScratchInstallation:
     db_path.unlink(missing_ok=True)
     return ScratchInstallation(
         path=config_path,
-        dburi=_sqlite_dburi(db_path),
+        dburi=sqlite_dburi(db_path),
         db_path=db_path,
     )
 

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -71,6 +71,11 @@ skills:
 """
 
 LANCE_DB_OVERRIDE_PATH = pathlib.Path("/tmp/rag.lancedb")
+# 'str(WindowsPath("/tmp/rag.lancedb"))' is '\tmp\rag.lancedb', and a
+# double-quoted YAML scalar expands '\t' / '\r' as escapes -- so the path
+# is emitted POSIX-style, which round-trips to the same 'pathlib.Path' on
+# either platform.
+LANCE_DB_OVERRIDE_YAML_PATH = LANCE_DB_OVERRIDE_PATH.as_posix()
 
 W_HR_SKILLS_ROOM_CONFIG_KW = BARE_ROOM_CONFIG_KW | {
     "skills": config_skills.RoomSkillsConfig(
@@ -86,7 +91,7 @@ W_HR_SKILLS_ROOM_CONFIG_YAML = f"""\
 skills:
     skill_configs:
         - kind: "haiku.rag.skills.rag"
-          rag_lancedb_override_path: "{LANCE_DB_OVERRIDE_PATH}"
+          rag_lancedb_override_path: "{LANCE_DB_OVERRIDE_YAML_PATH}"
 """
 
 W_NON_HR_TOOLS_ROOM_CONFIG_KW = BARE_ROOM_CONFIG_KW | {

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pathlib
 import uuid
 from unittest import mock
@@ -17,6 +18,11 @@ ROOM_ID = "test_room"
 THREAD_ID = uuid.uuid4()
 RUN_ID = uuid.uuid4()
 USERNAME = "phreddy"
+
+# 'write_transcript' requests owner-only '0600'. Windows has no POSIX mode
+# bits -- 'os.chmod' there only toggles the read-only flag -- so a writable
+# file reports '0666' however it was chmod'ed.
+EXPECTED_TRANSCRIPT_MODE = 0o600 if os.name == "posix" else 0o666
 
 ONE_ENVIRONMENT = mock.create_autospec(bs_models.EnvironmentInfo)
 ONE_ENVIRONMENT.name = "one"  # mock quirk
@@ -507,7 +513,7 @@ def test_write_transcript(transcripts_path, content, suffix):
     )
     assert found_path.suffix == suffix
     assert found_path.read_text(encoding="utf-8") == content
-    assert (found_path.stat().st_mode & 0o777) == 0o600
+    assert (found_path.stat().st_mode & 0o777) == EXPECTED_TRANSCRIPT_MODE
 
 
 @pytest.mark.parametrize("w_iconfig", [False, True])

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -19,10 +19,13 @@ THREAD_ID = uuid.uuid4()
 RUN_ID = uuid.uuid4()
 USERNAME = "phreddy"
 
-# 'write_transcript' requests owner-only '0600'. Windows has no POSIX mode
-# bits -- 'os.chmod' there only toggles the read-only flag -- so a writable
-# file reports '0666' however it was chmod'ed.
-EXPECTED_TRANSCRIPT_MODE = 0o600 if os.name == "posix" else 0o666
+# 'write_transcript' requests owner-only '0600', which every POSIX host
+# honours -- Linux and macOS (APFS / HFS+) alike, as 'os.name' is 'posix'
+# on both ('sys.platform' is what distinguishes 'darwin'). Windows is the
+# lone exception: it has no POSIX mode bits, and 'os.chmod' there only
+# toggles the read-only flag, so a writable file reports '0666' however
+# it was chmod'ed.
+EXPECTED_TRANSCRIPT_MODE = 0o666 if os.name == "nt" else 0o600
 
 ONE_ENVIRONMENT = mock.create_autospec(bs_models.EnvironmentInfo)
 ONE_ENVIRONMENT.name = "one"  # mock quirk


### PR DESCRIPTION
# fix: make the test suites pass on Windows as well as Linux

## Summary

The test suites only ran on Linux. On Windows the unit suite reported
**4 failures and 57 errors**, and the functional suite a further 4
errors.

Every one of those was a portability bug in the tests themselves. No
production code path under test was at fault, and no source file is
modified here: the failures were assertions and fixtures that had
quietly baked in POSIX assumptions.

Adds a `windows-latest` CI job so this does not regress.

## Root causes

Four distinct classes, in descending order of blast radius.

### 1. Windows paths expanded as escapes by `re.sub` (57 errors)

`tests/unit/cli/conftest.py` rewrites a scratch copy of
`example/minimal.yaml` to repoint its authz database. The replacement
was passed to `subn()` as a *string*, and `re.sub` expands backslash
escapes in replacement strings -- so a `tmp_path` of `C:\Users\...`
raised `re.PatternError: bad escape \U`. Now passed as a callable,
which bypasses escape processing entirely.

### 2. Windows paths inside a double-quoted YAML scalar

The same class of bug one layer down, and the more dangerous of the
two. With the regex fixed, the injected
`sync: "sqlite:///C:\Users\..."` then met YAML's own escape rules,
where `\U` requires eight hex digits.

Worth flagging for reviewers: `\U` failed loudly only by luck. `\t`,
`\L`, and `\N` are all valid YAML escapes and would have **silently**
corrupted the path instead.

Fixed by spelling these paths POSIX-style through a shared
`_sqlite_dburi()` helper. SQLAlchemy's sqlite dialect accepts
`sqlite:///C:/...` on Windows -- verified before relying on it.

`tests/unit/config/test_config_rooms.py` had the same defect:
`pathlib.Path("/tmp/rag.lancedb")` stringifies to `\tmp\rag.lancedb` on
Windows, so `\t` became a literal tab inside the fixture YAML. It now
interpolates `.as_posix()`, which round-trips to the same
`pathlib.Path` on either platform.

### 3. CRLF in captured subprocess output

`tests/unit/capabilities/test_filesystem_cap.py` compared script stdout
against an exact string. A child Python newline-translates `print` to
`\r\n` on Windows. The assertion now normalizes line endings.

`run_script` returns the script's stdout verbatim, which is correct
behaviour, so the fix belongs in the test rather than the capability.

### 4. POSIX mode bits

`tests/unit/skills/test_bwrap_sandbox.py` asserted
`st_mode & 0o777 == 0o600`. Windows has no POSIX mode bits -- `chmod`
there only toggles the read-only flag -- so a writable file reports
`0o666` however it was chmod'ed. The expected value is now derived from
`os.name`.

### Functional suite

`tests/functional/test_cli_smoketest.py` duplicates the scratch-
installation fixture and carried an identical copy of causes 1 and 2 (4
errors). Fixed the same way. All 21 non-`needs_llm` functional tests
now pass on Windows.

## Why not `skipif`

`addopts` includes `--cov=tests/unit` alongside
`--cov-fail-under=100`, so a test skipped on one platform leaves its
own body uncovered and fails the gate. Every fix here is therefore
platform-agnostic -- the same code runs on both -- rather than a skip.


## Verification

Run on both platforms, `-n auto`:

| | Linux | Windows |
| ---------------------- | ----------- | ----------- |
| Unit suite             | 3729 passed | 3729 passed |
| Coverage gate          | 100%        | 100%        |
| Functional (non-LLM)   | 4/4 changed | 21 passed   |

Linux was verified in a `python:3.13` container. `ruff check`,
`ruff format --check`, `actionlint`, `pymarkdown`, and `check-toml` all
pass on the changed files.

