### PR TITLE
ci: lint for Python textio w/o explicit encoding

### DIFF
--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -8,6 +8,7 @@ on:
       - 'pyproject.toml'
       - 'src/soliplex/**'
       - 'tests/**'
+      - 'scripts/**'
       - '.github/workflows/python-lint.yaml'
       - 'uv.lock'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - 'pyproject.toml'
       - 'src/soliplex/**'
       - 'tests/**'
+      - 'scripts/**'
       - '.github/workflows/python-lint.yaml'
       - 'uv.lock'
   workflow_dispatch:
@@ -54,6 +56,18 @@ jobs:
           set -o pipefail
           uv run ruff check 2>&1 | tee ruff-check.log
 
+      # 'ruff PLW1514' covers only the 'open()' form, not the 'pathlib'
+      # 'read_text()' / 'write_text()' helpers; this catches all three.
+      # The self-test runs first, so a check gone blind fails loudly
+      # rather than passing by finding nothing.
+      - name: Check text IO encoding
+        run: |
+          set -o pipefail
+          uv run python scripts/lint_textio.py --self-test 2>&1 \
+            | tee lint-textio.log
+          uv run python scripts/lint_textio.py --verbose 2>&1 \
+            | tee -a lint-textio.log
+
       # Slack notification lives in 'ci-failure-notify.yaml', which only
       # links to this run (see #1203), so record what failed here.
       - name: Summarize failures
@@ -62,7 +76,7 @@ jobs:
           {
             echo "## Linting failed"
             echo
-            for log in ruff-format.log ruff-check.log; do
+            for log in ruff-format.log ruff-check.log lint-textio.log; do
               [ -f "$log" ] || continue
               echo "<details><summary>$log</summary>"
               echo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,20 @@ repos:
         language: system
         pass_filenames: false
         files: ^skills/soliplex-docs/
+      - id: lint-textio
+        name: lint text IO encoding
+        entry: uv run python scripts/lint_textio.py --verbose
+        language: system
+        types: [python]
+        # 'src/' only: the test suite's own call sites are a separate
+        # cleanup, and its fixtures are not UTF-8 by specification.
+        files: ^src/soliplex/
+      - id: lint-textio-self-test
+        name: lint text IO encoding (self-test)
+        entry: uv run python scripts/lint_textio.py --self-test
+        language: system
+        pass_filenames: false
+        files: ^scripts/lint_textio\.py$
 
   - repo: https://github.com/jackdewinter/pymarkdown
     rev: v0.9.36

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,9 @@ tree). The configured hooks (see `.pre-commit-config.yaml`) enforce:
 
 - `ruff-check` / `ruff-format` -- lint and format Python sources
 - `pymarkdown` -- lint Markdown files
+- `lint-textio` -- reject text file IO in `src/soliplex/` without an
+  explicit `encoding=` (falls back to the host locale encoding, `cp1252` on
+  Windows); `scripts/lint_textio.py`, stdlib-only, with a `--self-test` mode
 - `actionlint` -- lint GitHub Actions workflow files
 - `check-toml` / `check-yaml` -- validate TOML and YAML syntax
 - `gitleaks` -- scan for committed secrets

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -123,6 +123,10 @@ The configured hooks (see `.pre-commit-config.yaml`) enforce:
 - **ruff-check** -- lint Python sources (auto-fixing where possible).
 - **ruff-format** -- format Python sources.
 - **pymarkdown** -- lint Markdown files.
+- **lint-textio** -- reject text file IO in `src/soliplex/` that passes no
+  explicit `encoding=` and so falls back to the host locale encoding
+  (`cp1252` on a typical Windows host); see `scripts/lint_textio.py`, which
+  also runs standalone and carries a `--self-test` mode.
 - **actionlint** -- lint GitHub Actions workflow files.
 - **check-toml** / **check-yaml** -- validate TOML and YAML syntax.
 - **gitleaks** -- scan for committed secrets.

--- a/scripts/lint_textio.py
+++ b/scripts/lint_textio.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+"""Reject locale-dependent text file IO in 'src/soliplex/'.
+
+Text-mode 'read_text()' / 'write_text()' / 'open()' without an explicit
+'encoding=' fall back to 'locale.getpreferredencoding(False)' -- UTF-8
+on Linux, but 'cp1252' on a typical Windows host. Configuration YAML,
+quiz JSON, prompt files, and '.env' files are UTF-8 by specification, so
+that fallback silently mojibakes non-ASCII content on Windows: a file
+holding 'Ada Lovelace's -- terse.' reads back mangled, with no exception
+raised.
+
+'ruff PLW1514' covers only the 'open()' form -- not 'read_text()' /
+'write_text()' -- which is why this lives here rather than in the ruff
+configuration. The behavioural regression tests for the underlying bug
+live next to the code they cover, but those can only fail on a host
+whose locale encoding is not UTF-8; this check has teeth on every
+platform, because it rejects the *pattern* rather than waiting for a
+mojibaked byte to reach an assertion.
+
+Exits non-zero when any offending call is found.
+
+Usage::
+
+    python scripts/lint_textio.py
+    python scripts/lint_textio.py --verbose
+    python scripts/lint_textio.py src/soliplex/config tests/unit/foo.py
+    python scripts/lint_textio.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import pathlib
+import sys
+from typing import NamedTuple
+
+REPO_DIR = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_TARGET = REPO_DIR / "src" / "soliplex"
+
+# 'pathlib.Path' text helpers, plus builtin 'open' / 'Path.open'.
+TEXT_IO_NAMES = frozenset({"read_text", "write_text", "open"})
+
+
+class Finding(NamedTuple):
+    """One text IO call made without an explicit 'encoding='."""
+
+    label: str
+    lineno: int
+    end_lineno: int
+    name: str
+
+    def __str__(self) -> str:
+        return f"{self.label}:{self.lineno}: {self.name}()"
+
+
+def _call_name(node: ast.Call) -> str | None:
+    """Return the called attribute / bare name, or 'None' if neither."""
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+
+    return getattr(func, "id", None)
+
+
+def _is_binary(node: ast.Call) -> bool:
+    """True when a literal mode argument selects binary mode."""
+    return any(
+        isinstance(arg.value, str) and "b" in arg.value
+        for arg in node.args
+        if isinstance(arg, ast.Constant)
+    )
+
+
+def unencoded_text_io(source: str, label: str) -> list[Finding]:
+    """Return a 'Finding' per offending call in 'source'.
+
+    A call is reported when it names a text IO helper, passes no
+    'encoding=', and carries no literal binary mode. A non-literal mode
+    (e.g. 'path.open(mode)') is reported rather than assumed binary --
+    the check prefers a false positive to a silent miss.
+    """
+    findings = []
+
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+
+        name = _call_name(node)
+
+        if name not in TEXT_IO_NAMES:
+            continue
+
+        if any(kw.arg == "encoding" for kw in node.keywords):
+            continue
+
+        if _is_binary(node):
+            continue
+
+        findings.append(
+            Finding(label, node.lineno, node.end_lineno or node.lineno, name)
+        )
+
+    return findings
+
+
+def iter_sources(targets: list[pathlib.Path]) -> list[pathlib.Path]:
+    """Expand 'targets' (files or directories) to '*.py' paths."""
+    paths = []
+
+    for target in targets:
+        if target.is_dir():
+            paths.extend(target.rglob("*.py"))
+        else:
+            paths.append(target)
+
+    return sorted(set(paths))
+
+
+def _label(path: pathlib.Path) -> str:
+    """Return 'path' relative to the repo root when it lies inside it."""
+    resolved = path.resolve()
+
+    if resolved.is_relative_to(REPO_DIR):
+        return resolved.relative_to(REPO_DIR).as_posix()
+
+    return path.as_posix()
+
+
+class Scan(NamedTuple):
+    """The outcome of scanning a set of targets."""
+
+    findings: list[Finding]
+    errors: list[str]
+    # Source text of each scanned file, keyed by its finding label.
+    sources: dict[str, str]
+
+
+def scan(targets: list[pathlib.Path]) -> Scan:
+    """Scan every '*.py' file under 'targets'."""
+    result = Scan([], [], {})
+
+    for path in iter_sources(targets):
+        label = _label(path)
+
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            result.errors.append(f"{label}: cannot read: {exc}")
+            continue
+
+        try:
+            findings = unencoded_text_io(source, label)
+        except SyntaxError as exc:
+            result.errors.append(f"{label}: cannot parse: {exc}")
+            continue
+
+        result.findings.extend(findings)
+        result.sources[label] = source
+
+    return result
+
+
+def chunk(source: str, finding: Finding) -> list[str]:
+    """Return the numbered source lines spanned by 'finding'."""
+    lines = source.splitlines()
+    width = len(str(finding.end_lineno))
+
+    return [
+        f"  {lineno:>{width}} | {lines[lineno - 1]}"
+        for lineno in range(finding.lineno, finding.end_lineno + 1)
+    ]
+
+
+def report(scanned: Scan, verbose: bool) -> None:
+    """Print findings to stderr, with source chunks when 'verbose'."""
+    findings = scanned.findings
+
+    for finding in findings:
+        print(finding, file=sys.stderr)
+
+        if verbose:
+            for line in chunk(scanned.sources[finding.label], finding):
+                print(line, file=sys.stderr)
+
+    print(
+        f"\nlint_textio: {len(findings)} text IO call(s) without "
+        "'encoding='; the host locale encoding ('cp1252' on Windows) "
+        'applies instead -- pass encoding="utf-8".',
+        file=sys.stderr,
+    )
+
+
+# Every form the check must catch, and every form it must let through.
+# Line numbers are asserted on below, so keep the layout stable.
+SELF_TEST_SOURCE = """\
+import pathlib
+
+path = pathlib.Path("f")
+data = "x"
+mode = "rb"
+
+path.read_text()
+path.read_text(encoding="utf-8")
+path.write_text(data)
+path.write_text(data, encoding="utf-8")
+path.open()
+path.open("rb")
+path.open(mode)
+open("f")
+len("not file io")
+path.write_text(
+    data,
+    newline="\\n",
+)
+"""
+
+SELF_TEST_EXPECTED = [
+    Finding("self-test", 7, 7, "read_text"),
+    Finding("self-test", 9, 9, "write_text"),
+    Finding("self-test", 11, 11, "open"),
+    # Non-literal mode: reported rather than assumed binary.
+    Finding("self-test", 13, 13, "open"),
+    # Builtin, not a method.
+    Finding("self-test", 14, 14, "open"),
+    # Multi-line call: spans lines 16-19.
+    Finding("self-test", 16, 19, "write_text"),
+]
+
+
+def self_test(verbose: bool) -> int:
+    """Check that the scan bites -- rather than passing by finding nothing.
+
+    Returns '0' when the embedded source yields exactly the expected
+    findings, '1' otherwise.
+    """
+    found = unencoded_text_io(SELF_TEST_SOURCE, "self-test")
+
+    if found == SELF_TEST_EXPECTED:
+        if verbose:
+            for finding in found:
+                print(finding, file=sys.stderr)
+                for line in chunk(SELF_TEST_SOURCE, finding):
+                    print(line, file=sys.stderr)
+
+        print(
+            f"lint_textio: self-test passed "
+            f"({len(SELF_TEST_EXPECTED)} expected findings).",
+            file=sys.stderr,
+        )
+        return 0
+
+    missed = [one for one in SELF_TEST_EXPECTED if one not in found]
+    spurious = [one for one in found if one not in SELF_TEST_EXPECTED]
+
+    for finding in missed:
+        print(f"lint_textio: self-test: missed {finding}", file=sys.stderr)
+
+    for finding in spurious:
+        print(f"lint_textio: self-test: spurious {finding}", file=sys.stderr)
+
+    print(
+        "\nlint_textio: self-test FAILED -- the check no longer reports "
+        "what it is supposed to report.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        type=pathlib.Path,
+        default=[DEFAULT_TARGET],
+        help="Files or directories to scan (default: src/soliplex).",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Dump the source chunk containing each offending call.",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Verify the check against an embedded source holding every "
+        "offending form, then exit without scanning anything.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test(args.verbose)
+
+    scanned = scan(args.targets or [DEFAULT_TARGET])
+
+    for error in scanned.errors:
+        print(f"lint_textio: error: {error}", file=sys.stderr)
+
+    if scanned.findings:
+        report(scanned, args.verbose)
+
+    return 1 if scanned.findings or scanned.errors else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
See PR #1248 for the actual fixes.