### PR TITLE
feat: list a user's threads across every room they can see

### DIFF
--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -248,6 +248,33 @@ class ThreadStorage(abc.ABC):
         """
 
     @abc.abstractmethod
+    async def list_user_threads_page(
+        self,
+        *,
+        user_name: str,
+        room_ids: list[str],
+        limit: int,
+        offset: int,
+    ) -> tuple[list[Thread], int]:
+        """Return one page of the user's threads across several rooms.
+
+        Unlike 'list_user_threads', which is scoped to a single room,
+        this spans every room in 'room_ids' -- the caller is responsible
+        for having already filtered those to the rooms the user may see.
+        An empty 'room_ids' therefore yields an empty page rather than
+        every room's threads.
+
+        Threads are ordered so that each room's threads are contiguous:
+        rooms by their latest run activity (most recent first, rooms with
+        no activity last), then -- within a room -- by thread name,
+        case-insensitively. Contiguity is what lets a client emit a
+        section divider whenever the room changes.
+
+        Returns the page and the total number of threads matching, so a
+        caller can tell whether more pages remain.
+        """
+
+    @abc.abstractmethod
     async def get_thread(
         self,
         *,

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -127,6 +127,86 @@ class ThreadStorage(agui.ThreadStorage):
             result = await session.scalars(query)
         return result
 
+    async def list_user_threads_page(
+        self,
+        *,
+        user_name: str,
+        room_ids: list[str],
+        limit: int,
+        offset: int,
+    ) -> tuple[list[agui_schema.Thread], int]:
+        room_ids = list(room_ids)
+
+        if not room_ids:
+            # No accessible rooms: short-circuit rather than emitting an
+            # 'IN ()', which SQLAlchemy warns about and which reads as
+            # "unfiltered" to anyone skimming the SQL.
+            return [], 0
+
+        async with self.session as session:
+            base = (
+                sqla_sql.select(agui_schema.Thread)
+                .where(agui_schema.Thread.user_name == user_name)
+                .where(agui_schema.Thread.room_id.in_(room_ids))
+            )
+
+            total = await session.scalar(
+                sqla_sql.select(sqla_sql.func.count()).select_from(
+                    base.subquery()
+                )
+            )
+
+            # Rooms sort by their latest activity, so the ordering has to
+            # come from an aggregate over runs. Doing it as a grouped
+            # subquery -- rather than joining runs directly -- keeps one
+            # row per thread: a direct join would multiply each thread by
+            # its run count and corrupt LIMIT/OFFSET.
+            room_activity = (
+                sqla_sql.select(
+                    agui_schema.Thread.room_id.label("room_id"),
+                    _LAST_ACTIVITY.label("last_activity"),
+                )
+                .join(agui_schema.Run.thread)
+                .where(agui_schema.Thread.user_name == user_name)
+                .group_by(agui_schema.Thread.room_id)
+                .subquery()
+            )
+
+            # LEFT OUTER on both: a room whose threads have no runs yet
+            # still has to appear, and so does a thread with no metadata
+            # row (one exists only once a name has been set).
+            query = (
+                base.outerjoin(
+                    room_activity,
+                    room_activity.c.room_id == agui_schema.Thread.room_id,
+                )
+                .outerjoin(agui_schema.Thread.thread_metadata)
+                .order_by(
+                    # Rooms with no activity sort last: 'NULLS LAST' is
+                    # not portable to SQLite, so order on the computed
+                    # is-null flag first.
+                    room_activity.c.last_activity.is_(None),
+                    room_activity.c.last_activity.desc(),
+                    # Tie-break on room_id so that rooms sharing an
+                    # activity timestamp still come out contiguous.
+                    agui_schema.Thread.room_id,
+                    sqla_sql.func.lower(
+                        sqla_sql.func.coalesce(
+                            agui_schema.ThreadMetadata.name, ""
+                        )
+                    ),
+                    # Final tie-break: two same-named threads in a room
+                    # must still page deterministically.
+                    agui_schema.Thread.id_,
+                )
+                .limit(limit)
+                .offset(offset)
+            )
+
+            threads = list(await session.scalars(query))
+
+        return threads, total
+
     async def get_thread(
         self,
         *,

--- a/src/soliplex/loggers.py
+++ b/src/soliplex/loggers.py
@@ -8,6 +8,7 @@ import typing
 
 SOLIPLEX_LOGGER_NAME = "soliplex"
 
+AGUI_GET_THREADS = "get agui threads"
 AGUI_GET_ROOM = "get room agui"
 AGUI_GET_ROOM_THREAD = "get room agui thread"
 AGUI_GET_ROOM_THREAD_RUN = "get room agui thread run"

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -875,6 +875,20 @@ class AGUI_Threads(pydantic.BaseModel):
     threads: list[AGUI_Thread]
 
 
+class AGUI_ThreadPage(pydantic.BaseModel):
+    """One page of the user's threads, spanning every room they may see.
+
+    'total' counts every thread the user has across those rooms, not
+    just the ones on this page, so a client can tell whether to keep
+    paging without probing for a short page.
+    """
+
+    threads: list[AGUI_Thread]
+    total: int = KW_ONLY
+    limit: int = KW_ONLY
+    offset: int = KW_ONLY
+
+
 # ----------------------------------------------------------------------------
 #   Room Authorization models
 # ----------------------------------------------------------------------------

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -99,6 +99,87 @@ async def _check_user_room_agent(
     return user_profile, agent
 
 
+#   Cap the page size so a client cannot ask for the whole table in one
+#   request; the default matches what the lobby's threads tab renders.
+_THREADS_PAGE_DEFAULT = 50
+_THREADS_PAGE_MAX = 200
+
+
+@util.logfire_span("GET /v1/agui/threads")
+@router.get("/v1/agui/threads")
+async def get_agui_threads(
+    limit: int = fastapi.Query(
+        default=_THREADS_PAGE_DEFAULT,
+        ge=1,
+        le=_THREADS_PAGE_MAX,
+    ),
+    offset: int = fastapi.Query(default=0, ge=0),
+    the_installation: installation.Installation = depend_the_installation,
+    the_threads: agui.ThreadStorage = depend_the_threads,
+    the_room_authz: authz.RoomAuthorizationPolicy = depend_the_room_authz,
+    the_user_claims: authn.UserClaims = depend_the_user_claims,
+    the_logger: loggers.LogWrapper = depend_the_logger,
+) -> models.AGUI_ThreadPage:
+    """Return a page of the user's threads across every room they may see"""
+    the_logger.debug(loggers.AGUI_GET_THREADS)
+
+    user_name = the_user_claims.get("preferred_username", "<unknown>")
+
+    # There is no room in the path to authorize against, so the room set
+    # has to be resolved up front. Going through 'get_room_configs' means
+    # this endpoint inherits exactly the filtering that 'GET /v1/rooms'
+    # already applies -- rather than reimplementing authz here, where a
+    # mistake would leak other users' threads.
+    room_configs = await the_installation.get_room_configs(
+        user=the_user_claims,
+        the_room_authz=the_room_authz,
+        the_logger=the_logger,
+    )
+
+    threads, total = await the_threads.list_user_threads_page(
+        user_name=user_name,
+        room_ids=list(room_configs),
+        limit=limit,
+        offset=offset,
+    )
+
+    # Per-thread last activity comes from the same grouped-query trick the
+    # per-room listing uses, asked once per room appearing on this page
+    # (rooms are contiguous, so a page spans very few of them) rather than
+    # once per thread.
+    page_room_ids = {a_thread.room_id for a_thread in threads}
+    last_activity = {}
+    for a_room_id in page_room_ids:
+        last_activity.update(
+            await the_threads.get_threads_last_activity(
+                user_name=user_name,
+                room_id=a_room_id,
+            )
+        )
+
+    model_threads = []
+    for a_thread in threads:
+        thread_meta = await a_thread.awaitable_attrs.thread_metadata
+
+        model_threads.append(
+            models.AGUI_Thread.from_thread(
+                a_thread,
+                a_thread_meta=models.AGUI_ThreadMetadata.from_thread_meta(
+                    thread_meta,
+                ),
+                a_thread_runs=None,
+                a_thread_last_activity=last_activity.get(a_thread.thread_id),
+            )
+        )
+
+    return models.AGUI_ThreadPage(
+        threads=model_threads,
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
 @util.logfire_span("GET /v1/rooms/{room_id}/agui")
 @router.get("/v1/rooms/{room_id}/agui")
 async def get_room_agui(

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -1,4 +1,5 @@
 import datetime
+import itertools
 from types import SimpleNamespace
 from unittest import mock
 
@@ -1448,3 +1449,212 @@ async def test_drive_agui_turn_swallows_save_errors(
     ]
 
     assert collected == events
+
+
+async def _named_thread(ts, *, room_id, name, user_name=USER_NAME):
+    """Create a thread carrying 'name' as its metadata name."""
+    thread = await ts.new_thread(
+        user_name=user_name,
+        email=EMAIL,
+        room_id=room_id,
+        thread_metadata={"name": name},
+    )
+    return await thread.awaitable_attrs.thread_id
+
+
+async def _page_names(ts, *, room_ids, limit=50, offset=0):
+    """Return (room_id, name) pairs for one page, in page order."""
+    threads, total = await ts.list_user_threads_page(
+        user_name=USER_NAME,
+        room_ids=room_ids,
+        limit=limit,
+        offset=offset,
+    )
+    pairs = []
+    for a_thread in threads:
+        meta = await a_thread.awaitable_attrs.thread_metadata
+        pairs.append((a_thread.room_id, None if meta is None else meta.name))
+    return pairs, total
+
+
+@pytest.mark.asyncio
+async def test_list_user_threads_page_no_rooms_short_circuits(
+    the_async_session,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    # An empty room set means "the user may see nothing", which must not
+    # degrade into an unfiltered listing.
+    threads, total = await ts.list_user_threads_page(
+        user_name=USER_NAME,
+        room_ids=[],
+        limit=10,
+        offset=0,
+    )
+
+    assert threads == []
+    assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_list_user_threads_page_sorts_names_within_a_room(
+    the_async_session,
+    unit_of_work,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    async with unit_of_work():
+        await _named_thread(ts, room_id=ROOM_ID, name="charlie")
+        await _named_thread(ts, room_id=ROOM_ID, name="Alpha")
+        await _named_thread(ts, room_id=ROOM_ID, name="bravo")
+
+    pairs, total = await _page_names(ts, room_ids=[ROOM_ID])
+
+    # Case-insensitive: "Alpha" sorts before "bravo", not after it.
+    assert [name for _, name in pairs] == ["Alpha", "bravo", "charlie"]
+    assert total == 3
+
+
+@pytest.mark.asyncio
+async def test_list_user_threads_page_orders_rooms_by_activity(
+    the_async_session,
+    unit_of_work,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    async with unit_of_work():
+        stale = await _named_thread(ts, room_id=ROOM_ID, name="stale")
+        fresh = await _named_thread(ts, room_id=ROOM_ID_2, name="fresh")
+
+        for thread_id, room_id, when in (
+            (stale, ROOM_ID, T_OLD),
+            (fresh, ROOM_ID_2, T_NEW),
+        ):
+            run = await ts.new_run(
+                user_name=USER_NAME,
+                room_id=room_id,
+                thread_id=thread_id,
+            )
+            run.created = when
+            run.finished = when
+
+    pairs, _total = await _page_names(ts, room_ids=[ROOM_ID, ROOM_ID_2])
+
+    # The more recently active room leads, and each room's threads stay
+    # contiguous so a client can divide on room change.
+    assert [room_id for room_id, _ in pairs] == [ROOM_ID_2, ROOM_ID]
+
+
+@pytest.mark.asyncio
+async def test_list_user_threads_page_keeps_rooms_contiguous(
+    the_async_session,
+    unit_of_work,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    async with unit_of_work():
+        # Interleave names across rooms: were the sort name-major rather
+        # than room-major, these would alternate room in the page.
+        await _named_thread(ts, room_id=ROOM_ID, name="a")
+        await _named_thread(ts, room_id=ROOM_ID_2, name="b")
+        await _named_thread(ts, room_id=ROOM_ID, name="c")
+        await _named_thread(ts, room_id=ROOM_ID_2, name="d")
+
+    pairs, _total = await _page_names(ts, room_ids=[ROOM_ID, ROOM_ID_2])
+    room_order = [room_id for room_id, _ in pairs]
+
+    # Each room appears as exactly one contiguous block.
+    assert len(set(room_order)) == 2
+    assert room_order == sorted(room_order, key=room_order.index)
+    blocks = [key for key, _ in itertools.groupby(room_order)]
+    assert len(blocks) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_user_threads_page_includes_unnamed_threads(
+    the_async_session,
+    unit_of_work,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    async with unit_of_work():
+        # No metadata row at all -- the outer join must still yield it.
+        await ts.new_thread(
+            user_name=USER_NAME,
+            email=EMAIL,
+            room_id=ROOM_ID,
+        )
+        await _named_thread(ts, room_id=ROOM_ID, name="named")
+
+    pairs, total = await _page_names(ts, room_ids=[ROOM_ID])
+
+    assert total == 2
+    assert sorted(name or "" for _, name in pairs) == ["", "named"]
+
+
+@pytest.mark.asyncio
+async def test_list_user_threads_page_paginates_without_gaps(
+    the_async_session,
+    unit_of_work,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    async with unit_of_work():
+        for index in range(5):
+            await _named_thread(ts, room_id=ROOM_ID, name=f"thread-{index}")
+
+    first, total = await _page_names(ts, room_ids=[ROOM_ID], limit=2)
+    second, _ = await _page_names(ts, room_ids=[ROOM_ID], limit=2, offset=2)
+    third, _ = await _page_names(ts, room_ids=[ROOM_ID], limit=2, offset=4)
+
+    assert total == 5
+    assert len(first) == 2
+    assert len(second) == 2
+    assert len(third) == 1
+
+    # 'total' counts every match, not the page, and paging neither skips
+    # nor repeats a thread.
+    seen = [name for _, name in first + second + third]
+    assert seen == sorted(seen)
+    assert len(set(seen)) == 5
+
+
+@pytest.mark.asyncio
+async def test_list_user_threads_page_excludes_unlisted_rooms(
+    the_async_session,
+    unit_of_work,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    async with unit_of_work():
+        await _named_thread(ts, room_id=ROOM_ID, name="visible")
+        await _named_thread(ts, room_id=ROOM_ID_2, name="hidden")
+
+    pairs, total = await _page_names(ts, room_ids=[ROOM_ID])
+
+    # A room absent from 'room_ids' contributes nothing -- this is the
+    # cross-room authorization boundary.
+    assert [name for _, name in pairs] == ["visible"]
+    assert total == 1
+
+
+@pytest.mark.asyncio
+async def test_list_user_threads_page_scopes_to_the_user(
+    the_async_session,
+    unit_of_work,
+):
+    ts = agui_persistence.ThreadStorage(the_async_session)
+
+    async with unit_of_work():
+        await _named_thread(ts, room_id=ROOM_ID, name="mine")
+        await _named_thread(
+            ts,
+            room_id=ROOM_ID,
+            name="theirs",
+            user_name=OTHER_USER_NAME,
+        )
+
+    pairs, total = await _page_names(ts, room_ids=[ROOM_ID])
+
+    assert [name for _, name in pairs] == ["mine"]
+    assert total == 1

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -2264,3 +2264,180 @@ async def test_post_agui_resolve_recent_feedback(
     the_logger.debug.assert_called_once_with(
         loggers.AGUI_POST_RESOLVE_RECENT_FEEDBACK,
     )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("w_thread_meta", [False, True])
+async def test_get_agui_threads(the_threads, test_thread, w_thread_meta):
+    the_installation = mock.create_autospec(installation.Installation)
+    the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    the_installation.get_room_configs.return_value = {
+        TEST_ROOM_ID: mock.create_autospec(config_rooms.RoomConfig),
+    }
+
+    if w_thread_meta:
+        thread_meta = test_thread.thread_metadata = _make_thread_metadata()
+        test_thread.awaitable_attrs.thread_metadata = _awaitable(
+            "thread_metadata",
+            thread_meta,
+        )
+    else:
+        test_thread.awaitable_attrs.thread_metadata = _awaitable(
+            "thread_metadata",
+            None,
+        )
+
+    the_threads.list_user_threads_page.return_value = ([test_thread], 1)
+    the_threads.get_threads_last_activity.return_value = {
+        TEST_THREAD_ID_STR: NOW,
+    }
+
+    found = await agui_views.get_agui_threads(
+        limit=25,
+        offset=0,
+        the_installation=the_installation,
+        the_threads=the_threads,
+        the_room_authz=the_room_authz,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    (m_thread,) = found.threads
+
+    assert m_thread.room_id == TEST_ROOM_ID
+    assert m_thread.thread_id == TEST_THREAD_ID_UUID
+    assert m_thread.runs is None
+    assert m_thread.last_activity == NOW
+
+    if w_thread_meta:
+        assert m_thread.metadata.name == TEST_THREAD_NAME
+    else:
+        assert m_thread.metadata is None
+
+    # The page echoes its own bounds so a client can page without
+    # tracking what it asked for.
+    assert found.total == 1
+    assert found.limit == 25
+    assert found.offset == 0
+
+    the_threads.list_user_threads_page.assert_called_once_with(
+        user_name=USER_NAME,
+        room_ids=[TEST_ROOM_ID],
+        limit=25,
+        offset=0,
+    )
+
+    the_logger.debug.assert_called_once_with(loggers.AGUI_GET_THREADS)
+
+
+@pytest.mark.anyio
+async def test_get_agui_threads_restricts_to_authorized_rooms(the_threads):
+    the_installation = mock.create_autospec(installation.Installation)
+    the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    the_installation.get_room_configs.return_value = {
+        TEST_ROOM_ID: mock.create_autospec(config_rooms.RoomConfig),
+    }
+    the_threads.list_user_threads_page.return_value = ([], 0)
+
+    await agui_views.get_agui_threads(
+        limit=50,
+        offset=0,
+        the_installation=the_installation,
+        the_threads=the_threads,
+        the_room_authz=the_room_authz,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    # The room set must come from the authz-filtering helper, and only
+    # those rooms may reach the query -- this is the boundary that stops
+    # the endpoint returning threads from rooms the user cannot see.
+    the_installation.get_room_configs.assert_called_once_with(
+        user=THE_USER_CLAIMS,
+        the_room_authz=the_room_authz,
+        the_logger=the_logger,
+    )
+    _args, kwargs = the_threads.list_user_threads_page.call_args
+    assert kwargs["room_ids"] == [TEST_ROOM_ID]
+
+
+@pytest.mark.anyio
+async def test_get_agui_threads_with_no_visible_rooms(the_threads):
+    the_installation = mock.create_autospec(installation.Installation)
+    the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    the_installation.get_room_configs.return_value = {}
+    the_threads.list_user_threads_page.return_value = ([], 0)
+
+    found = await agui_views.get_agui_threads(
+        limit=50,
+        offset=0,
+        the_installation=the_installation,
+        the_threads=the_threads,
+        the_room_authz=the_room_authz,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found.threads == []
+    assert found.total == 0
+
+    # No rooms on the page means no activity lookups at all.
+    the_threads.get_threads_last_activity.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_get_agui_threads_groups_activity_lookups_by_room(
+    the_threads,
+):
+    the_installation = mock.create_autospec(installation.Installation)
+    the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    the_installation.get_room_configs.return_value = {
+        TEST_ROOM_ID: mock.create_autospec(config_rooms.RoomConfig),
+    }
+
+    def _thread(thread_id):
+        a_thread = mock.create_autospec(
+            agui.Thread,
+            room_id=TEST_ROOM_ID,
+            thread_id=thread_id,
+            thread_metadata=None,
+            created=NOW,
+            awaitable_attrs=mock.AsyncMock(),
+            instance=True,
+        )
+        a_thread.awaitable_attrs.thread_metadata = _awaitable(
+            "thread_metadata",
+            None,
+        )
+        return a_thread
+
+    threads = [_thread(TEST_THREAD_ID_STR), _thread(str(uuid.uuid4()))]
+    the_threads.list_user_threads_page.return_value = (threads, 2)
+    the_threads.get_threads_last_activity.return_value = {}
+
+    found = await agui_views.get_agui_threads(
+        limit=50,
+        offset=0,
+        the_installation=the_installation,
+        the_threads=the_threads,
+        the_room_authz=the_room_authz,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert len(found.threads) == 2
+
+    # Two threads sharing a room cost one activity query, not two: the
+    # lookup is per room on the page, not per thread.
+    the_threads.get_threads_last_activity.assert_called_once_with(
+        user_name=USER_NAME,
+        room_id=TEST_ROOM_ID,
+    )


### PR DESCRIPTION
# Summary

**Phase 1 of 3 — backend half. Pairs with soliplex/frontend#508; merge this first.**

Customers cannot find a thread without first remembering which room holds it.
The lobby lists rooms and nothing else, so reaching a thread means opening its
room and scanning the sidebar — threads in rooms nobody thought to check are, in
practice, lost.

This adds `GET /api/v1/agui/threads`, which pages a user's threads across every
room they can see. The frontend PR builds the lobby tab on top of it.

## Why an endpoint rather than client-side fan-out

The frontend could have called the existing per-room listing once per room and
merged. That downloads every thread on the server before rendering the first
one, so "lazy loading" would only ever be virtualised *rendering*, never lazy
*fetching*. It also puts phase 2's label filtering on the client, where it would
have to page through everything to filter anything.

The `thread` table already indexes `user_name` and `room_id`, so the query is
cheap. **No schema change, so no Alembic revision.**

## Changes

- `agui.ThreadStorage` gains abstract `list_user_threads_page`.
- `agui.persistence.ThreadStorage` implements it. Ordering is
  `room-last-activity DESC, room_id, lower(name) ASC`:
  - The `room_id` tie-break is load-bearing — it keeps each room's threads
    **contiguous**, which is what lets a client draw a section divider when the
    room changes instead of regrouping a half-loaded list.
  - Room activity comes from a grouped subquery rather than a direct join to
    runs; a direct join multiplies each thread by its run count and corrupts
    `LIMIT`/`OFFSET`.
  - Both joins are `LEFT OUTER`, so a room with no runs yet and a thread with no
    metadata row both still appear.
  - Rooms with no activity sort last via an is-null flag, since `NULLS LAST` is
    not portable to SQLite.
- `models.AGUI_ThreadPage` — threads plus `total`/`limit`/`offset`, so a client
  can tell whether to keep paging without probing for a short page.
- `views.agui.get_agui_threads` — the route, page size capped at 200.
- One new log constant.

## Authorization

The route has no room in its path, so the visible room set is resolved up front
through `Installation.get_room_configs` — the same helper `GET /v1/rooms`
already filters with, rather than a second implementation of the same rule. This
is the one place in the feature where a mistake leaks other users' threads, so
it has a dedicated test asserting only authorized rooms reach the query, and an
empty room set short-circuits rather than degrading into an unfiltered listing.

## Test Plan

- [x] `pytest tests/unit` — 3,729 passing, **100% branch coverage held**
- [x] `ruff check src tests` clean
- [x] 8 new persistence tests: room contiguity, case-insensitive name ordering,
      activity-based room ordering, unnamed threads included, pagination without
      gaps, room exclusion, user scoping, empty-room-set short circuit
- [x] 5 new view tests, including the authorization boundary and that activity
      lookups are per room on the page rather than per thread
- [x] Verified against a live server with 82 threads across 3 rooms: rooms come
      out contiguous, `Alpha, mango, Zebra` orders case-insensitively, and
      4+4+1 of 9 pages with no skips or repeats across page boundaries
- [ ] Manual testing completed

`tests/functional` has 3 pre-existing errors on a clean `main`
(`test_agent_tool_calling` ×2, `test_get_quiz_post_quiz_question`) — unrelated to
this change; verified by running them on `main`.

## The 3-phase stack

Both repos, phase by phase. Each phase is two PRs, backend first.

| Phase | Delivers | This PR |
| ----- | -------- | ------- |
| **1** | Lobby **Threads** tab aggregating threads across rooms, lazily paged | ✅ backend half |
| 2 | **Labels** — data model, CRUD API, query syntax, properties modal, management tab | designed |
| 3 | **Auto-labelling** on thread creation | awaiting team-leader approval |

Phase 2 extends this endpoint's storage method with `label_ids` and a name
filter rather than adding a parallel query — keep that in mind when reviewing
the signature.

A decision record covering all three phases, the alternatives rejected, and four
open questions is shared separately as a link.

## Related Issues

Fixes #
