### PR TITLE
fix: skip invalid 'STATE_DELTA' patches

### DIFF
--- a/src/soliplex/agui/__init__.py
+++ b/src/soliplex/agui/__init__.py
@@ -8,6 +8,7 @@ import typing
 
 import fastapi
 from ag_ui import core as agui_core
+from pydantic_ai import ui as ai_ui
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
 AGUI_Events = list[agui_core.Event]
@@ -21,6 +22,16 @@ _COMPACTIBLE_TYPES = {  # event_type: compacting_attr
     agui_core.EventType.REASONING_MESSAGE_CONTENT: "message_id",
     agui_core.EventType.TOOL_CALL_ARGS: "tool_call_id",
 }
+
+#
+#   Events which terminate a run's event stream
+#
+TERMINAL_EVENT_TYPES = frozenset(
+    [
+        agui_core.EventType.RUN_FINISHED,
+        agui_core.EventType.RUN_ERROR,
+    ]
+)
 
 
 class AGUI_Exception(ValueError):
@@ -580,6 +591,24 @@ async def compact_event_stream(stream: AGUI_EventStream):
                 compacting_id = getattr(event, compacting_attr, None)
             else:
                 yield event
+
+
+async def with_final_state(
+    *,
+    stream: AGUI_EventStream,
+    deps: ai_ui.StateHandler | None,
+) -> AGUI_EventStream:
+    """Yield events from 'stream', adding a final AG-UI state snapshot.
+
+    The snapshot precedes the run's terminal event: AG-UI clients may stop
+    reading after a terminal event, and on replay the parser only accepts a
+    snapshot while the run is still in the RUNNING state.
+    """
+    async for event in stream:
+        if deps is not None and event.type in TERMINAL_EVENT_TYPES:
+            yield agui_core.StateSnapshotEvent(snapshot=deps.state)
+
+        yield event
 
 
 async def get_the_threads(request: fastapi.Request) -> ThreadStorage:

--- a/src/soliplex/agui/parser.py
+++ b/src/soliplex/agui/parser.py
@@ -244,6 +244,15 @@ class EventStreamParser:
     result: typing.Any = None
 
     state: dict = dataclasses.field(default_factory=dict)
+
+    #   Currently-skipped deltas: non-empty means our 'state' is incomplete.
+    #   See 'STATE_DELTA' handling below (#1257).
+    invalid_state_deltas: Events = dataclasses.field(default_factory=list)
+
+    #   All skipped deltas, preserved even when a snapshot heals our 'state'.
+    #   See 'STATE_DELTA' handling below (#1257).
+    skipped_state_deltas: Events = dataclasses.field(default_factory=list)
+
     messages: Messages = dataclasses.field(default_factory=list)
 
     messages_by_id: MessagesByID = dataclasses.field(default_factory=dict)
@@ -484,14 +493,36 @@ class EventStreamParser:
             case agui_core.EventType.STATE_DELTA:
                 self._assert_running(event)
 
-                new_state = jsonpatch.apply_patch(self.state, event.delta)
+                try:
+                    new_state = jsonpatch.apply_patch(self.state, event.delta)
 
-                self.state = new_state
+                except (
+                    jsonpatch.JsonPatchException,
+                    jsonpatch.JsonPointerException,
+                ):
+                    # The delta was recorded against state we don't have,
+                    # and therefore cannot be applied.  Skip it, but record
+                    # it twice:
+                    #
+                    # - 'invalid_state_deltas' signals that our current 'state'
+                    #   is incomplete.
+                    #
+                    # - 'skipped_state_deltas' preserves the skip for later
+                    #   debugging, even when a subsequent 'STATE_SNAPSHOT"
+                    #   clears the invalid list.
+                    self.invalid_state_deltas.append(event)
+                    self.skipped_state_deltas.append(event)
+
+                else:
+                    self.state = new_state
 
             case agui_core.EventType.STATE_SNAPSHOT:
                 self._assert_running(event)
 
                 self.state = event.snapshot
+
+                # Clear the invalid list, because our 'state' is now correct.
+                self.invalid_state_deltas.clear()
 
             case agui_core.EventType.MESSAGES_SNAPSHOT:
                 self._assert_running(event)

--- a/src/soliplex/agui/persistence.py
+++ b/src/soliplex/agui/persistence.py
@@ -962,7 +962,11 @@ async def drive_agui_turn(
 
     ``run_stream_kwargs`` is forwarded verbatim to the Pydantic AI adapter.
     """
-    event_stream = adapter.run_stream(**(run_stream_kwargs or {}))
+    stream_kwargs = run_stream_kwargs or {}
+    event_stream = agui.with_final_state(
+        stream=adapter.run_stream(**stream_kwargs),
+        deps=stream_kwargs.get("deps"),
+    )
     compacted = agui.compact_event_stream(event_stream)
     async for event in compacted:
         try:

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -661,18 +661,11 @@ async def init_agent_stream(
     run_stream_kwargs: dict,
     **drive_kwargs,
 ):
-    deps = run_stream_kwargs.get("deps")
-
-    async def with_final_state():
-        async for event in agui_adapter.run_stream(**run_stream_kwargs):
-            if (
-                deps is not None
-                and event.type == agui_core.EventType.RUN_FINISHED
-            ):
-                yield agui_core.StateSnapshotEvent(snapshot=deps.state)
-            yield event
-
-    compacted = agui.compact_event_stream(with_final_state())
+    w_final_state = agui.with_final_state(
+        stream=agui_adapter.run_stream(**run_stream_kwargs),
+        deps=run_stream_kwargs.get("deps"),
+    )
+    compacted = agui.compact_event_stream(w_final_state)
     await drive_llm_stream(llm_stream=compacted, **drive_kwargs)
 
 

--- a/tests/unit/agui/test_agui_package.py
+++ b/tests/unit/agui/test_agui_package.py
@@ -88,6 +88,16 @@ TEXT_CONTENT_2_D = agui_core.TextMessageContentEvent(
 
 OTHER = agui_core.RawEvent(event=None, source="test-raw")
 
+THREAD_ID = "test-thread-id"
+RUN_ID = "test-run-id"
+
+RUN_STARTED = agui_core.RunStartedEvent(thread_id=THREAD_ID, run_id=RUN_ID)
+RUN_FINISHED = agui_core.RunFinishedEvent(thread_id=THREAD_ID, run_id=RUN_ID)
+RUN_ERROR = agui_core.RunErrorEvent(message="test error")
+
+FINAL_STATE = {"rag": {"citations": ["c1"]}}
+STATE_SNAPSHOT = agui_core.StateSnapshotEvent(snapshot=FINAL_STATE)
+
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
@@ -211,6 +221,54 @@ async def test_compact_event_stream(events, expected):
             yield event
 
     found = [event async for event in agui.compact_event_stream(stream())]
+
+    for f_event, e_event in zip(found, expected, strict=True):
+        assert f_event == e_event
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "events, w_deps, expected",
+    [
+        # A snapshot precedes either terminal event, ...
+        (
+            [RUN_STARTED, RUN_FINISHED],
+            True,
+            [RUN_STARTED, STATE_SNAPSHOT, RUN_FINISHED],
+        ),
+        (
+            [RUN_STARTED, RUN_ERROR],
+            True,
+            [RUN_STARTED, STATE_SNAPSHOT, RUN_ERROR],
+        ),
+        # ... but only for a run which carries AG-UI state, ...
+        (
+            [RUN_STARTED, RUN_FINISHED],
+            False,
+            [RUN_STARTED, RUN_FINISHED],
+        ),
+        # ... and only if the stream reaches a terminal event.
+        (
+            [RUN_STARTED, OTHER],
+            True,
+            [RUN_STARTED, OTHER],
+        ),
+    ],
+)
+async def test_with_final_state(events, w_deps, expected):
+    deps = mock.Mock(state=FINAL_STATE) if w_deps else None
+
+    async def stream():
+        for event in events:
+            yield event
+
+    found = [
+        event
+        async for event in agui.with_final_state(
+            stream=stream(),
+            deps=deps,
+        )
+    ]
 
     for f_event, e_event in zip(found, expected, strict=True):
         assert f_event == e_event

--- a/tests/unit/agui/test_agui_parser.py
+++ b/tests/unit/agui/test_agui_parser.py
@@ -213,6 +213,14 @@ W_TEST_E_STATE_DELTA = agui_core.StateDeltaEvent(
     ]
 )
 
+# Recorded against a state we don't have:  raises 'JsonPointerException',
+# which is not a 'JsonPatchException'.  See:  soliplex#1257.
+W_MISSING_PARENT_E_STATE_DELTA = agui_core.StateDeltaEvent(
+    delta=[
+        {"op": "replace", "path": "/missing/foo", "value": "bar"},
+    ]
+)
+
 STATE_SNAPSHOT = {"foo": "qux", "spam": "baz"}
 E_STATE_SNAPSHOT = agui_core.StateSnapshotEvent(
     snapshot=STATE_SNAPSHOT,
@@ -902,27 +910,43 @@ def test_esp_call_w_tool_call_result(
 #
 #   State management events
 #
-patch_failed = pytest.raises(jsonpatch.JsonPatchException)
 
 
 @pytest.mark.parametrize(
-    "status, state, event, expectation",
+    "status, state, event, expectation, exp_skipped",
     [
-        (INITIALIZED, {}, E_STATE_DELTA, not_running),
-        (RUNNING, {}, E_STATE_DELTA, no_error({"foo": "bar"})),
-        (RUNNING, {"foo": "foo"}, E_STATE_DELTA, no_error({"foo": "bar"})),
-        (RUNNING, {}, W_TEST_E_STATE_DELTA, patch_failed),
+        (INITIALIZED, {}, E_STATE_DELTA, not_running, False),
+        (RUNNING, {}, E_STATE_DELTA, no_error({"foo": "bar"}), False),
+        (
+            RUNNING,
+            {"foo": "foo"},
+            E_STATE_DELTA,
+            no_error({"foo": "bar"}),
+            False,
+        ),
+        # A delta which does not apply to the state we have is skipped and
+        # recorded, rather than killing the replay:  soliplex#1257.
+        (RUNNING, {}, W_TEST_E_STATE_DELTA, no_error({}), True),
+        (RUNNING, {}, W_MISSING_PARENT_E_STATE_DELTA, no_error({}), True),
         (
             RUNNING,
             {"foo": "foo"},
             W_TEST_E_STATE_DELTA,
             no_error({"foo": "bar"}),
+            False,
         ),
-        (FINISHED, {}, E_STATE_DELTA, not_running),
-        (ERROR, {}, E_STATE_DELTA, not_running),
+        (FINISHED, {}, E_STATE_DELTA, not_running, False),
+        (ERROR, {}, E_STATE_DELTA, not_running, False),
     ],
 )
-def test_esp_call_w_state_delta(event_kept, status, state, event, expectation):
+def test_esp_call_w_state_delta(
+    event_kept,
+    status,
+    state,
+    event,
+    expectation,
+    exp_skipped,
+):
     kw, check_log = event_kept
 
     esp = agui_parser.EventStreamParser(
@@ -936,6 +960,10 @@ def test_esp_call_w_state_delta(event_kept, status, state, event, expectation):
 
     if isinstance(expected, dict):
         assert esp.state == expected
+
+    exp_deltas = [event] if exp_skipped else []
+    assert esp.invalid_state_deltas == exp_deltas
+    assert esp.skipped_state_deltas == exp_deltas
 
     check_log(event)
 
@@ -968,6 +996,22 @@ def test_esp_call_w_state_snapshot(
         assert esp.state == expected
 
     check_log(event)
+
+
+def test_esp_call_w_state_snapshot_clears_invalid_deltas():
+    esp = agui_parser.EventStreamParser(
+        run_status=RUNNING,
+        state={},
+        invalid_state_deltas=[W_TEST_E_STATE_DELTA],
+        skipped_state_deltas=[W_TEST_E_STATE_DELTA],
+    )
+
+    esp(E_STATE_SNAPSHOT)
+
+    assert esp.state == STATE_SNAPSHOT
+    assert esp.invalid_state_deltas == []
+    # Kept for debugging, even though the snapshot superseded it.
+    assert esp.skipped_state_deltas == [W_TEST_E_STATE_DELTA]
 
 
 @pytest.mark.parametrize(
@@ -1007,6 +1051,11 @@ def test_esp_call_w_messages_snapshot(
         assert esp.messages == expected
 
     check_log(event)
+
+
+# Unlike a state delta, an activity delta which cannot be applied still
+# propagates.
+patch_failed = pytest.raises(jsonpatch.JsonPatchException)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/agui/test_agui_persistence.py
+++ b/tests/unit/agui/test_agui_persistence.py
@@ -1424,6 +1424,42 @@ async def test_drive_agui_turn_persists_and_yields(
 
 
 @pytest.mark.anyio
+async def test_drive_agui_turn_adds_final_state(
+    monkeypatch,
+    identity_compact,
+):
+    deps = mock.Mock(state=agui_constants.STATE_SNAPTSHOT)
+    expected = [
+        agui_constants.STATE_SNAPSHOT_EVENT,
+        agui_constants.BARE_RUN_FINISHED_EVENT,
+    ]
+    saved = []
+
+    async def fake_save(engine, **kwargs):
+        saved.append(kwargs["event"])
+
+    monkeypatch.setattr(agui_persistence, "save_single_event", fake_save)
+
+    collected = [
+        event
+        async for event in agui_persistence.drive_agui_turn(
+            adapter=_adapter([agui_constants.BARE_RUN_FINISHED_EVENT]),
+            engine=object(),
+            user_name="u",
+            room_id="r",
+            thread_id="t",
+            run_id="x",
+            run_stream_kwargs={"deps": deps},
+        )
+    ]
+
+    assert collected == expected
+    # The snapshot must be persisted too:  replaying a stored run relies
+    # on it to re-establish the authoritative state.
+    assert saved == expected
+
+
+@pytest.mark.anyio
 async def test_drive_agui_turn_swallows_save_errors(
     monkeypatch,
     identity_compact,

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1360,7 +1360,19 @@ async def test_stream_llm_events(num_events):
 
 # -- init_agent_stream -------------------------------------------------
 
+IAS_RUN_STARTED_EVENT = agui_core.RunStartedEvent(
+    thread_id=TEST_THREAD_ID_STR,
+    run_id=TEST_RUN_ID_STR,
+)
+IAS_RUN_FINISHED_EVENT = agui_core.RunFinishedEvent(
+    thread_id=TEST_THREAD_ID_STR,
+    run_id=TEST_RUN_ID_STR,
+)
 
+
+# 'agui.with_final_state' owns which events get a snapshot (see
+# 'test_agui_package.test_with_final_state'):  here we check only that
+# 'init_agent_stream' wires it up, ahead of compaction, with the run's deps.
 @pytest.mark.asyncio
 @mock.patch("soliplex.views.agui.drive_llm_stream")
 @mock.patch("soliplex.agui.compact_event_stream")
@@ -1380,14 +1392,8 @@ async def test_init_agent_stream_adds_final_state(ces, dls):
     }
 
     async def events():
-        yield agui_core.RunStartedEvent(
-            thread_id=TEST_THREAD_ID_STR,
-            run_id=TEST_RUN_ID_STR,
-        )
-        yield agui_core.RunFinishedEvent(
-            thread_id=TEST_THREAD_ID_STR,
-            run_id=TEST_RUN_ID_STR,
-        )
+        yield IAS_RUN_STARTED_EVENT
+        yield IAS_RUN_FINISHED_EVENT
 
     adapter.run_stream.return_value = events()
     ces.side_effect = lambda stream: stream
@@ -1400,6 +1406,7 @@ async def test_init_agent_stream_adds_final_state(ces, dls):
 
     stream = dls.await_args.kwargs["llm_stream"]
     found = [event async for event in stream]
+
     adapter.run_stream.assert_called_once_with(**run_stream_kwargs)
     assert [event.type for event in found] == [
         agui_core.EventType.RUN_STARTED,


### PR DESCRIPTION
  ... in 'agui_parser.EventStreamParser.__call__', flagging that
  the parser's 'state' is invalid until the next 'STATE_SNAPSHOT'.

feat: 'agui.with_final_state'

  ... builds a wrapper for the AG-UI event stream; the wrapper
  emits final 'STATE_SNAPSHOT' before terminal events
  ('FINISHED', 'ERROR'), allowing completed runs to be replayed
  through the parser with valid final AG-UI state.

  Used by both 'views.agui.init_agent_stream' and
  'agui.persistence.drive_agent_tuern' (FBO the CLI).

Closes #1257.