### PR TITLE
feat: 'RunFeedbackInfo.{parent_run_id,agui_state}'

### DIFF
--- a/src/soliplex/tools/agui_run_feedback.py
+++ b/src/soliplex/tools/agui_run_feedback.py
@@ -84,6 +84,14 @@ RUN_STATUS_NOTES = {
     agui_parser.RunStatus.FINISHED: "The run finished normally.",
 }
 
+#   Appended to the note when replaying the run left state deltas which
+#   could not be applied, and which no later snapshot superseded:  the
+#   recovered state is missing whatever those deltas carried.
+INCOMPLETE_STATE_NOTE = (
+    "The recovered 'agui_state' is incomplete:  {count} recorded state "
+    "update(s) could not be applied."
+)
+
 
 class RunFeedbackInfo(pydantic.BaseModel):
     """Information about the run which was the target of feedback
@@ -100,6 +108,13 @@ class RunFeedbackInfo(pydantic.BaseModel):
 
       'run_id' (string): UUID of the run against which the feedback was made.
 
+      'parent_run_id' (string or None):  UUID of the run this one continues,
+        or None for the first run of its thread.
+
+      'agui_state' (mapping or None):  the AG-UI state as of the end of the
+        run, recovered by replaying its recorded events.  It may be
+        incomplete;  'run_status_note' says so when it is.
+
       'user_prompt' (string or None):  the prompt which drove the run, or
         None if the run recorded none.  A run resumed to supply a tool
         result (e.g. a human-in-the-loop approval) has its prompt in an
@@ -112,9 +127,10 @@ class RunFeedbackInfo(pydantic.BaseModel):
       'run_status' (one of "INITIALIZED", "RUNNING", "FINISHED", "ERROR"):
         the run's status, recovered by replaying its recorded events.
 
-      'run_status_note' (string):  what that status means for this run.
-        Report it to the user when 'user_prompt' or 'agent_response' is
-        None:  it explains what became of the run.
+      'run_status_note' (string):  what that status means for this run, and
+        whether 'agui_state' came back incomplete.  Report it to the user
+        when 'user_prompt' or 'agent_response' is None, or when relaying
+        'agui_state':  it explains what became of the run.
     """
 
     user_name: str
@@ -122,6 +138,8 @@ class RunFeedbackInfo(pydantic.BaseModel):
     room_id: str
     thread_id: str
     run_id: str
+    parent_run_id: str | None = None
+    agui_state: dict[str, typing.Any] | None = None
     user_prompt: str | None = None
     agent_response: str | None = None
     run_status: str
@@ -383,6 +401,7 @@ async def get_feedback_run_info(
     thread = await run.awaitable_attrs.thread
     email = await thread.awaitable_attrs.email
     run_input = await run.awaitable_attrs.run_agent_input
+    parent_run_id = await run.awaitable_attrs.parent_run_id
     events = await run.awaitable_attrs.events
 
     esp = agui_parser.EventStreamParser(run_input)
@@ -409,6 +428,17 @@ async def get_feedback_run_info(
     # tool calls) may have recorded neither:  report what it did record,
     # explaining the gap via the run's status, rather than failing.
     run_status = esp.run_status
+    run_status_note = RUN_STATUS_NOTES[run_status]
+
+    if esp.invalid_state_deltas:
+        run_status_note = "  ".join(
+            [
+                run_status_note,
+                INCOMPLETE_STATE_NOTE.format(
+                    count=len(esp.invalid_state_deltas),
+                ),
+            ]
+        )
 
     return RunFeedbackInfo(
         user_name=to_query.user_name,
@@ -416,10 +446,12 @@ async def get_feedback_run_info(
         room_id=to_query.room_id,
         thread_id=to_query.thread_id,
         run_id=run_id,
+        parent_run_id=parent_run_id,
+        agui_state=esp.state,
         user_prompt=user_prompts[-1] if user_prompts else None,
         agent_response=agent_responses[-1] if agent_responses else None,
         run_status=run_status.name,
-        run_status_note=RUN_STATUS_NOTES[run_status],
+        run_status_note=run_status_note,
     )
 
 

--- a/tests/unit/tools/test_agui_run_feedback.py
+++ b/tests/unit/tools/test_agui_run_feedback.py
@@ -33,6 +33,8 @@ OTHER_EMAIL = "bharney@example.com"
 ROOM_ID = "test-room-id"
 THREAD_ID = "test-thread-id"
 RUN_ID = "test-run-id"
+PARENT_RUN_ID = "test-parent-run-id"
+AGUI_STATE = {"test-namespace": {"test-key": "test-value"}}
 THUMBS_UP = "thumbs_up"
 REASON = "test-feedback-reason"
 REVIEWED_NOTE = "test-feedback-reviewed-note"
@@ -151,6 +153,14 @@ def the_run(request, the_thread, the_run_feedback):
             awaitable_attrs=mock.AsyncMock(),
         )
         run.awaitable_attrs.run_id = _awaitable("run_id", RUN_ID)
+        run.awaitable_attrs.parent_run_id = _awaitable(
+            "parent_run_id",
+            PARENT_RUN_ID,
+        )
+        run.awaitable_attrs.run_input = _awaitable(
+            "run_input",
+            {},
+        )
         run.awaitable_attrs.thread = _awaitable("thread", the_thread)
         run.awaitable_attrs.run_feedback = _awaitable(
             "run_feedback", the_run_feedback
@@ -257,7 +267,10 @@ async def test__do_query(
 
     lrrf.assert_called_once_with(**rf_query.as_kwargs)
 
-    if not the_run:  # silence resource warnings for unused fixtures
+    if the_run:  # silence resource warnings for unused fixtures
+        await the_run.awaitable_attrs.parent_run_id
+        await the_run.awaitable_attrs.run_input
+    else:
         await the_thread.awaitable_attrs.user_name
         await the_thread.awaitable_attrs.email
         await the_thread.awaitable_attrs.room_id
@@ -443,20 +456,22 @@ MULTI_RUN_MESSAGES = EARLIER_MESSAGES + SINGLE_RUN_MESSAGES
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "messages, run_status, exp_prompt, exp_response",
+    "messages, run_status, exp_prompt, exp_response, n_invalid",
     [
         # run which never started:  nothing recorded at all
-        (EMPTY_RUN_MESSAGES, RS.INITIALIZED, None, None),
+        (EMPTY_RUN_MESSAGES, RS.INITIALIZED, None, None, 0),
         # run which never finished:  no response *yet*
-        (ONLY_PROMPT_MESSAGES, RS.RUNNING, USER_PROMPT, None),
+        (ONLY_PROMPT_MESSAGES, RS.RUNNING, USER_PROMPT, None, 0),
         # run which errored before responding
-        (ONLY_PROMPT_MESSAGES, RS.ERROR, USER_PROMPT, None),
+        (ONLY_PROMPT_MESSAGES, RS.ERROR, USER_PROMPT, None, 0),
         # run resumed to supply a tool result (e.g. an approval):  its
         # prompt belongs to an earlier run of the thread
-        (ONLY_RESPONSE_MESSAGES, RS.FINISHED, None, RESPONSE_MESSAGE),
+        (ONLY_RESPONSE_MESSAGES, RS.FINISHED, None, RESPONSE_MESSAGE, 0),
         # normal cases:  the *last* exchange of the run
-        (SINGLE_RUN_MESSAGES, RS.FINISHED, USER_PROMPT, RESPONSE_MESSAGE),
-        (MULTI_RUN_MESSAGES, RS.FINISHED, USER_PROMPT, RESPONSE_MESSAGE),
+        (SINGLE_RUN_MESSAGES, RS.FINISHED, USER_PROMPT, RESPONSE_MESSAGE, 0),
+        (MULTI_RUN_MESSAGES, RS.FINISHED, USER_PROMPT, RESPONSE_MESSAGE, 0),
+        # run whose replay could not apply some of its state deltas
+        (SINGLE_RUN_MESSAGES, RS.FINISHED, USER_PROMPT, RESPONSE_MESSAGE, 2),
     ],
 )
 @mock.patch("soliplex.agui.parser.EventStreamParser")
@@ -469,6 +484,7 @@ async def test_get_feedback_run_info(
     run_status,
     exp_prompt,
     exp_response,
+    n_invalid,
 ):
     get_run = ctx_w_deps.deps.the_threads.get_run
 
@@ -501,6 +517,10 @@ async def test_get_feedback_run_info(
 
     esp.return_value.messages = messages
     esp.return_value.run_status = run_status
+    esp.return_value.state = AGUI_STATE
+    esp.return_value.invalid_state_deltas = [
+        agui_constants.STATE_DELTA_EVENT
+    ] * n_invalid
 
     db_events = []
     for agui_event in agui_events:
@@ -513,6 +533,10 @@ async def test_get_feedback_run_info(
         awaitable_attrs=mock.AsyncMock(),
     )
     run.awaitable_attrs.thread = _awaitable("thread", the_thread)
+    run.awaitable_attrs.parent_run_id = _awaitable(
+        "parent_run_id",
+        PARENT_RUN_ID,
+    )
     run.awaitable_attrs.run_agent_input = _awaitable("run_agent_input", rai)
     run.awaitable_attrs.events = _awaitable("events", db_events)
     get_run.return_value = run
@@ -533,10 +557,18 @@ async def test_get_feedback_run_info(
     assert found.room_id == ROOM_ID
     assert found.thread_id == THREAD_ID
     assert found.run_id == RUN_ID
+    assert found.parent_run_id == PARENT_RUN_ID
+    assert found.agui_state == AGUI_STATE
     assert found.user_prompt == exp_prompt
     assert found.agent_response == exp_response
     assert found.run_status == run_status.name
-    assert found.run_status_note == arf_tools.RUN_STATUS_NOTES[run_status]
+    assert arf_tools.RUN_STATUS_NOTES[run_status] in found.run_status_note
+
+    if n_invalid:
+        assert "could not be applied" in found.run_status_note
+        assert str(n_invalid) in found.run_status_note
+    else:
+        assert "could not be applied" not in found.run_status_note
 
     for agui_event, esp_call in zip(
         agui_events,


### PR DESCRIPTION
Allows a reviewer to see e.g. citations, or request the former (parent)
run.

Reports incomplete state (e.g., from b0rken deltas without a final
snapshot) via the 'run_status_note' field added in PR #1266.

Closes #1254.