### PR TITLE
derive deferred loading from what a capability offers

### DIFF
--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -5,8 +5,6 @@ import typing
 
 import pydantic_ai
 from haiku.rag.capabilities import analysis as hr_caps_analysis
-from haiku.rag.capabilities import compaction as hr_caps_compaction
-from haiku.rag.capabilities import policy as hr_caps_policy
 from haiku.rag.capabilities import rag as hr_caps_rag
 from pydantic_ai import agent as ai_agent
 from pydantic_ai import capabilities as ai_capabilities
@@ -25,13 +23,6 @@ ToolConfigMap = dict[str, typing.Any]
 # Capabilities which take 'vision' from agent config's 'multimodal'
 HR_VisionCapabilities = (
     hr_caps_rag.RAGCapability | hr_caps_analysis.AnalysisCapability
-)
-
-# Capabilities which can always be eagerly loaded
-HookOnlyCapabilities = (
-    hr_caps_compaction.EvidenceCompactionCapability
-    | hr_caps_policy.CitationPolicyCapability
-    | cap_rag_audit.RAGAccessAuditCapability
 )
 
 
@@ -94,6 +85,27 @@ def make_mcp_client_toolset(
     return factory(**toolset_config.tool_kwargs)
 
 
+def _is_routing_capability(
+    capability: ai_capabilities.AbstractCapability,
+) -> bool:
+    """Whether the model has anything to load from this capability.
+
+    Tools or instructions are what there is to route between; a hook-only
+    capability offers neither.
+    """
+    if capability.get_instructions() or capability.get_native_tools():
+        return True
+
+    toolset = capability.get_toolset()
+
+    if toolset is None:
+        return False
+
+    # A capability registering no tools of its own still gets an empty
+    # 'FunctionToolset', so ask whether it is empty, not whether it exists.
+    return bool(getattr(toolset, "tools", True))
+
+
 def get_default_agent_from_configs(
     *,
     agent_config: config_agents.AgentConfig,
@@ -135,13 +147,10 @@ def get_default_agent_from_configs(
     #
     # Multiple stay deferred so the model routes between them via
     # 'load_capability'.
-    #
-    # Hook-only capabilities expose no tools to route
-    # between, so they neither defer nor count.
     routing_capabilities = [
         capability
         for capability in capabilities
-        if not isinstance(capability, HookOnlyCapabilities)
+        if _is_routing_capability(capability)
     ]
     defer_loading = len(routing_capabilities) > 1
     for capability in routing_capabilities:

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -8,6 +8,7 @@ from haiku.rag.capabilities import rag as hr_caps_rag
 from haiku.rag.config import models as hr_models
 from pydantic_ai import capabilities as ai_caps
 from pydantic_ai import tools as ai_tools
+from pydantic_ai import toolsets as ai_toolsets
 
 from soliplex import agents
 from soliplex import mcp_client
@@ -358,6 +359,24 @@ def test_get_default_agent_from_configs_leaves_evidence_capabilities_to_config(
     assert built == [rag_capability]
 
 
+def _instructions_only(cap_id: str) -> ai_caps.Capability:
+    """A capability offering instructions and no tools."""
+    return ai_caps.Capability(id=cap_id, instructions="Do the thing.")
+
+
+def _tools_only(cap_id: str) -> ai_caps.Capability:
+    """A capability offering tools and no instructions."""
+    return ai_caps.Capability(id=cap_id, tools=[test_tool])
+
+
+def _w_toolset(cap_id: str) -> ai_caps.Capability:
+    """A capability offering a toolset built elsewhere."""
+    return ai_caps.Capability(
+        id=cap_id,
+        toolsets=[ai_toolsets.FunctionToolset([test_tool])],
+    )
+
+
 @pytest.mark.parametrize("w_audit", [False, True])
 @pytest.mark.parametrize(
     "w_caps, exp_defers",
@@ -426,9 +445,27 @@ def test_get_default_agent_from_configs_leaves_evidence_capabilities_to_config(
             ],
             [True, True, False, False],
         ),
-        # TBD: Test cases for #1270
-        # ([OneNonHookCapability()], False),
-        # ([OneNonHookCapability(), AnotherNonHookCapability()], False),
+        # Capabilities named nowhere in this module, classified by what
+        # they offer the model rather than by their type (#1270).
+        ([_instructions_only("one")], False),
+        ([_instructions_only("one"), _instructions_only("two")], [True, True]),
+        ([_tools_only("one")], False),
+        ([_tools_only("one"), _tools_only("two")], [True, True]),
+        # A toolset built elsewhere.
+        ([_w_toolset("one"), _w_toolset("two")], [True, True]),
+        # Native tools are neither instructions nor a toolset.
+        ([ai_caps.WebSearch(id="one")], False),
+        (
+            [ai_caps.WebSearch(id="one"), ai_caps.WebSearch(id="two")],
+            [True, True],
+        ),
+        # Offering nothing to load: hook-only, whatever the type.
+        ([ai_caps.Capability(id="bare")], False),
+        ([ai_caps.Thinking(id="thinking")], False),
+        (
+            [_instructions_only("one"), ai_caps.Capability(id="bare")],
+            False,
+        ),
     ],
 )
 @mock.patch("soliplex.config.agents.get_model_from_config")


### PR DESCRIPTION
Replaces the hard-coded `HookOnlyCapabilities` union in `agents.py` with a check on what a capability
offers the model. 
Essentially it boils down to: If a capability offers tools in some way or instructions it's a routing capability otherwise the model never sees it. 

| capability | instructions | toolset | native tools | routing |
|---|---|---|---|---|
| `rag`, `analysis` | yes | `FunctionToolset`, 2 tools | no | yes |
| `WebSearch`, `WebFetch`, `ToolSearch` | no | `None` | yes | yes |
| `evidence_compaction`, `citation_policy`, `rag_audit` | no | `None` | no | no |
| `Thinking` | no | `None` | no | no |
| a `Capability` with instructions only | yes | empty `FunctionToolset` | no | yes |
| a `Capability` with tools only | no | `FunctionToolset`, 1 tool | no | yes |
| a `Capability` with an external toolset | no | `FunctionToolset`, 1 tool | no | yes |
| a bare `Capability` | no | empty `FunctionToolset` | no | no |

Closes #1270