### PR TITLE
Fix broken configs

### DIFF
--- a/example/haiku.rag.yaml
+++ b/example/haiku.rag.yaml
@@ -36,17 +36,30 @@ embeddings:
     name: qwen3-embedding:4b
     provider: ollama
     vector_dim: 2560
+    #
+    #  Point at a vLLM endpoint with the 'vllm' provider and its
+    #  OpenAI-compatible URL, in place of the two lines above:
+    #
+    #  provider: vllm
+    #  base_url: http://localhost:11438/v1
 
-# Omit the 'reranking' section to disable re-ranking.
+# Omit the 'reranking' section to disable re-ranking, or set 'model: null'.
 #reranking:
-# model:
-#   name: ''
-#   provider: ''
+#  model:
+#    name: BAAI/bge-reranker-v2-m3
+#    provider: vllm
+#    base_url: http://localhost:11439/v1
 
 qa:
   model:
     name: gpt-oss:latest
     provider: ollama
+    #
+    #  vLLM serves an OpenAI-compatible API, so a vLLM-hosted QA model uses
+    #  the 'openai' provider with its URL:
+    #
+    #  provider: openai
+    #  base_url: http://localhost:11432/v1
 
 processing:
   chunk_size: 256
@@ -73,8 +86,3 @@ providers:
   #
   #  ollama:
   #   base_url: http://localhost:11434
-
-  vllm:
-    embeddings_base_url: ""
-    rerank_base_url: ""
-    qa_base_url: ""


### PR DESCRIPTION
haiku.rag will be rejecting unknown configuration keys, so had a look to identify if any in soliplex.

This change should address this properly.