### PR TITLE
feat: clear global registries via metaconfig

### DIFF
--- a/docs/config/meta.md
+++ b/docs/config/meta.md
@@ -9,6 +9,56 @@ E.g., registering a new tool configuration class in the `meta.tool_configs`
 section allows use of that class when configuring a custom tool in a given
 room.
 
+Most subsections register into a global registry which Soliplex has
+already populated with its own defaults at import time. Registration is
+additive: a `meta` entry adds to those defaults, or replaces one of them
+when it reuses the same key. To discard the defaults instead, see
+[Clearing Default Registrations](#clearing-default-registrations) below.
+
+## Clearing Default Registrations
+
+Any subsection may include the string `"$$CLEAR$$"` as one of its
+entries. The registry that subsection feeds is emptied before the
+remaining entries in that same list are registered, so the installation
+ends up with *only* what it configured explicitly.
+
+This is useful for locking an installation down: a deployment which must
+resolve every secret through a corporate vault, for example, can discard
+the built-in secret sources rather than merely adding to them.
+
+```yaml
+meta:
+  secret_sources:
+  - "$$CLEAR$$"
+  - config_klass: "my_package.config.VaultSecretSource"
+    registered_func: "my_package.secrets.get_vault_secret"
+```
+
+The marker clears only the registry (or registries) belonging to the
+subsection that contains it, and each subsection is cleared
+independently. Its position within the list does not matter, and
+repeating it has no additional effect: the clear always happens first,
+before any entry in that list is registered.
+
+Two subsections clear more than one registry, because their registries
+cannot meaningfully be separated:
+
+- `tool_configs` also clears `mcp_server_tool_wrappers`, since a wrapper
+  cannot outlive the tool configuration it wraps.
+
+- `secret_sources` clears both the source configuration classes and their
+  corresponding getter functions, since a source kind is registered as a
+  pair.
+
+One subsection clears only part of its registry: `jsonpath_functions`
+removes the functions supplied by configuration but keeps the RFC 9535
+built-ins, which the shared JSONPath environment requires.
+
+Subsections are applied in the order in which they are listed in this
+document. That matters when one subsection validates against another:
+see [Registering MCP Server Tool Wrapper
+Types](#registering-mcp-server-tool-wrapper-types).
+
 ## Registering AG-UI Feature Classes
 
 See [AG-UI Features](agui.md) for the full registry lifecycle; this
@@ -42,13 +92,33 @@ meta:
     source: "server"
 ```
 
+By default, importing Soliplex's skill configurations registers the
+features used by the `haiku.rag` skills, just as though we configured
+explicitly:
+
+```yaml
+meta:
+  agui_features:
+  - name: "rag"
+    model_klass: "haiku.rag.capabilities.rag.RAGState"
+    source: "server"
+  - name: "analysis"
+    model_klass: "haiku.rag.capabilities.analysis.AnalysisState"
+    source: "server"
+  - name: "citation_policy"
+    model_klass: "haiku.rag.capabilities.policy.CitationPolicyState"
+    source: "server"
+```
+
 ## Registering Tool Configuration Classes
 
 The `meta.tool_configs` section enumerates tool configuration types so that
 they can be referenced by their `tool_name`.
 
 The section contains a list of Python "dotted names", i.e. strings which
-can be used to import the configuration class.
+can be used to import the configuration class. Each entry may instead be
+a mapping with a single `config_klass` key, whose value is that same
+dotted name.
 
 Example:
 
@@ -58,51 +128,45 @@ meta:
   - "my_package.config.MyToolConfig"
 ```
 
+By default, Soliplex registers its own tool config class, just as though
+we configured explicitly:
+
+```yaml
+meta:
+  tool_configs:
+  - "soliplex.config.tools.SearchDocumentsToolConfig"
+```
+
 ## Registering MCP Client Toolset Configuration Classes
 
 The `meta.mcp_toolset_configs` section enumerates MCP client toolset
 configuration types so that they can be referenced by their 'kind'.
 
 The section contains a list of Python "dotted names", i.e. strings which
-can be used to import the configuration class.
+can be used to import the configuration class. Each entry may instead be
+a mapping with a single `config_klass` key, whose value is that same
+dotted name.
 
-By default, Soliplex registers its own tool config classes, just as though
-we configured explicitly:
+By default, Soliplex registers its own toolset config classes, just as
+though we configured explicitly:
 
 ```yaml
 meta:
   mcp_toolset_configs:
-  - "soliplex.config.Stdio_MCP_ClientToolsetConfig"
-  - "soliplex.config.HTTP_MCP_ClientToolsetConfig"
-```
-
-## Registering Skill Configuration Classes
-
-The `meta.skill_configs` section enumerates skill
-configuration types so that they can be referenced by their 'kind'.
-
-The section contains a list of Python "dotted names", i.e. strings which
-can be used to import the configuration class.
-
-By default, Soliplex registers its own tool config classes, just as though
-we configured explicitly:
-
-```yaml
-meta:
-  skill_configs:
-  - "soliplex.config.HR_RAG_SkillConfig"
-  - "soliplex.config.HR_Analysis_SkillConfig"
+  - "soliplex.config.tools.Stdio_MCP_ClientToolsetConfig"
+  - "soliplex.config.tools.HTTP_MCP_ClientToolsetConfig"
+  - "soliplex.config.tools.SSE_MCP_ClientToolsetConfig"
 ```
 
 ## Registering MCP Server Tool Wrapper Types
 
-The `meta.mcp_server_tool_wrappers` section maps tool configuration classes to
-the equivalent wrapper class, used then offering the tool to external
+The `meta.mcp_server_tool_wrappers` section maps tool configuration classes
+to the equivalent wrapper class, used when offering the tool to external
 MCP clients.
 
 The section contains a list of mappings with keys `config_klass` and
-`wrapper_klass`.  Values for both keys Python "dotted names", i.e. strings
-which can be used to import the corresponding class.
+`wrapper_klass`.  Values for both keys are Python "dotted names", i.e.
+strings which can be used to import the corresponding class.
 
 Example:
 
@@ -113,21 +177,83 @@ meta:
     wrapper_klass: "my_package.config.MyMCPWrapper"
 ```
 
+Soliplex registers no wrappers by default: this registry is empty unless
+an installation populates it.
+
+The class named by `config_klass` must already be registered as a tool
+configuration, either by Soliplex itself or by the `meta.tool_configs`
+section of this same installation configuration; `tool_configs` is
+applied first for exactly that reason. Naming an unregistered class is an
+error, and loading the configuration fails rather than silently skipping
+the wrapper.
+
+## Registering Skill Configuration Classes
+
+The `meta.skill_configs` section enumerates skill
+configuration types so that they can be referenced by their 'kind'.
+
+The section contains a list of Python "dotted names", i.e. strings which
+can be used to import the configuration class. Each entry may instead be
+a mapping with a single `config_klass` key, whose value is that same
+dotted name.
+
+By default, Soliplex registers its own skill config classes, just as
+though we configured explicitly:
+
+```yaml
+meta:
+  skill_configs:
+  - "soliplex.config.skills.HR_RAG_SkillConfig"
+  - "soliplex.config.skills.HR_Analysis_SkillConfig"
+  - "soliplex.config.skills.HR_EvidenceCompaction_SkillConfig"
+  - "soliplex.config.skills.HR_CitationPolicy_SkillConfig"
+  - "soliplex.config.skills.BwrapSandboxSkillConfig"
+  - "soliplex.config.skills.EntrypointCapabilityConfig"
+```
+
+## Registering Agent Capability Types
+
+The `meta.agent_capability_types` section enumerates agent capability
+types so that they can be referenced by name in a room's agent
+configuration. The name a capability is registered under is its Python
+class name, not a separate `kind` string.
+
+The section contains a list of Python "dotted names", i.e. strings which
+can be used to import the capability class. Each entry may instead be a
+mapping with a single `config_klass` key, whose value is that same dotted
+name.
+
+Example:
+
+```yaml
+meta:
+  agent_capability_types:
+  - "my_package.capabilities.MyCapability"
+```
+
+By default, Soliplex registers the capability types published by
+`pydantic_ai.capabilities` — `NativeTool`, `Thinking`, `WebSearch` and
+the rest — so the set available without configuration follows the
+installed `pydantic-ai` version.
+
 ## Registering Agent Configuration Classes
 
 The `meta.agent_configs` section enumerates agent configuration types so that
 they can be referenced by their `kind`.
 
 The section contains a list of Python "dotted names", i.e. strings which
-can be used to import the configuration class.
+can be used to import the configuration class. Each entry may instead be
+a mapping with a single `config_klass` key, whose value is that same
+dotted name.
 
-By default, Soliplex registers its own agent config class, just as though
-we configured explicitly:
+By default, Soliplex registers its own agent config classes, just as
+though we configured explicitly:
 
 ```yaml
 meta:
   agent_configs:
-  - "soliplex.config.AgentConfig"
+  - "soliplex.config.agents.AgentConfig"
+  - "soliplex.config.agents.FactoryAgentConfig"
 ```
 
 ## Registering Secret Source Configurations
@@ -140,19 +266,35 @@ retrieve the secret value.
 The `meta.secret_sources` section allows configuring new secret source
 configurations and their corresponding functions.
 
+The section contains a list of mappings, each of which must include:
+
+- `config_klass`, a Python "dotted name" which can be used to import the
+  source configuration class. The kind it is registered under is taken
+  from that class, not spelled separately.
+
+- `registered_func`, a Python "dotted name" which can be used to import
+  the callable which resolves a secret from an instance of
+  `config_klass`. It is passed the source configuration instance and
+  returns the secret value, raising a `soliplex.secrets.SecretError`
+  subclass if it cannot.
+
+Unlike the sections above, a bare dotted name is not accepted here: both
+keys are required, because a source kind is only usable when its
+configuration class and its getter are both registered.
+
 By default, these classes are configured to use the corresponding
-functions in 'soliplex.secrets', just as if we configured here:
+functions in `soliplex.secrets`, just as if we configured here:
 
 ```yaml
 meta:
   secret_sources:
-  - config_klass: "soliplex.config.EnvVarSecretSource"
+  - config_klass: "soliplex.config.secrets.EnvVarSecretSource"
     registered_func: "soliplex.secrets.get_env_var_secret"
-  - config_klass: "soliplex.config.FilePathSecretSource"
+  - config_klass: "soliplex.config.secrets.FilePathSecretSource"
     registered_func: "soliplex.secrets.get_file_path_secret"
-  - config_klass: "soliplex.config.SubprocessSecretSource"
+  - config_klass: "soliplex.config.secrets.SubprocessSecretSource"
     registered_func: "soliplex.secrets.get_subprocess_secret"
-  - config_klass: "soliplex.config.RandomCharsSecretSource"
+  - config_klass: "soliplex.config.secrets.RandomCharsSecretSource"
     registered_func: "soliplex.secrets.get_random_chars_secret"
 ```
 

--- a/src/soliplex/config/meta.py
+++ b/src/soliplex/config/meta.py
@@ -36,6 +36,16 @@ class WrapperForUnknownToolConfig(ValueError):
         )
 
 
+@dataclasses.dataclass(kw_only=True, frozen=True)
+class ClearMetaRegistry:
+    """Marker used to signal that a config registry is to be cleared
+
+    If passed, it is only sensible as the first in a list of meta configs.
+    """
+
+    MARKER: typing.ClassVar[str] = "$$CLEAR$$"
+
+
 @dataclasses.dataclass(kw_only=True)
 class AGUI_FeatureConfigMeta:
     """Registered config class
@@ -366,18 +376,67 @@ class InstallationConfigMeta:
     'MCP_TOOLSET_CONFIG_CLASSES_BY_KIND'.
     """
 
-    agui_features: list[str | AGUI_FeatureConfigMeta] = ()
-    tool_configs: list[str | ToolConfigMeta] = ()
-    mcp_toolset_configs: list[str | MCP_ToolsetConfigMeta] = ()
-    mcp_server_tool_wrappers: list[MCP_ServerToolWrapperConfigMeta] = ()
-    skill_configs: list[str | SkillConfigMeta] = ()
-    agent_capability_types: list[str | AgentCapabilityMeta] = ()
-    agent_configs: list[str | AgentConfigMeta] = ()
-    secret_sources: list[str | SecretSourceMeta] = ()
-    jsonpath_functions: list[JSONPathFunctionConfigMeta] = ()
+    agui_features: list[str | AGUI_FeatureConfigMeta | ClearMetaRegistry] = ()
+    tool_configs: list[str | ToolConfigMeta | ClearMetaRegistry] = ()
+    mcp_toolset_configs: list[
+        str | MCP_ToolsetConfigMeta | ClearMetaRegistry
+    ] = ()
+    mcp_server_tool_wrappers: list[
+        MCP_ServerToolWrapperConfigMeta | ClearMetaRegistry
+    ] = ()
+    skill_configs: list[str | SkillConfigMeta | ClearMetaRegistry] = ()
+    agent_capability_types: list[
+        str | AgentCapabilityMeta | ClearMetaRegistry
+    ] = ()
+    agent_configs: list[str | AgentConfigMeta | ClearMetaRegistry] = ()
+    secret_sources: list[str | SecretSourceMeta | ClearMetaRegistry] = ()
+    jsonpath_functions: list[
+        JSONPathFunctionConfigMeta | ClearMetaRegistry
+    ] = ()
 
     # Set by `from_yaml` factory
     _config_path: pathlib.Path = None
+
+    @staticmethod
+    def _partition_cmrs(
+        entries: list[str | dict],
+        *,
+        config_klass: typing.Any,
+    ):
+        """Partition a list of YAML config entries into two groups
+
+        - Those having 'ClearMetaRegistry.MARKER' as their string value;
+        - Those which don't.
+
+        If the first group is non-empty, prepend the returned list with
+        a 'ClearMetaRegistry' instance, signalling the processor that it
+        should clear the registry (or registries) it populates before adding
+        config based on the remaining entries.
+        """
+        has_clear = any(entry == ClearMetaRegistry.MARKER for entry in entries)
+        clear_pfx = [ClearMetaRegistry()] if has_clear else []
+
+        return clear_pfx + [
+            config_klass.from_yaml(entry)
+            for entry in entries
+            if entry != ClearMetaRegistry.MARKER
+        ]
+
+    @staticmethod
+    def _strip_clear(entries: tuple | list) -> tuple[list, bool]:
+        """Convert entries to a list.
+
+        If any CMR are present, strip them, returning 'stripped, True'
+
+        Otherwise, return  'converted_list, False'
+        """
+        stripped = [
+            entry
+            for entry in entries
+            if not isinstance(entry, ClearMetaRegistry)
+        ]
+        clear = len(stripped) < len(entries)
+        return stripped, clear
 
     @classmethod
     def from_yaml(cls, config_path: pathlib.Path, config_dict: dict | None):
@@ -387,53 +446,50 @@ class InstallationConfigMeta:
         config_dict["_config_path"] = config_path
 
         try:
-            config_dict["agui_features"] = [
-                AGUI_FeatureConfigMeta.from_yaml(af_yaml)
-                for af_yaml in config_dict.get("agui_features", ())
-            ]
+            config_dict["agui_features"] = cls._partition_cmrs(
+                config_dict.get("agui_features", ()),
+                config_klass=AGUI_FeatureConfigMeta,
+            )
 
-            config_dict["tool_configs"] = [
-                ToolConfigMeta.from_yaml(tc_yaml)
-                for tc_yaml in config_dict.get("tool_configs", ())
-            ]
+            config_dict["tool_configs"] = cls._partition_cmrs(
+                config_dict.get("tool_configs", ()),
+                config_klass=ToolConfigMeta,
+            )
 
-            config_dict["mcp_toolset_configs"] = [
-                MCP_ToolsetConfigMeta.from_yaml(mcp_tc_yaml)
-                for mcp_tc_yaml in config_dict.get("mcp_toolset_configs", ())
-            ]
+            config_dict["mcp_toolset_configs"] = cls._partition_cmrs(
+                config_dict.get("mcp_toolset_configs", ()),
+                config_klass=MCP_ToolsetConfigMeta,
+            )
 
-            config_dict["mcp_server_tool_wrappers"] = [
-                MCP_ServerToolWrapperConfigMeta.from_yaml(mcp_tc_yaml)
-                for mcp_tc_yaml in config_dict.get(
-                    "mcp_server_tool_wrappers",
-                    (),
-                )
-            ]
+            config_dict["mcp_server_tool_wrappers"] = cls._partition_cmrs(
+                config_dict.get("mcp_server_tool_wrappers", ()),
+                config_klass=MCP_ServerToolWrapperConfigMeta,
+            )
 
-            config_dict["skill_configs"] = [
-                SkillConfigMeta.from_yaml(sc_yaml)
-                for sc_yaml in config_dict.get("skill_configs", ())
-            ]
+            config_dict["skill_configs"] = cls._partition_cmrs(
+                config_dict.get("skill_configs", ()),
+                config_klass=SkillConfigMeta,
+            )
 
-            config_dict["agent_capability_types"] = [
-                AgentCapabilityMeta.from_yaml(ac_yaml)
-                for ac_yaml in config_dict.get("agent_capability_types", ())
-            ]
+            config_dict["agent_capability_types"] = cls._partition_cmrs(
+                config_dict.get("agent_capability_types", ()),
+                config_klass=AgentCapabilityMeta,
+            )
 
-            config_dict["agent_configs"] = [
-                AgentConfigMeta.from_yaml(ac_yaml)
-                for ac_yaml in config_dict.get("agent_configs", ())
-            ]
+            config_dict["agent_configs"] = cls._partition_cmrs(
+                config_dict.get("agent_configs", ()),
+                config_klass=AgentConfigMeta,
+            )
 
-            config_dict["secret_sources"] = [
-                SecretSourceMeta.from_yaml(ss_yaml)
-                for ss_yaml in config_dict.get("secret_sources", ())
-            ]
+            config_dict["secret_sources"] = cls._partition_cmrs(
+                config_dict.get("secret_sources", ()),
+                config_klass=SecretSourceMeta,
+            )
 
-            config_dict["jsonpath_functions"] = [
-                JSONPathFunctionConfigMeta.from_yaml(jf_yaml)
-                for jf_yaml in config_dict.get("jsonpath_functions", ())
-            ]
+            config_dict["jsonpath_functions"] = cls._partition_cmrs(
+                config_dict.get("jsonpath_functions", ()),
+                config_klass=JSONPathFunctionConfigMeta,
+            )
 
             return cls(**config_dict)
 
@@ -448,27 +504,55 @@ class InstallationConfigMeta:
             ) from exc
 
     def __post_init__(self):
-        self.agui_features = list(self.agui_features)
-        feature_registry = config_agui.AGUI_FEATURES_BY_NAME
+        af_registry = config_agui.AGUI_FEATURES_BY_NAME
+        tc_registry = config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME
+        mtc_registry = config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND
+        mstw_registry = config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME
+        sc_registry = config_skills.SKILL_CONFIG_CLASSES_BY_KIND
+        act_registry = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME
+        ac_registry = config_agents.AGENT_CONFIG_CLASSES_BY_KIND
+        sg_registry = config_secrets.SECRET_GETTERS_BY_KIND
+        ss_registry = config_secrets.SourceClassesByKind
+        jf_registry = authz.the_jsonpath_environment.function_extensions
+
+        self.agui_features, af_clear = self._strip_clear(self.agui_features)
+
+        if af_clear:
+            af_registry.clear()
+
         for af_meta in self.agui_features:
-            feature_registry[af_meta.name] = config_agui.AGUI_Feature(
+            af_registry[af_meta.name] = config_agui.AGUI_Feature(
                 name=af_meta.name,
                 model_klass=af_meta.model_klass,
                 source=af_meta.source,
             )
 
-        self.tool_configs = list(self.tool_configs)
-        tc_registry = config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME
+        self.tool_configs, tc_clear = self._strip_clear(self.tool_configs)
+
+        if tc_clear:
+            tc_registry.clear()
+            mstw_registry.clear()  # no wrappers without tools
+
         for tc_meta in self.tool_configs:
             tc_registry[tc_meta.tool_name] = tc_meta.config_klass
 
-        self.mcp_toolset_configs = list(self.mcp_toolset_configs)
-        mtc_registry = config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND
+        self.mcp_toolset_configs, mtc_clear = self._strip_clear(
+            self.mcp_toolset_configs,
+        )
+
+        if mtc_clear:
+            mtc_registry.clear()
+
         for mtc_meta in self.mcp_toolset_configs:
             mtc_registry[mtc_meta.kind] = mtc_meta.config_klass
 
-        self.mcp_server_tool_wrappers = list(self.mcp_server_tool_wrappers)
-        mstw_registry = config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME
+        self.mcp_server_tool_wrappers, mstw_clear = self._strip_clear(
+            self.mcp_server_tool_wrappers,
+        )
+
+        if mstw_clear:
+            mstw_registry.clear()
+
         for mstw_meta in self.mcp_server_tool_wrappers:
             if mstw_meta.tool_name not in tc_registry:
                 raise WrapperForUnknownToolConfig(
@@ -477,36 +561,60 @@ class InstallationConfigMeta:
                 )
             mstw_registry[mstw_meta.tool_name] = mstw_meta.wrapper_klass
 
-        self.skill_configs = list(self.skill_configs)
-        sc_registry = config_skills.SKILL_CONFIG_CLASSES_BY_KIND
+        self.skill_configs, sc_clear = self._strip_clear(self.skill_configs)
+
+        if sc_clear:
+            sc_registry.clear()
+
         for sc_meta in self.skill_configs:
             sc_registry[sc_meta.kind] = sc_meta.config_klass
 
-        self.agent_capability_types = list(self.agent_capability_types)
-        act_registry = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME
+        self.agent_capability_types, act_clear = self._strip_clear(
+            self.agent_capability_types,
+        )
+        if act_clear:
+            act_registry.clear()
+
         for act_meta in self.agent_capability_types:
             act_registry[act_meta.capability_name] = act_meta.config_klass
 
-        self.agent_configs = list(self.agent_configs)
-        ac_registry = config_agents.AGENT_CONFIG_CLASSES_BY_KIND
+        self.agent_configs, ac_clear = self._strip_clear(self.agent_configs)
+
+        if ac_clear:
+            ac_registry.clear()
+
         for ac_meta in self.agent_configs:
             ac_registry[ac_meta.kind] = ac_meta.config_klass
 
-        self.secret_sources = list(self.secret_sources)
-        sg_registry = config_secrets.SECRET_GETTERS_BY_KIND
-        ss_registry = config_secrets.SourceClassesByKind
+        self.secret_sources, ss_clear = self._strip_clear(self.secret_sources)
+
+        if ss_clear:
+            ss_registry.clear()
+            sg_registry.clear()
+
         for ss_meta in self.secret_sources:
             sg_registry[ss_meta.kind] = ss_meta.registered_func
             ss_registry[ss_meta.kind] = ss_meta.config_klass
 
-        self.jsonpath_functions = list(self.jsonpath_functions)
+        self.jsonpath_functions, jf_clear = self._strip_clear(
+            self.jsonpath_functions,
+        )
+
+        if jf_clear:
+            jf_registered = (
+                set(jf_registry) - authz.BUILTIN_JSONPATH_FUNCTION_NAMES
+            )
+            for jf_key in jf_registered:
+                del jf_registry[jf_key]
+
         for jf_meta in self.jsonpath_functions:
             authz.register_jsonpath_function(jf_meta.name, jf_meta.func)
 
     @property
     def as_yaml(self) -> dict:
+        first_clear = [ClearMetaRegistry.MARKER]
         agui_feature_registry = config_agui.AGUI_FEATURES_BY_NAME
-        agui_feature_entries = [
+        agui_feature_entries = first_clear + [
             {
                 "name": feature.name,
                 "model_klass": _utils._dotted_name(feature.model_klass),
@@ -516,17 +624,17 @@ class InstallationConfigMeta:
         ]
 
         tc_registry = config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME
-        tool_config_entries = [
+        tool_config_entries = first_clear + [
             _utils._dotted_name(klass) for klass in tc_registry.values()
         ]
 
         mcptc_registry = config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND
-        mcp_toolset_config_entries = [
+        mcp_toolset_config_entries = first_clear + [
             _utils._dotted_name(klass) for klass in mcptc_registry.values()
         ]
 
         mcptw_registry = config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME
-        mcp_server_tool_wrapper_entries = [
+        mcp_server_tool_wrapper_entries = first_clear + [
             {
                 "config_klass": _utils._dotted_name(
                     tc_registry[tool_name],
@@ -537,34 +645,50 @@ class InstallationConfigMeta:
         ]
 
         sc_registry = config_skills.SKILL_CONFIG_CLASSES_BY_KIND
-        skill_config_entries = [
+        skill_config_entries = first_clear + [
             _utils._dotted_name(klass) for klass in sc_registry.values()
         ]
 
         cap_registry = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME.values()
-        capability_type_entries = [
+        capability_type_entries = first_clear + [
             _utils._dotted_name(klass) for klass in cap_registry
         ]
 
         ac_registry = config_agents.AGENT_CONFIG_CLASSES_BY_KIND
-        agent_config_entries = [
+        agent_config_entries = first_clear + [
             _utils._dotted_name(klass) for klass in ac_registry.values()
         ]
 
         ss_registry = config_secrets.SourceClassesByKind
         sg_registry = config_secrets.SECRET_GETTERS_BY_KIND
+
+        # A source kind is usable only if it is in both registries:
+        # 'SecretConfig.from_yaml' parses it via 'SourceClassesByKind',
+        # 'soliplex.secrets' resolves it via 'SECRET_GETTERS_BY_KIND'.
+        # Skipping kinds with no getter avoids a 'KeyError' here when the
+        # two disagree.
         secret_source_entries = [
             {
                 "config_klass": _utils._dotted_name(
                     ss_registry[kind],
                 ),
-                "registered_func": _utils._dotted_name(r_func),
+                "registered_func": _utils._dotted_name(sg_registry[kind]),
             }
-            for kind, r_func in sg_registry.items()
+            for kind in ss_registry
+            if kind in sg_registry
         ]
 
+        # Emit the clear marker only for registries that really lost one
+        # of their import-time kinds, because '__post_init__' empties both
+        # before re-registering: a clear asked for here deletes anything
+        # the entries above skipped. Hence the union -- a kind sitting in
+        # only one registry must not provoke that.
+        registered_kinds = ss_registry.keys() | sg_registry.keys()
+        if not config_secrets.DEFAULT_SECRET_SOURCE_KINDS <= registered_kinds:
+            secret_source_entries = first_clear + secret_source_entries
+
         jsonpath_function_registry = authz.registered_jsonpath_functions()
-        jsonpath_function_entries = [
+        jsonpath_function_entries = first_clear + [
             {"name": name, "func": _utils._dotted_name(func)}
             for name, func in jsonpath_function_registry.items()
         ]

--- a/src/soliplex/config/secrets.py
+++ b/src/soliplex/config/secrets.py
@@ -198,6 +198,15 @@ SourceClassesByKind = {
 }
 
 
+# The source kinds Soliplex registers itself, captured before any
+# metaconfig registration can add to either registry. 'soliplex.secrets'
+# registers a getter for exactly these kinds, so this is the default key
+# set for both 'SourceClassesByKind' and 'SECRET_GETTERS_BY_KIND'.
+# 'InstallationConfigMeta.as_yaml' compares against it to distinguish a
+# registry a config cleared from one that was never touched.
+DEFAULT_SECRET_SOURCE_KINDS = frozenset(SourceClassesByKind)
+
+
 @dataclasses.dataclass(kw_only=True)
 class SecretConfig:
     secret_name: str

--- a/tests/unit/config/test_config_meta.py
+++ b/tests/unit/config/test_config_meta.py
@@ -1,5 +1,6 @@
 import contextlib
 import copy
+import dataclasses
 
 import _test_features as agui_features
 import _test_metaconfig
@@ -53,6 +54,25 @@ meta:
         source: "server"
 """
 
+W_AGUI_FEATURES_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "agui_features": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.AGUI_FeatureConfigMeta(
+            name=AGUI_FEATURE_NAME_FOR_META,
+            model_klass=agui_features.EmptyFeatureModel,
+            source="server",
+        ),
+    ],
+}
+W_AGUI_FEATURES_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  agui_features:
+      - "{config_meta.ClearMetaRegistry.MARKER}"
+      - name: "{AGUI_FEATURE_NAME_FOR_META}"
+        model_klass: "_test_features.EmptyFeatureModel"
+        source: "server"
+"""
+
 
 W_TOOL_CONFIGS_ICMETA_KW = BARE_ICMETA_KW | {
     "tool_configs": [
@@ -76,6 +96,64 @@ meta:
       wrapper_klass: "_test_metaconfig.DummyMCPWrapper"
 """
 
+W_TOOL_CONFIGS_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "tool_configs": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.ToolConfigMeta(
+            config_klass=_test_metaconfig.DummyToolConfig,
+        ),
+    ],
+}
+W_TOOL_CONFIGS_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  tool_configs:
+    - "{config_meta.ClearMetaRegistry.MARKER}"
+    - "_test_metaconfig.DummyToolConfig"
+"""
+
+W_TOOL_WRAPPERS_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "mcp_server_tool_wrappers": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.MCP_ServerToolWrapperConfigMeta(
+            config_klass=_test_metaconfig.DummyToolConfig,
+            wrapper_klass=_test_metaconfig.DummyMCPWrapper,
+        ),
+    ],
+}
+W_TOOL_WRAPPERS_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  mcp_server_tool_wrappers:
+    - "{config_meta.ClearMetaRegistry.MARKER}"
+    - config_klass: "_test_metaconfig.DummyToolConfig"
+      wrapper_klass: "_test_metaconfig.DummyMCPWrapper"
+"""
+
+W_TOOL_CONFIGS_W_WRAPPERS_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "tool_configs": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.ToolConfigMeta(
+            config_klass=_test_metaconfig.DummyToolConfig,
+        ),
+    ],
+    "mcp_server_tool_wrappers": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.MCP_ServerToolWrapperConfigMeta(
+            config_klass=_test_metaconfig.DummyToolConfig,
+            wrapper_klass=_test_metaconfig.DummyMCPWrapper,
+        ),
+    ],
+}
+W_TOOL_CONFIGS_W_WRAPPERS_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  tool_configs:
+    - "{config_meta.ClearMetaRegistry.MARKER}"
+    - "_test_metaconfig.DummyToolConfig"
+  mcp_server_tool_wrappers:
+    - "{config_meta.ClearMetaRegistry.MARKER}"
+    - config_klass: "_test_metaconfig.DummyToolConfig"
+      wrapper_klass: "_test_metaconfig.DummyMCPWrapper"
+"""
+
 
 W_MCP_TOOLSET_CONFIGS_ICMETA_KW = BARE_ICMETA_KW | {
     "mcp_toolset_configs": [
@@ -87,6 +165,22 @@ W_MCP_TOOLSET_CONFIGS_ICMETA_KW = BARE_ICMETA_KW | {
 W_MCP_TOOLSET_CONFIGS_ICMETA_YAML = """\
 meta:
   mcp_toolset_configs:
+    - "_test_metaconfig.DummyMCP_ToolsetConfig"
+"""
+
+
+W_MCP_TOOLSET_CONFIGS_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "mcp_toolset_configs": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.MCP_ToolsetConfigMeta(
+            config_klass=_test_metaconfig.DummyMCP_ToolsetConfig,
+        ),
+    ],
+}
+W_MCP_TOOLSET_CONFIGS_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  mcp_toolset_configs:
+    - "{config_meta.ClearMetaRegistry.MARKER}"
     - "_test_metaconfig.DummyMCP_ToolsetConfig"
 """
 
@@ -104,6 +198,21 @@ meta:
     - "_test_metaconfig.DummySkillConfig"
 """
 
+W_SKILL_CONFIGS_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "skill_configs": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.SkillConfigMeta(
+            config_klass=_test_metaconfig.DummySkillConfig,
+        ),
+    ],
+}
+W_SKILL_CONFIGS_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  skill_configs:
+    - "{config_meta.ClearMetaRegistry.MARKER}"
+    - "_test_metaconfig.DummySkillConfig"
+"""
+
 
 W_AGENT_CAPABILITY_ICMETA_KW = BARE_ICMETA_KW | {
     "agent_capability_types": [
@@ -118,6 +227,21 @@ meta:
       - "_test_metaconfig.DummyAgentCapability"
 """
 
+W_AGENT_CAPABILITY_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "agent_capability_types": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.AgentCapabilityMeta(
+            config_klass=_test_metaconfig.DummyAgentCapability
+        ),
+    ],
+}
+W_AGENT_CAPABILITY_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  agent_capability_types:
+      - "{config_meta.ClearMetaRegistry.MARKER}"
+      - "_test_metaconfig.DummyAgentCapability"
+"""
+
 
 W_AGENT_CONFIGS_ICMETA_KW = BARE_ICMETA_KW | {
     "agent_configs": [
@@ -129,6 +253,21 @@ W_AGENT_CONFIGS_ICMETA_KW = BARE_ICMETA_KW | {
 W_AGENT_CONFIGS_ICMETA_YAML = """\
 meta:
   agent_configs:
+      - "_test_metaconfig.DummyAgentConfig"
+"""
+
+W_AGENT_CONFIGS_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "agent_configs": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.AgentConfigMeta(
+            config_klass=_test_metaconfig.DummyAgentConfig,
+        ),
+    ],
+}
+W_AGENT_CONFIGS_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  agent_configs:
+      - "{config_meta.ClearMetaRegistry.MARKER}"
       - "_test_metaconfig.DummyAgentConfig"
 """
 
@@ -152,6 +291,23 @@ meta:
       "registered_func": "soliplex.config.test_secret_func"
 """
 
+W_SECRET_SOURCE_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "secret_sources": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.SecretSourceMeta(
+            config_klass=_test_metaconfig.DummySecretSource,
+            registered_func=secret_source_func,
+        ),
+    ],
+}
+W_SECRET_SOURCE_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  secret_sources:
+    - "{config_meta.ClearMetaRegistry.MARKER}"
+    - "config_klass": "_test_metaconfig.DummySecretSource"
+      "registered_func": "soliplex.config.test_secret_func"
+"""
+
 
 JSONPATH_FUNCTION_NAME = "faux_filter"
 W_JSONPATH_FUNCTIONS_ICMETA_KW = BARE_ICMETA_KW | {
@@ -165,6 +321,23 @@ W_JSONPATH_FUNCTIONS_ICMETA_KW = BARE_ICMETA_KW | {
 W_JSONPATH_FUNCTIONS_ICMETA_YAML = f"""\
 meta:
   jsonpath_functions:
+      - name: "{JSONPATH_FUNCTION_NAME}"
+        func: "_test_metaconfig.dummy_jsonpath_func"
+"""
+
+W_JSONPATH_FUNCTIONS_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
+    "jsonpath_functions": [
+        config_meta.ClearMetaRegistry(),
+        config_meta.JSONPathFunctionConfigMeta(
+            name=JSONPATH_FUNCTION_NAME,
+            func=_test_metaconfig.dummy_jsonpath_func,
+        ),
+    ],
+}
+W_JSONPATH_FUNCTIONS_W_CLEAR_ICMETA_YAML = f"""\
+meta:
+  jsonpath_functions:
+      - "{config_meta.ClearMetaRegistry.MARKER}"
       - name: "{JSONPATH_FUNCTION_NAME}"
         func: "_test_metaconfig.dummy_jsonpath_func"
 """
@@ -397,6 +570,128 @@ def test_jsonpathfunctionconfigmeta_from_yaml():
     assert meta.func is _test_metaconfig.dummy_jsonpath_func
 
 
+@dataclasses.dataclass(frozen=True)
+class _TestConfig:
+    @classmethod
+    def from_yaml(cls, entry):
+        return cls()
+
+
+@pytest.mark.parametrize(
+    "w_entries, exp_entries",
+    [
+        ([], []),
+        (
+            [
+                config_meta.ClearMetaRegistry.MARKER,
+            ],
+            [
+                config_meta.ClearMetaRegistry(),
+            ],
+        ),
+        (
+            [
+                config_meta.ClearMetaRegistry.MARKER,
+                config_meta.ClearMetaRegistry.MARKER,
+            ],
+            [
+                config_meta.ClearMetaRegistry(),
+            ],
+        ),
+        (
+            [
+                config_meta.ClearMetaRegistry.MARKER,
+                {},
+            ],
+            [
+                config_meta.ClearMetaRegistry(),
+                _TestConfig(),
+            ],
+        ),
+        (
+            [
+                {},
+                config_meta.ClearMetaRegistry.MARKER,
+            ],
+            [
+                config_meta.ClearMetaRegistry(),
+                _TestConfig(),
+            ],
+        ),
+        (
+            [
+                config_meta.ClearMetaRegistry.MARKER,
+                {},
+                config_meta.ClearMetaRegistry.MARKER,
+            ],
+            [
+                config_meta.ClearMetaRegistry(),
+                _TestConfig(),
+            ],
+        ),
+    ],
+)
+def test_installationconfigmeta__partition_cmrs(w_entries, exp_entries):
+
+    found = config_meta.InstallationConfigMeta._partition_cmrs(
+        w_entries,
+        config_klass=_TestConfig,
+    )
+
+    assert found == exp_entries
+
+
+@pytest.mark.parametrize(
+    "w_entries, exp_entries, exp_clear",
+    [
+        ([], [], False),
+        (
+            [config_meta.ClearMetaRegistry()],
+            [],
+            True,
+        ),
+        (
+            [config_meta.ClearMetaRegistry(), config_meta.ClearMetaRegistry()],
+            [],
+            True,
+        ),
+        (
+            [config_meta.ClearMetaRegistry(), {}],
+            [{}],
+            True,
+        ),
+        (
+            [{}],
+            [{}],
+            False,
+        ),
+        (
+            [{}, config_meta.ClearMetaRegistry()],
+            [{}],
+            True,
+        ),
+        (
+            [
+                config_meta.ClearMetaRegistry(),
+                {},
+                config_meta.ClearMetaRegistry(),
+            ],
+            [{}],
+            True,
+        ),
+    ],
+)
+def test_installationconfigmeta__strip_clear(
+    w_entries, exp_entries, exp_clear
+):
+
+    found = config_meta.InstallationConfigMeta._strip_clear(w_entries)
+
+    entries, clear = found
+    assert entries == exp_entries
+    assert clear == exp_clear
+
+
 @pytest.mark.parametrize(
     "config_yaml, expected_kw",
     [
@@ -422,17 +717,17 @@ def test_jsonpathfunctionconfigmeta_from_yaml():
 def test_installationconfigmeta_from_yaml(
     temp_dir,
     patched_soliplex_config,
+    patched_agui_features,
+    patched_tool_configs,
+    patched_mcp_toolset_configs,
+    patched_mcp_tool_wrappers,
     patched_skill_configs,
     patched_agent_capabilities,
     patched_agent_configs,
     patched_secret_getters,
     patched_secret_sources,
-    patched_agui_features,
-    patched_app_routers,
-    patched_tool_configs,
-    patched_mcp_toolset_configs,
-    patched_mcp_tool_wrappers,
     patched_jsonpath_functions,
+    patched_app_routers,
     config_yaml,
     expected_kw,
 ):
@@ -519,6 +814,16 @@ def test_installationconfigmeta_from_yaml(
                     == mcptcp_by_class_name[wrapper_klassname]
                 )
 
+        if config_dict_meta and "skill_configs" in config_dict_meta:
+            scs_by_class_name = {
+                f"{klass.__module__}.{klass.__name__}": klass
+                for klass in patched_skill_configs.values()
+            }
+            for klass_name in config_dict_meta["skill_configs"]:
+                assert (
+                    scs_by_class_name[klass_name].kind in patched_skill_configs
+                )
+
         if config_dict_meta and "agent_capability_types" in config_dict_meta:
             acts_by_class_name = {
                 f"{klass.__module__}.{klass.__name__}": klass.__name__
@@ -554,6 +859,267 @@ def test_installationconfigmeta_from_yaml(
             )
 
 
+@pytest.mark.parametrize(
+    "config_yaml, expected_kw",
+    [
+        pytest.param(
+            W_AGUI_FEATURES_W_CLEAR_ICMETA_YAML,
+            W_AGUI_FEATURES_W_CLEAR_ICMETA_KW,
+            id="agui_features",
+        ),
+        pytest.param(
+            W_TOOL_CONFIGS_W_CLEAR_ICMETA_YAML,
+            W_TOOL_CONFIGS_W_CLEAR_ICMETA_KW,
+            id="tool_configs_only",
+        ),
+        pytest.param(
+            W_TOOL_WRAPPERS_W_CLEAR_ICMETA_YAML,
+            W_TOOL_WRAPPERS_W_CLEAR_ICMETA_KW,
+            id="tool_wrappers_only",
+        ),
+        pytest.param(
+            W_TOOL_CONFIGS_W_WRAPPERS_W_CLEAR_ICMETA_YAML,
+            W_TOOL_CONFIGS_W_WRAPPERS_W_CLEAR_ICMETA_KW,
+            id="tool_configs and wrappers",
+        ),
+        pytest.param(
+            W_MCP_TOOLSET_CONFIGS_W_CLEAR_ICMETA_YAML,
+            W_MCP_TOOLSET_CONFIGS_W_CLEAR_ICMETA_KW,
+            id="MCP toolsets",
+        ),
+        pytest.param(
+            W_SKILL_CONFIGS_W_CLEAR_ICMETA_YAML,
+            W_SKILL_CONFIGS_W_CLEAR_ICMETA_KW,
+            id="skills",
+        ),
+        pytest.param(
+            W_AGENT_CAPABILITY_W_CLEAR_ICMETA_YAML,
+            W_AGENT_CAPABILITY_W_CLEAR_ICMETA_KW,
+            id="agent_capabilities",
+        ),
+        pytest.param(
+            W_AGENT_CONFIGS_W_CLEAR_ICMETA_YAML,
+            W_AGENT_CONFIGS_W_CLEAR_ICMETA_KW,
+            id="agents",
+        ),
+        pytest.param(
+            W_SECRET_SOURCE_W_CLEAR_ICMETA_YAML,
+            W_SECRET_SOURCE_W_CLEAR_ICMETA_KW,
+            id="secret sources",
+        ),
+        pytest.param(
+            W_JSONPATH_FUNCTIONS_W_CLEAR_ICMETA_YAML,
+            W_JSONPATH_FUNCTIONS_W_CLEAR_ICMETA_KW,
+            id="jsonpath functions",
+        ),
+    ],
+)
+def test_installationconfigmeta_from_yaml_w_clear(
+    temp_dir,
+    patched_soliplex_config,
+    patched_agui_features,
+    patched_tool_configs,
+    patched_mcp_toolset_configs,
+    patched_mcp_tool_wrappers,
+    patched_skill_configs,
+    patched_agent_capabilities,
+    patched_agent_configs,
+    patched_secret_getters,
+    patched_secret_sources,
+    patched_jsonpath_functions,
+    patched_app_routers,
+    config_yaml,
+    expected_kw,
+):
+    patched_soliplex_config["test_secret_func"] = secret_source_func
+    expected_kw = copy.deepcopy(expected_kw)
+
+    yaml_file = temp_dir / "config.yaml"
+    yaml_file.write_text(config_yaml)
+
+    with yaml_file.open() as fp:
+        config_dict = yaml.safe_load(fp)
+
+    config_dict_meta = copy.deepcopy(config_dict["meta"])
+
+    if "mcp_server_tool_wrappers" in config_dict_meta:
+        # Cannot register wrappers for unknown tool configs
+        patched_tool_configs["_test_metaconfig.dummy_tool"] = object()
+
+    expected = config_meta.InstallationConfigMeta(
+        _config_path=yaml_file,
+        **expected_kw,
+    )
+
+    # ICMeta c'tor loads defaults
+    patched_app_routers.clear()
+
+    if "agui_features" in config_dict_meta:
+        patched_agui_features.clear()
+        patched_agui_features["before"] = object()
+
+    if "tool_configs" in config_dict_meta:
+        patched_tool_configs.clear()
+        patched_tool_configs["before"] = object()
+
+        # TC clear must clear wrappers
+        patched_mcp_tool_wrappers.clear()
+        patched_mcp_tool_wrappers["before"] = object()
+
+    if "mcp_toolset_configs" in config_dict_meta:
+        patched_mcp_toolset_configs.clear()
+        patched_mcp_toolset_configs["before"] = object()
+
+    if "mcp_server_tool_wrappers" in config_dict_meta:
+        patched_mcp_tool_wrappers.clear()
+        patched_mcp_tool_wrappers["before"] = object()
+
+    if "skill_configs" in config_dict_meta:
+        patched_skill_configs.clear()
+        patched_skill_configs["before"] = object()
+
+    if "agent_capability_types" in config_dict_meta:
+        patched_agent_capabilities.clear()
+        patched_agent_capabilities["before"] = object()
+
+    if "agent_configs" in config_dict_meta:
+        patched_agent_configs.clear()
+        patched_agent_configs["before"] = object()
+
+    if "secret_sources" in config_dict_meta:
+        patched_secret_sources.clear()
+        patched_secret_sources["before"] = object()
+        patched_secret_getters.clear()
+        patched_secret_getters["before"] = object()
+
+    if "jsonpath_functions" in config_dict_meta:
+        patched_jsonpath_functions.clear()
+        patched_jsonpath_functions["before"] = object()
+
+    ic_meta = config_meta.InstallationConfigMeta.from_yaml(
+        yaml_file,
+        config_dict_meta.copy() if config_dict_meta is not None else None,
+    )
+
+    assert ic_meta == expected
+
+    if "agui_features" in config_dict_meta:
+        assert "before" not in patched_agui_features
+
+        for (af_name, af_found), af_expected in zip(
+            patched_agui_features.items(),
+            config_dict_meta["agui_features"][1:],  # skip clear
+            strict=True,
+        ):
+            assert af_name == af_expected["name"]
+            assert af_found.name == af_expected["name"]
+            assert af_found.model_klass == af_expected["model_klass"]
+            assert af_found.source == af_expected["source"]
+
+    if "tool_configs" in config_dict_meta:
+        assert "before" not in patched_tool_configs
+        assert "before" not in patched_mcp_tool_wrappers
+
+        tcs_by_class_name = {
+            f"{klass.__module__}.{klass.__name__}": klass
+            for klass in patched_tool_configs.values()
+        }
+        for klass_name in config_dict_meta["tool_configs"]:
+            if klass_name != config_meta.ClearMetaRegistry.MARKER:
+                assert (
+                    tcs_by_class_name[klass_name].tool_name
+                    in patched_tool_configs
+                )
+
+    if "mcp_toolset_configs" in config_dict_meta:
+        assert "before" not in patched_mcp_toolset_configs
+
+        mtscs_by_class_name = {
+            f"{klass.__module__}.{klass.__name__}": klass
+            for klass in patched_mcp_toolset_configs.values()
+        }
+        for klass_name in config_dict_meta["mcp_toolset_configs"]:
+            if klass_name != config_meta.ClearMetaRegistry.MARKER:
+                assert (
+                    mtscs_by_class_name[klass_name].kind
+                    in patched_mcp_toolset_configs
+                )
+
+    if "mcp_server_tool_wrappers" in config_dict_meta:
+        assert "before" not in patched_mcp_tool_wrappers
+
+        mcptcp_by_class_name = {
+            f"{klass.__module__}.{klass.__name__}": klass
+            for klass in patched_mcp_tool_wrappers.values()
+        }
+        for meta_kw in config_dict_meta["mcp_server_tool_wrappers"]:
+            if meta_kw != config_meta.ClearMetaRegistry.MARKER:
+                tool_config_klass = _utils._from_dotted_name(
+                    meta_kw["config_klass"]
+                )
+                wrapper_klassname = meta_kw["wrapper_klass"]
+                assert (
+                    patched_mcp_tool_wrappers[tool_config_klass.tool_name]
+                    == mcptcp_by_class_name[wrapper_klassname]
+                )
+
+    if "skill_configs" in config_dict_meta:
+        assert "before" not in patched_skill_configs
+
+        scs_by_class_name = {
+            f"{klass.__module__}.{klass.__name__}": klass
+            for klass in patched_skill_configs.values()
+        }
+        for klass_name in config_dict_meta["skill_configs"]:
+            if klass_name != config_meta.ClearMetaRegistry.MARKER:
+                assert (
+                    scs_by_class_name[klass_name].kind in patched_skill_configs
+                )
+
+    if "agent_capability_types" in config_dict_meta:
+        assert "before" not in patched_agent_capabilities
+
+        acts_by_class_name = {
+            f"{klass.__module__}.{klass.__name__}": klass.__name__
+            for klass in patched_agent_capabilities.values()
+        }
+        for klass_name in config_dict_meta["agent_capability_types"]:
+            if klass_name != config_meta.ClearMetaRegistry.MARKER:
+                short_name = acts_by_class_name[klass_name]
+                assert short_name in patched_agent_capabilities
+
+    if "agent_configs" in config_dict_meta:
+        assert "before" not in patched_agent_configs
+
+        acs_by_class_name = {
+            f"{klass.__module__}.{klass.__name__}": klass
+            for klass in patched_agent_configs.values()
+        }
+        for klass_name in config_dict_meta["agent_configs"]:
+            if klass_name != config_meta.ClearMetaRegistry.MARKER:
+                kind = acs_by_class_name[klass_name].kind
+                assert kind in patched_agent_configs
+
+    if "secret_sources" in config_dict_meta:
+        assert "before" not in patched_secret_getters
+        assert "before" not in patched_secret_sources
+
+        ss_klass = _test_metaconfig.DummySecretSource
+        assert patched_secret_getters == {ss_klass.kind: secret_source_func}
+        assert patched_secret_sources == {ss_klass.kind: ss_klass}
+
+    if "jsonpath_functions" in config_dict_meta:
+        assert "before" not in patched_jsonpath_functions
+
+        assert authz.registered_jsonpath_functions() == {
+            JSONPATH_FUNCTION_NAME: _test_metaconfig.dummy_jsonpath_func
+        }
+        assert (
+            patched_jsonpath_functions[JSONPATH_FUNCTION_NAME]
+            is _test_metaconfig.dummy_jsonpath_func
+        )
+
+
 @pytest.mark.parametrize("w_jsonpath", [False, True])
 @pytest.mark.parametrize("w_secret_reg", [False, True])
 @pytest.mark.parametrize("w_agent", [False, True])
@@ -584,7 +1150,8 @@ def test_installationconfigmeta_as_yaml(
 ):
     patched_soliplex_config["test_secret_func"] = secret_source_func
 
-    expected = copy.deepcopy(BARE_ICMETA_KW)
+    first_clear = config_meta.ClearMetaRegistry.MARKER
+    expected = {key: [first_clear] for key in BARE_ICMETA_KW}
 
     if w_tools:
         klass = _test_metaconfig.DummyToolConfig
@@ -660,6 +1227,22 @@ def test_installationconfigmeta_as_yaml(
     assert found == expected
 
 
+def test_installationconfigmeta_as_yaml_wo_secret_source_clear(
+    patched_secret_sources,
+    patched_secret_getters,
+):
+    # Every import-time kind is registered in both registries, so nothing
+    # was suppressed and 'as_yaml' must not ask a reload to clear them.
+    for kind in config_secrets.DEFAULT_SECRET_SOURCE_KINDS:
+        patched_secret_sources[kind] = _test_metaconfig.DummySecretSource
+        patched_secret_getters[kind] = _test_metaconfig.dummy_secret_getter
+
+    found = config_meta.InstallationConfigMeta().as_yaml["secret_sources"]
+
+    assert config_meta.ClearMetaRegistry.MARKER not in found
+    assert len(found) == len(config_secrets.DEFAULT_SECRET_SOURCE_KINDS)
+
+
 def _registry_snapshot():
     """Copy every registry 'InstallationConfigMeta' writes into."""
     return {
@@ -700,6 +1283,7 @@ def _clear_registries():
     config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME.clear()
     config_agents.AGENT_CONFIG_CLASSES_BY_KIND.clear()
     config_secrets.SECRET_GETTERS_BY_KIND.clear()
+    config_secrets.SourceClassesByKind.clear()
 
     # Drop only the config-supplied filters, leaving the RFC 9535
     # built-ins the environment needs.
@@ -743,6 +1327,7 @@ def _round_trip_icmeta_registries(config_path, config_dict):
     "config_yaml",
     [
         BARE_ICMETA_YAML,
+        # YAML which does not clear the registries
         W_AGUI_FEATURES_ICMETA_YAML,
         W_TOOL_CONFIGS_ICMETA_YAML,
         W_MCP_TOOLSET_CONFIGS_ICMETA_YAML,
@@ -752,6 +1337,15 @@ def _round_trip_icmeta_registries(config_path, config_dict):
         W_SECRET_SOURCE_ICMETA_YAML,
         W_JSONPATH_FUNCTIONS_ICMETA_YAML,
         FULL_ICMETA_YAML,
+        # YAML which already clears the registries
+        W_AGUI_FEATURES_W_CLEAR_ICMETA_YAML,
+        W_TOOL_CONFIGS_W_CLEAR_ICMETA_YAML,
+        W_MCP_TOOLSET_CONFIGS_W_CLEAR_ICMETA_YAML,
+        W_SKILL_CONFIGS_W_CLEAR_ICMETA_YAML,
+        W_AGENT_CAPABILITY_W_CLEAR_ICMETA_YAML,
+        W_AGENT_CONFIGS_W_CLEAR_ICMETA_YAML,
+        W_SECRET_SOURCE_W_CLEAR_ICMETA_YAML,
+        W_JSONPATH_FUNCTIONS_W_CLEAR_ICMETA_YAML,
     ],
 )
 def test_installationconfigmeta_as_yaml_round_trips_registries(
@@ -764,6 +1358,7 @@ def test_installationconfigmeta_as_yaml_round_trips_registries(
     patched_agent_capabilities,
     patched_agent_configs,
     patched_secret_getters,
+    patched_secret_sources,
     patched_jsonpath_functions,
     temp_dir,
     config_yaml,


### PR DESCRIPTION
Note follow up in #1284 for 'secret getter' registry meta-config.

Closes #1280.