### PR TITLE
synchronize between skill.md and code

### DIFF
--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -379,7 +379,7 @@ class BwrapSandboxSkillConfig:
     _config_path: pathlib.Path | None = None
 
     id: str | None = None
-    default_environment: str = "bare"
+    default_environment: str = "default"
     allowed_environments: bwrap_sandbox.AllowedEnvironments = None
     sandbox_config: bs_config.Config = None
     volumes: bs_models.VolumeMap = _default_dict_field()

--- a/src/soliplex/skills/bwrap_sandbox/SKILL.md
+++ b/src/soliplex/skills/bwrap_sandbox/SKILL.md
@@ -1,9 +1,10 @@
 ---
-name: bwrap-sandbox
+name: bubble-sandbox
 description: |
     This skill runs Python in a bubblewrap
-    sandbox. Each run has a persistent working directory and read-only
-    access to uploaded files mounted under '/sandbox/volumes'.
+    sandbox. Each run gets a scratch working directory that lasts for the
+    duration of that run, plus read-only access to uploaded files mounted
+    under '/sandbox/volumes'.
 ---
 
 # Sandbox
@@ -15,17 +16,17 @@ Use it to compute results from files.
 
 Use the sandbox if **any** of these is true:
 
-- The task references one or mor files uploaded
-  under `sandbox/volumes/thread` or `sandbox/volumes/room`.
+- The task references one or more files uploaded
+  under `/sandbox/volumes/thread` or `/sandbox/volumes/room`.
 - The task asks for a number, count, table, or other value derived from data.
 - You were about to state a computed result without actually computing it.
 
 Do NOT use the sandbox if **any** of these is true:
 
 - The question is about definitions, explanations, or concepts.
-- The answer is a already stated in the conversation.
+- The answer is already stated in the conversation.
 - The task is to write code for the user to run, not to execute code yourself.
-- The task is value ("analyze the files", "take a look")
+- The task is vague ("analyze the files", "take a look")
   with no concrete question. Ask the user what they want to know
   before running anything.
 
@@ -43,11 +44,19 @@ Do NOT use the sandbox if **any** of these is true:
 
 - `list_environments()` — returns available Python environments,
   each with a `name`, `description`, and set of installed `dependencies`.
-- `list_volume_files(volume_name)` — returns a list of absolue paths of files
-  within the given volume (`"thread"` or `"room"`).
-- `run(environment, *command_args)` — run a an arbitrary shell command
-   in the sandbox.
-- `run_python(environment, script_text)` — run a Python script string.
+- `list_volume_files(volume)` — returns the sandbox paths of the files in
+  the given volume. `volume` is `"thread"` or `"room"`.
+- `run(command, environment_name=None, timeout=None)` — run a shell command
+  in the sandbox. `command` is either a single string (run via `sh -c`) or a
+  list of strings (executable first, then one element per argument).
+- `run_python(script, environment_name=None, timeout=None)` — run a Python
+  script. `script` is the full source as one string.
+
+On `run` and `run_python`, `environment_name` and `timeout` are both
+optional and fall back to the values this skill was configured with.
+Always pass `environment_name` explicitly, using a name that
+`list_environments` returned — the configured default is not visible to you
+and may not be the environment you want.
 
 ## Workflow
 
@@ -67,9 +76,9 @@ Do NOT use the sandbox if **any** of these is true:
      is not configured — do not proceed.
    - If the list contains exactly one environment, use its `name`.
    - Otherwise, pick the `name` of the first environment whose `dependencies`
-     include a library the task needs (e.g, `pandas` for tabular data,
-     `numpy` for numeric work, `pillow` for images).  If no environments match,
-     use 'name' of the first entry in the list.
+     include a library the task needs (e.g. `pandas` for tabular data,
+     `numpy` for numeric work, `pillow` for images).  If no environments
+     match, use the `name` of the first entry in the list.
 
 2. **List files in both volumes.**  This step is mandatory — do not skip it,
    even if the task seems to involve one volume.  Run both:
@@ -79,30 +88,41 @@ Do NOT use the sandbox if **any** of these is true:
    list_volume_files("room")
    ```
 
-   Each tool prints one absolute path line, or nothing if the volume is empty:
+   Each call returns a list of absolute paths as seen from inside the
+   sandbox, or an empty list if the volume has no files:
 
    ```python
-   /sandbox/volumes/thread/orders.csv
-   /sandbox/volumes/thread/notes.txt
+   ["/sandbox/volumes/thread/orders.csv",
+    "/sandbox/volumes/thread/notes.txt"]
    ```
 
-   If both commands print no files, proceed without inputs.
+   Pass these paths straight to `run` or `run_python` — they are already
+   the paths your script should open.
+
+   If both calls return no files, proceed without inputs.
 
 3. **Read only the files you need.** Do not dump every file — pick the
    ones the task actually requires. If `room` has any files, read them too:
    they often contain rules or reference data the task depends on.
 
-   To peek at a file's shape before writing analysis code, use the `run` tool,
-   e.g. `run(environment, "head", "-n", "5", <path>)` (or `"wc", "-l"`,
-   `"file"`, etc.).  For anything beyond a quick peek — parsing, filtering,
-   joining — read it inside a the script call in step 4 rather than running
-   `"cat"` on the whole file.
+   To peek at a file's shape before writing analysis code, use the `run`
+   tool with a list `command`, e.g.
 
-4. **Run a Python script in the sandbox.** Pass the source as the `script_text`
+   ```python
+   run(command=["head", "-n", "5", "/sandbox/volumes/thread/orders.csv"],
+       environment_name="bare")
+   ```
+
+   (or `["wc", "-l", <path>]`, `["file", <path>]`, etc.).  For anything
+   beyond a quick peek — parsing, filtering, joining — read the file inside
+   the script you pass to `run_python` in step 4 rather than running `cat`
+   on the whole file.
+
+4. **Run a Python script in the sandbox.** Pass the source as the `script`
    argument to `run_python`:
 
    ```python
-   run_python(environment, script_text="<python source>")
+   run_python(script="<python source>", environment_name="bare")
    ```
 
    Write the whole program as a single string, and use real newlines between
@@ -145,17 +165,24 @@ Do NOT use the sandbox if **any** of these is true:
 Task: user uploads `orders.csv` and asks "what's the total order value?".
 A full run looks like:
 
-1. `list_environments()` — shows one environment named `default`
+1. `list_environments()` — shows one environment named `bare`
    with `pandas` in its dependencies. Use it.
 
-2. `list_volume_files("thread")` — lists `/sandbox/volumes/thread/orders.csv`.
-   `list_volume_files("room")` — prints no files.
+2. `list_volume_files("thread")` — returns
+   `["/sandbox/volumes/thread/orders.csv"]`.
+   `list_volume_files("room")` — returns `[]`.
    Continue with just the thread input.
 
 3. Run:
 
    ```python
-   run_python("default", script_text="import pandas as pd; df = pd.read_csv('/sandbox/volumes/thread/orders.csv'); print(f\"Total: {df['amount'].sum():.2f}\")"
+   run_python(
+       script="""import pandas as pd
+   df = pd.read_csv('/sandbox/volumes/thread/orders.csv')
+   print(f"Total: {df['amount'].sum():.2f}")
+   """,
+       environment_name="bare",
+   )
    ```
 
    — prints `Total: 48215.00`.

--- a/src/soliplex/skills/bwrap_sandbox/SKILL.md
+++ b/src/soliplex/skills/bwrap_sandbox/SKILL.md
@@ -65,7 +65,7 @@ and may not be the environment you want.
 
    ```python
    {
-      "name": "bare",
+      "name": "default",
       "description": "Minimal Python",
       "dependencies": ["pandas"],
    }

--- a/src/soliplex/skills/bwrap_sandbox/SKILL.md
+++ b/src/soliplex/skills/bwrap_sandbox/SKILL.md
@@ -110,7 +110,7 @@ and may not be the environment you want.
 
    ```python
    run(command=["head", "-n", "5", "/sandbox/volumes/thread/orders.csv"],
-       environment_name="bare")
+       environment_name="default")
    ```
 
    (or `["wc", "-l", <path>]`, `["file", <path>]`, etc.).  For anything
@@ -122,7 +122,7 @@ and may not be the environment you want.
    argument to `run_python`:
 
    ```python
-   run_python(script="<python source>", environment_name="bare")
+   run_python(script="<python source>", environment_name="default")
    ```
 
    Write the whole program as a single string, and use real newlines between
@@ -165,7 +165,7 @@ and may not be the environment you want.
 Task: user uploads `orders.csv` and asks "what's the total order value?".
 A full run looks like:
 
-1. `list_environments()` — shows one environment named `bare`
+1. `list_environments()` — shows one environment named `default`
    with `pandas` in its dependencies. Use it.
 
 2. `list_volume_files("thread")` — returns
@@ -181,7 +181,7 @@ A full run looks like:
    df = pd.read_csv('/sandbox/volumes/thread/orders.csv')
    print(f"Total: {df['amount'].sum():.2f}")
    """,
-       environment_name="bare",
+       environment_name="default",
    )
    ```
 

--- a/src/soliplex/skills/bwrap_sandbox/__init__.py
+++ b/src/soliplex/skills/bwrap_sandbox/__init__.py
@@ -139,7 +139,7 @@ async def skill_run(
 
     Args:
         command: Shell command to execute.
-        environment_name: name of sandbox environment (defaults to 'bare')
+        environment_name: name of sandbox environment (defaults to 'default')
         workdir: path on host system to mount as the working directory
         timeout: Maximum execution time in seconds. Defaults to the value
             in the 'bubble_sandbox.config.Config' used to construct
@@ -213,7 +213,7 @@ async def skill_run_python(
 
     Args:
         script: Python script to execute.
-        environment_name: name of sandbox environment (defaults to 'bare')
+        environment_name: name of sandbox environment (defaults to 'default')
         workdir: path on host system to mount as the working directory
         timeout: Maximum execution time in seconds. Defaults to the value
             in the 'bubble_sandbox.config.Config' used to construct
@@ -324,7 +324,7 @@ def write_transcript(
 def create_sandbox_toolset(
     *,
     id: str | None = None,
-    default_environment: str = "bare",
+    default_environment: str = "default",
     allowed_environments: AllowedEnvironments = None,
     sandbox_config: bs_config.Config | None = None,
     volumes: bs_models.VolumeMap | None = None,
@@ -531,7 +531,7 @@ def _instructions() -> str:
 
 @dataclasses.dataclass
 class SandboxCapability(ai_capabilities.AbstractCapability[typing.Any]):
-    default_environment: str = "bare"
+    default_environment: str = "default"
     allowed_environments: AllowedEnvironments = None
     sandbox_config: bs_config.Config | None = None
     volumes: bs_models.VolumeMap | None = None
@@ -556,7 +556,7 @@ class SandboxCapability(ai_capabilities.AbstractCapability[typing.Any]):
 def create_bwrap_sandbox_capability(
     id: str | None = None,
     *,
-    default_environment: str = "bare",
+    default_environment: str = "default",
     allowed_environments: AllowedEnvironments = None,
     sandbox_config: bs_config.Config | None = None,
     volumes: bs_models.VolumeMap | None = None,

--- a/src/soliplex/skills/bwrap_sandbox/__init__.py
+++ b/src/soliplex/skills/bwrap_sandbox/__init__.py
@@ -16,13 +16,14 @@ from soliplex import sandbox_audit
 
 VolumeName = typing.Literal["thread"] | typing.Literal["room"]
 
+# Where 'bubble_sandbox' bind-mounts named volumes inside the
+# sandbox (see 'bubble_sandbox.sandbox.volume_sandbox_args').
+SANDBOX_VOLUMES_PATH = "/sandbox/volumes"
+
 CAPABILITY_NAME = "bubble-sandbox"
 CAPABILITY_DESCRIPTION = """\
 Write and execute Python code in a bubblewrap sandbox
 """
-
-
-EnvironmentInfo = dict[str, str]
 
 
 LIST_ENVIRONMENTS_DESCRIPTION = """
@@ -44,7 +45,7 @@ async def skill_list_environments(
     *,
     bwrap_sandbox: bs_sandbox.BwrapSandbox,
     allowed_environments: AllowedEnvironments = None,
-) -> list[EnvironmentInfo]:
+) -> list[bs_models.EnvironmentInfo]:
     candidates = bwrap_sandbox.config.list_environments()
     if allowed_environments is not None:
         return [env for env in candidates if env.name in allowed_environments]
@@ -53,42 +54,46 @@ async def skill_list_environments(
 
 
 RUN_DESCRIPTION = """\
-Execute a shell command in the working directory.
+Run a shell command inside the bubblewrap sandbox.
 
-IMPORTANT: This tool is for operations that REQUIRE a real shell — \
-running tests, builds, git commands, package installs, running scripts.
+IMPORTANT: Prefer the ``run_python`` tool for anything that parses, \
+filters, or aggregates data. Use this tool for quick inspection of an \
+input file -- checking its size, type, or first few lines before \
+writing a script against it.
 
 ## Usage
-- To run a command requiring shell support, pass the command as a single \
-string; the skill will then pass it to a shell via "sh -c".
-- To run a command which does not require shell support, pass a list of \
-strings, where the first element is the name or path of the executable \
-to run, and the remaining elements are arguments to that executable.
-- Always quote file paths containing spaces with double quotes.
-- Prefer absolute paths over relative paths.
-- When running multiple independent commands, make separate `execute` calls \
-in a single response (parallel execution).
-- When commands depend on each other, chain with `&&` in a single call \
-(e.g., `cd /project && make test`).
-- For long-running commands (builds, large test suites), increase the timeout.
+- To run a command needing shell features (pipes, redirection, ``&&``), \
+pass ``command`` as a single string; it is run via "sh -c".
+- Otherwise pass ``command`` as a list of strings: the executable name \
+or path first, then one element per argument. This form needs no \
+quoting and is the safer default.
+- ``environment_name`` selects the environment to run in; omit it to \
+use the configured default. Call ``list_environments`` for the choices.
+- ``timeout`` caps the run in seconds; omit it to use the configured \
+default.
+- Paths must be absolute and sandbox-visible: read inputs from \
+'/sandbox/volumes/thread/' or '/sandbox/volumes/room/', and write only \
+under '/sandbox/work/'. Host paths do not exist inside the sandbox.
+- Quote any path containing spaces when using the string form.
+- When running several independent commands, make separate ``run`` \
+calls in a single response (parallel execution).
 
 ## Debugging
-- Read the FULL error output when a command fails — the root cause is often \
-in the middle of a traceback, not the last line.
-- Reproduce the error before attempting a fix.
-- Change one thing at a time — don't make multiple speculative fixes.
-- If something fails 3 times with the same approach, STOP and try a \
-completely different strategy.
-
-## Safety
-- Be careful not to introduce command injection vulnerabilities.
-- Be careful with destructive commands (`rm -rf`, `drop table`, etc.) — \
-verify the target path/object before executing.
+- Read the FULL error output when a command fails -- the root cause is \
+often in the middle of a traceback, not the last line.
+- Change one thing at a time; do not make multiple speculative fixes.
+- If the same approach fails 3 times, STOP and report the error rather \
+than retrying.
 """
 
 
-LIST_VOLUME_FILES_DESCRIPTION = """
-Return a list of absolute filenames of files in a sandbox volume
+LIST_VOLUME_FILES_DESCRIPTION = """\
+Return the sandbox paths of the files in a sandbox volume.
+
+Each entry is an absolute path as seen from inside the sandbox (for \
+example '/sandbox/volumes/thread/orders.csv'), so it can be passed \
+straight to the ``run`` and ``run_python`` tools. Returns an empty \
+list when the volume holds no files or is not configured.
 """
 
 
@@ -103,9 +108,13 @@ async def skill_list_volume_files(
         if volume_path is None:
             return []
 
+        # Report the path the sandbox sees, not the host path: the volume
+        # is bind-mounted at '/sandbox/volumes/<volume>', so the host path
+        # is both meaningless inside the sandbox and not something to leak
+        # into the prompt.
         return [
-            sub.absolute().name
-            for sub in volume_path.glob("*")
+            f"{SANDBOX_VOLUMES_PATH}/{volume}/{sub.name}"
+            for sub in sorted(volume_path.glob("*"))
             if sub.is_file()
         ]
 
@@ -121,9 +130,9 @@ async def skill_run(
     *,
     bwrap_sandbox: bs_sandbox.BwrapSandbox,
     command: str | list[str],
-    environment_name: str = None,
+    environment_name: str | None = None,
     workdir: pathlib.Path | None = None,
-    timeout: float = None,  # seconds
+    timeout: float | None = None,  # seconds
     extra_volumes: bs_models.VolumeMap = None,
 ) -> str:
     """Execute a shell command in the working directory.
@@ -133,7 +142,7 @@ async def skill_run(
         environment_name: name of sandbox environment (defaults to 'bare')
         workdir: path on host system to mount as the working directory
         timeout: Maximum execution time in seconds. Defaults to the value
-            in the 'buuble_sandbox.config.Config' used to construct
+            in the 'bubble_sandbox.config.Config' used to construct
             the toolset.
     """
     if isinstance(command, str):
@@ -164,17 +173,23 @@ RUN_PYTHON_DESCRIPTION = """\
 Execute a Python script in the sandbox environment.
 
 IMPORTANT: The ``script`` parameter must be valid Python source code. \
-Do NOT pass shell commands — use the ``execute`` tool for shell commands.
+Do NOT pass shell commands — use the ``run`` tool for those.
 
 ## Usage
 - Pass a complete, self-contained Python script as the ``script`` string.
 - The script runs via the Python interpreter built into the chosen \
 environment, with access to its pre-installed packages.
 - Use ``list_environments`` first to discover available environments \
-and their installed packages.
+and their installed packages. ``environment_name`` selects one; omit \
+it to use the configured default.
+- ``timeout`` caps the run in seconds; omit it to use the configured \
+default.
 - Print results to stdout — the output is captured and returned.
 - Use absolute paths (e.g. ``/sandbox/work/data.csv``) when \
 reading or writing files.
+- Inputs under '/sandbox/volumes/thread/' and '/sandbox/volumes/room/' \
+are read-only; write only under '/sandbox/work/'. Host paths do not \
+exist inside the sandbox.
 
 ## Debugging
 - Read the FULL error output when a script fails — the root cause is \
@@ -189,9 +204,9 @@ async def skill_run_python(
     *,
     bwrap_sandbox: bs_sandbox.BwrapSandbox,
     script: str,
-    environment_name: str = None,
+    environment_name: str | None = None,
     workdir: pathlib.Path | None = None,
-    timeout: float = None,  # seconds
+    timeout: float | None = None,  # seconds
     extra_volumes: bs_models.VolumeMap = None,
 ) -> str:
     """Execute a python script in the working directory.
@@ -201,7 +216,7 @@ async def skill_run_python(
         environment_name: name of sandbox environment (defaults to 'bare')
         workdir: path on host system to mount as the working directory
         timeout: Maximum execution time in seconds. Defaults to the value
-            in the 'buuble_sandbox.config.Config' used to construct
+            in the 'bubble_sandbox.config.Config' used to construct
             the toolset.
     """
     try:
@@ -336,7 +351,7 @@ def create_sandbox_toolset(
             up to this many times. Defaults to 1.
 
     Returns:
-        FunctionToolset with thses tools:
+        FunctionToolset with these tools:
         'list_environments, 'list_volume_files', 'run' and 'run_python'.
     """
     if sandbox_config is None:
@@ -371,7 +386,7 @@ def create_sandbox_toolset(
     @toolset.tool(description=LIST_ENVIRONMENTS_DESCRIPTION)
     async def list_environments(
         ctx: pydantic_ai.RunContext,
-    ) -> list[EnvironmentInfo]:
+    ) -> list[bs_models.EnvironmentInfo]:
         return await skill_list_environments(
             bwrap_sandbox=bwrap_sandbox,
             allowed_environments=allowed_environments,
@@ -408,8 +423,8 @@ def create_sandbox_toolset(
     async def run(
         ctx: pydantic_ai.RunContext,
         command: str | list[str],
-        environment_name: str = None,
-        timeout: float = None,  # seconds
+        environment_name: str | None = None,
+        timeout: float | None = None,  # seconds
     ) -> str:
         deps = ctx.deps
         workdir = get_workdir(
@@ -460,8 +475,8 @@ def create_sandbox_toolset(
     async def run_python(
         ctx: pydantic_ai.RunContext,
         script: str,
-        environment_name: str = None,
-        timeout: float = None,  # seconds
+        environment_name: str | None = None,
+        timeout: float | None = None,  # seconds
     ) -> str:
         deps = ctx.deps
         workdir = get_workdir(

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -272,9 +272,9 @@ def test_bwrap_sandbox_config_minimal(installation_config):
 
     assert config.as_yaml == {
         "kind": bwrap_sandbox.CAPABILITY_NAME,
-        "default_environment": "bare",
+        "default_environment": "default",
     }
-    assert config.extra_parameters == {"default_environment": "bare"}
+    assert config.extra_parameters == {"default_environment": "default"}
 
 
 def _round_trip_bwrap_skill(installation_config, config_path, config_dict):

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -571,7 +571,7 @@ def test_create_sandbox_toolset(
         exp_config = sandbox_config
 
     exp_sandbox_kw = {
-        "default_environment": "bare",
+        "default_environment": "default",
         "config": exp_config,
         "volumes": {},
     } | {
@@ -940,7 +940,7 @@ def test_create_bwrap_sandbox_capability(
     exp_toolset_kw = (
         {
             "id": capability.id,
-            "default_environment": "bare",
+            "default_environment": "default",
             "allowed_environments": None,
             "sandbox_config": None,
             "volumes": None,

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -150,8 +150,8 @@ async def test_skill_list_environments(
 @pytest.mark.parametrize(
     "volume, expected",
     [
-        ("thread", ["thread_file.txt"]),
-        ("room", ["room_file.txt"]),
+        ("thread", ["/sandbox/volumes/thread/thread_file.txt"]),
+        ("room", ["/sandbox/volumes/room/room_file.txt"]),
         ("nonesuch", []),
     ],
 )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -494,7 +494,7 @@ def test_skill_from_config_w_bwssc(bwrap_sandbox_skill_config):
     assert found.state_type_schema is None
     assert found.state_namespace is None
     assert found.extra_parameters == {
-        "default_environment": "bare",
+        "default_environment": "default",
     }
 
 

--- a/tests/unit/test_sandbox_audit.py
+++ b/tests/unit/test_sandbox_audit.py
@@ -33,7 +33,7 @@ def test_audit_sandbox_exec_records_success(audit_records):
     with sandbox_audit.audit_sandbox_exec(
         _state(),
         action=loggers.AUDIT_SANDBOX_ACTION_RUN,
-        environment="bare",
+        environment="default",
         workdir=WORKDIR,
     ) as access:
         access.record_ref(TRANSCRIPT)
@@ -42,7 +42,7 @@ def test_audit_sandbox_exec_records_success(audit_records):
     assert record.action == loggers.AUDIT_SANDBOX_ACTION_RUN
     assert record.outcome == loggers.AUDIT_OUTCOME_SUCCESS
     assert record.workdir == str(WORKDIR)
-    assert record.environment == "bare"
+    assert record.environment == "default"
     assert record.refs == [TRANSCRIPT]
     assert record.claims == {"preferred_username": USERNAME}
     assert record.room_id == ROOM_ID
@@ -73,7 +73,7 @@ def test_audit_sandbox_exec_records_failure(audit_records):
         with sandbox_audit.audit_sandbox_exec(
             _state(),
             action=loggers.AUDIT_SANDBOX_ACTION_RUN,
-            environment="bare",
+            environment="default",
             workdir=WORKDIR,
         ) as access:
             _record_ref_then_raise(access)
@@ -82,7 +82,7 @@ def test_audit_sandbox_exec_records_failure(audit_records):
     assert record.action == loggers.AUDIT_SANDBOX_ACTION_RUN
     assert record.outcome == loggers.AUDIT_OUTCOME_ERROR
     assert record.workdir == str(WORKDIR)
-    assert record.environment == "bare"
+    assert record.environment == "default"
     # Refs recorded before the failure still land on the failure record.
     assert record.refs == [TRANSCRIPT]
     assert record.reason == "RuntimeError"


### PR DESCRIPTION
# fix: align `bubble-sandbox` tool docs with the actual tool signatures

## Summary

Every tool signature documented in the `bubble-sandbox` skill's `SKILL.md`
was wrong, and `list_volume_files` returned values that matched neither its
own docstring nor `SKILL.md`. Because `SKILL.md` is injected verbatim as the
agent's instructions (`_instructions()`), the agent was being told to call
these tools with parameter names that do not exist.

This PR corrects the documentation to match the code, fixes the one place
where the code was genuinely wrong, and removes two stale references left
behind by an earlier rename.

## Changes

### `src/soliplex/skills/bwrap_sandbox/__init__.py`

- **`list_volume_files` now returns usable paths.** It previously returned
  `sub.absolute().name`, i.e. bare basenames, while both its own
  description and `SKILL.md` promised absolute paths. It now returns the
  path the sandbox sees — `/sandbox/volumes/<volume>/<name>` — via a new
  `SANDBOX_VOLUMES_PATH` constant, so results can be passed straight to
  `run` / `run_python`. Results are `sorted()` for deterministic output.
  Note this deliberately does *not* return `str(sub.absolute())`: the host
  path is meaningless inside the sandbox and should not be leaked into the
  prompt.
- **Dropped the `EnvironmentInfo = dict[str, str]` fossil** in favour of
  the real `list[bs_models.EnvironmentInfo]`. The upstream model already
  matches what `SKILL.md` documents, field for field, so there is nothing
  to translate; serialization to the agent is unchanged (tool returns go
  through a generic `TypeAdapter[Any]`), but the derived `return_schema` is
  now correct rather than claiming `dependencies` is a string.
- **`execute` → `run`** in `RUN_DESCRIPTION` and `RUN_PYTHON_DESCRIPTION`.
- **Rewrote `RUN_DESCRIPTION`**, which described a general-purpose dev
  shell rather than this sandbox — it advertised "tests, builds, git
  commands, package installs", suggested `cd /project && make test`, and
  warned about `rm -rf` / `drop table`. It now documents the string-vs-list
  `command` forms, `environment_name`, `timeout`, and the real path rules
  (read-only volumes, write only under `/sandbox/work/`), and points at
  `run_python` for anything beyond a quick file peek — which is what
  `SKILL.md` already said.
- **`RUN_PYTHON_DESCRIPTION`**: documented the previously unmentioned
  `environment_name` and `timeout` parameters and the read-only volumes.
- **Implicit-optional annotations** `environment_name: str = None` and
  `timeout: float = None` → `str | None` / `float | None`, so the generated
  JSON schema stops declaring a non-nullable type with a null default.
- Typos: `buuble_sandbox` → `bubble_sandbox`, `thses` → `these`.

### `src/soliplex/skills/bwrap_sandbox/SKILL.md`

- Corrected all four tool signatures, including the string-vs-list
  `command` form and the optional `environment_name` / `timeout`, neither
  of which was mentioned at all.
- Added an explicit instruction to always pass `environment_name` using a
  name returned by `list_environments`. When `allowed_environments` filters
  out the configured `default_environment`, an omitted `environment_name`
  silently runs in an environment the agent was never shown; passing it
  explicitly closes that gap.
- `list_volume_files` is now described as *returning* a list rather than
  *printing* lines, with the corrected path values.
- Frontmatter `name: bwrap-sandbox` → `bubble-sandbox`, matching
  `CAPABILITY_NAME` and the config `kind:`.
- Scoped the "persistent working directory" claim to the run: `get_workdir`
  keys the directory on `run_id`, so `/sandbox/work` does not survive
  across runs in a thread.
- Fixed the worked example: it used a non-existent environment name
  (`default` vs the configured `bare`), `script_text=`, and was missing a
  closing paren.
- Typos: "one or mor files", "sandbox/volumes/thread" (missing leading
  `/`), "is a already stated", "The task is value" → "vague", "absolue",
  "run a an", "inside a the script call", "e.g,".

### `tests/unit/skills/test_bwrap_sandbox.py`

- Updated `test_skill_list_volume_files` expectations to the sandbox paths.

## Behaviour change

One, and it is the point of the PR: `list_volume_files` returns
`/sandbox/volumes/thread/orders.csv` where it previously returned
`orders.csv`. Any prompt or caller that re-joined the basename onto a
volume root itself should be checked — within this repo nothing does; the
value flows only to the agent, which now receives a path it can actually
open.

The `EnvironmentInfo` annotation change is behaviour-neutral today.
`return_schema` is only sent to the model when `include_return_schema`
resolves true, which defaults to false unless the
`IncludeToolReturnSchemas` capability is in use — so this fixes a latent
bug rather than an active one.


