### PR TITLE
fix windows error on test_config_rag

### DIFF
--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -209,7 +209,12 @@ def test__rdb_override_path_expands_user(db_rag_path, monkeypatch):
     Without expansion it would be resolved against the room directory as
     a literal '~', which is never a database.
     """
+    # 'expanduser' reads a different variable per platform: 'HOME' on
+    # POSIX, 'USERPROFILE' (then 'HOMEDRIVE' + 'HOMEPATH') on Windows,
+    # where 'HOME' is ignored outright. Set both so '~' resolves to the
+    # fixture directory rather than the real home on either platform.
     monkeypatch.setenv("HOME", str(db_rag_path))
+    monkeypatch.setenv("USERPROFILE", str(db_rag_path))
     db_override_path = db_rag_path / "test.lancedb"
     db_override_path.mkdir()
 


### PR DESCRIPTION
# fix: make the `~` expansion test pass on Windows

## Summary

`test__rdb_override_path_expands_user` fails on Windows. It monkeypatches
`HOME` to point `~` at its fixture directory, but Windows'
`pathlib.Path.expanduser()` ignores `HOME` — so `~` expanded to the real
user profile, the fixture database was not there, and the property under
test raised `RagDbFileNotFound`.

The fix sets `USERPROFILE` alongside `HOME`, so the test controls `~` on
either platform.

## Root cause

`expanduser()` consults a different variable per platform:

| Platform | Variable consulted |
| --- | --- |
| POSIX | `HOME` |
| Windows | `USERPROFILE`, then `HOMEDRIVE` + `HOMEPATH` |

Windows does not fall back to `HOME` at all, so setting it alone has no
effect there. Observed on this checkout:

```text
HOME only      -> C:\Users\bryan\test.lancedb     # HOME ignored
+ USERPROFILE  -> C:\tmp\fakehome\test.lancedb    # honoured
```

**The production code is correct and unchanged.**
`_RAGDatabaseBase.rag_lancedb_path` calling `.expanduser()` is the right
behaviour on both platforms; only the test's environment setup was wrong.


## Changes

`tests/unit/config/test_config_rag.py` — one added `monkeypatch.setenv`
call, plus a comment recording the per-platform precedence so the next
person does not have to rediscover it.

```python
monkeypatch.setenv("HOME", str(db_rag_path))
monkeypatch.setenv("USERPROFILE", str(db_rag_path))
```

No production code changes.

