### PR TITLE
fix: run feedback tools do not share request session

### DIFF
--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -10,6 +10,7 @@ from pydantic_ai import agent as ai_agent
 from pydantic_ai import capabilities as ai_capabilities
 from pydantic_ai import tools as ai_tools
 from pydantic_ai import toolsets as ai_toolsets
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agui
 from soliplex import mcp_client
@@ -45,7 +46,7 @@ class AgentDependencies:
     """
 
     the_installation: typing.Any  # installation.Installation
-    the_threads: agui.ThreadStorage = None
+    thread_persistence_engine: sqla_asyncio.AsyncEngine = None
     state: agui.AGUI_State = dataclasses.field(default_factory=dict)
     room_id: str | None = None
     thread_id: str | None = None

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -16,7 +16,6 @@ from sqlalchemy.ext import asyncio as sqla_asyncio
 from sqlalchemy.pool import NullPool
 
 from soliplex import agents
-from soliplex import agui
 from soliplex import authz
 from soliplex import loggers
 from soliplex import mcp_server
@@ -405,7 +404,7 @@ class Installation:
         *,
         room_id: str,
         user: dict,
-        the_threads: agui.ThreadStorage = None,
+        thread_persistence_engine: sqla_asyncio.AsyncEngine = None,
         the_room_authz: authz.RoomAuthorizationPolicy = None,
         run_agent_input: agui_core.RunAgentInput = None,
         the_logger: loggers.LogWrapper = None,
@@ -424,8 +423,8 @@ class Installation:
             thread_id = run_agent_input.thread_id
             run_id = run_agent_input.run_id
 
-        if the_threads is not None:
-            kwargs["the_threads"] = the_threads
+        if thread_persistence_engine is not None:
+            kwargs["thread_persistence_engine"] = thread_persistence_engine
 
         return agents.AgentDependencies(
             the_installation=self,

--- a/src/soliplex/tools/agui_run_feedback.py
+++ b/src/soliplex/tools/agui_run_feedback.py
@@ -4,6 +4,7 @@
 - Allow privileged users to mark feedback a as "reviewed", "resolved".
 """
 
+import contextlib
 import datetime
 import enum
 import typing
@@ -12,10 +13,12 @@ import jsonpatch
 import pydantic
 import pydantic_ai
 from ag_ui import core as agui_core
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agents
 from soliplex import agui
 from soliplex.agui import parser as agui_parser
+from soliplex.agui import persistence as agui_persistence
 
 FRS = agui.FeedbackReviewStatus
 STATE_NAMESPACE = "soliplex-agui-run-feedback"
@@ -241,11 +244,28 @@ class FeedbackResolution(pydantic.BaseModel):
     note: str | None = None
 
 
-async def _do_query(
+@contextlib.asynccontextmanager
+async def _get_threads_storage(
     ctx: pydantic_ai.RunContext[agents.AgentDependencies],
+):
+    """Context manager for tool-call local thread storage / session
+
+    Cannot be derived from the FastAPI request dependency, because
+    tool calls must run / complete in their own boundaries.
+    """
+    engine = ctx.deps.thread_persistence_engine
+    async with sqla_asyncio.AsyncSession(bind=engine) as session:
+        # One transaction per tool call: the storage methods no longer
+        # commit, so the tool call owns the unit of work -- committed on a
+        # clean response, rolled back if the handler raises.
+        async with session.begin():
+            yield agui_persistence.ThreadStorage(session)
+
+
+async def _do_query(
+    the_threads: agui_persistence.ThreadStorage,
     query: RecentRunFeedbackQuery,
 ) -> RecentRunFeedback:
-    the_threads = ctx.deps.the_threads
     runs_w_recent_fb = await the_threads.list_recent_run_feedback(
         **query.as_kwargs,
     )
@@ -328,7 +348,8 @@ async def query_recent_feedback(
     )
     before_state = {} if raw_state is None else {STATE_NAMESPACE: raw_state}
 
-    entries = await _do_query(ctx, query)
+    async with _get_threads_storage(ctx) as the_threads:
+        entries = await _do_query(the_threads, query)
     our_state.query = query
     our_state.entries = entries
 
@@ -390,29 +411,29 @@ async def get_feedback_run_info(
 
     to_query, _ = _find_feedback_by_run_id(our_state, run_id)
 
-    the_threads = ctx.deps.the_threads
-    run = await the_threads.get_run(
-        user_name=to_query.user_name,
-        room_id=to_query.room_id,
-        thread_id=to_query.thread_id,
-        run_id=to_query.run_id,
-    )
+    async with _get_threads_storage(ctx) as the_threads:
+        run = await the_threads.get_run(
+            user_name=to_query.user_name,
+            room_id=to_query.room_id,
+            thread_id=to_query.thread_id,
+            run_id=to_query.run_id,
+        )
 
-    thread = await run.awaitable_attrs.thread
-    email = await thread.awaitable_attrs.email
-    run_input = await run.awaitable_attrs.run_agent_input
-    parent_run_id = await run.awaitable_attrs.parent_run_id
-    events = await run.awaitable_attrs.events
+        thread = await run.awaitable_attrs.thread
+        email = await thread.awaitable_attrs.email
+        run_input = await run.awaitable_attrs.run_agent_input
+        parent_run_id = await run.awaitable_attrs.parent_run_id
+        events = await run.awaitable_attrs.events
 
-    esp = agui_parser.EventStreamParser(run_input)
+        esp = agui_parser.EventStreamParser(run_input)
 
-    for event in events:
-        try:
-            e_model = event.to_agui_model()
-        # agui_core.events.Event is not all-inclusive :<
-        except pydantic.ValidationError:  # pragma: NO COVER
-            continue
-        esp(e_model)
+        for event in events:
+            try:
+                e_model = event.to_agui_model()
+            # agui_core.events.Event is not all-inclusive :<
+            except pydantic.ValidationError:  # pragma: NO COVER
+                continue
+            esp(e_model)
 
     user_prompts = [
         message.content for message in esp.messages if message.role == "user"
@@ -471,17 +492,17 @@ async def review_recent_feedback(
         our_state, review.run_id, [FromWhichAttrs.OPENED]
     )
 
-    the_threads = ctx.deps.the_threads
     user = ctx.deps.user
-    await the_threads.review_run_feedback(
-        reviewer_user_name=user.preferred_username,
-        reviewer_email=user.email,
-        note=review.note,
-        user_name=to_review.user_name,
-        room_id=to_review.room_id,
-        thread_id=to_review.thread_id,
-        run_id=to_review.run_id,
-    )
+    async with _get_threads_storage(ctx) as the_threads:
+        await the_threads.review_run_feedback(
+            reviewer_user_name=user.preferred_username,
+            reviewer_email=user.email,
+            note=review.note,
+            user_name=to_review.user_name,
+            room_id=to_review.room_id,
+            thread_id=to_review.thread_id,
+            run_id=to_review.run_id,
+        )
 
     to_review.status = FRS.REVIEWED
     to_review.note = review.note
@@ -515,17 +536,17 @@ async def resolve_recent_feedback(
         [FromWhichAttrs.OPENED, FromWhichAttrs.REVIEWED],
     )
 
-    the_threads = ctx.deps.the_threads
     user = ctx.deps.user
-    await the_threads.resolve_run_feedback(
-        resolver_user_name=user.preferred_username,
-        resolver_email=user.email,
-        note=resolution.note,
-        user_name=to_resolve.user_name,
-        room_id=to_resolve.room_id,
-        thread_id=to_resolve.thread_id,
-        run_id=to_resolve.run_id,
-    )
+    async with _get_threads_storage(ctx) as the_threads:
+        await the_threads.resolve_run_feedback(
+            resolver_user_name=user.preferred_username,
+            resolver_email=user.email,
+            note=resolution.note,
+            user_name=to_resolve.user_name,
+            room_id=to_resolve.room_id,
+            thread_id=to_resolve.thread_id,
+            run_id=to_resolve.run_id,
+        )
 
     to_resolve.status = FRS.RESOLVED
     to_resolve.note = resolution.note

--- a/src/soliplex/views/agui.py
+++ b/src/soliplex/views/agui.py
@@ -698,7 +698,6 @@ async def post_room_agui_thread_id_run_id(
     thread_id: pydantic.UUID4,
     run_id: pydantic.UUID4,
     the_installation: installation.Installation = depend_the_installation,
-    the_threads: agui.ThreadStorage = depend_the_threads,
     the_room_authz: authz.RoomAuthorizationPolicy = depend_the_room_authz,
     the_user_claims: authn.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
@@ -788,13 +787,6 @@ async def post_room_agui_thread_id_run_id(
         agent=agent,
     )
 
-    # Persist the run input in its own short-lived, committed session
-    # rather than via the request-scoped 'the_threads'. This handler
-    # returns a long-lived StreamingResponse, so the request session's
-    # transaction stays open for the whole stream; committing the input
-    # write here releases its lock immediately (and keeps the request
-    # transaction from holding a writer lock behind the incremental
-    # per-event background saves).
     try:
         async with sqla_asyncio.AsyncSession(
             bind=request.state.threads_engine,
@@ -818,7 +810,7 @@ async def post_room_agui_thread_id_run_id(
         room_id=room_id,
         user=user,
         run_agent_input=agui_adapter.run_input,
-        the_threads=the_threads,
+        thread_persistence_engine=request.state.threads_engine,
         the_logger=the_logger,
     )
 

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -11,7 +11,6 @@ from sqlalchemy import pool as sqla_pool  # NullPool
 from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agents
-from soliplex import agui
 from soliplex import installation
 from soliplex import loggers
 from soliplex import models
@@ -1000,7 +999,7 @@ async def test_installation_get_agent_for_completion(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("w_the_threads", [False, True])
+@pytest.mark.parametrize("w_tp_engine", [False, True])
 @pytest.mark.parametrize("w_run_agent_input", [False, True])
 @pytest.mark.parametrize(
     "w_room_id, raises", [("room_id", False), ("nonesuch", True)]
@@ -1011,7 +1010,7 @@ async def test_installation_get_agent_deps_for_room(
     w_room_id,
     raises,
     w_run_agent_input,
-    w_the_threads,
+    w_tp_engine,
 ):
     tc_config = mock.create_autospec(config_tools.ToolConfig)
     sdtc_config = mock.create_autospec(config_tools.ToolConfig)
@@ -1037,9 +1036,9 @@ async def test_installation_get_agent_deps_for_room(
     if w_run_agent_input:
         kw["run_agent_input"] = RUN_AGENT_INPUT
 
-    the_threads = mock.create_autospec(agui.ThreadStorage)
-    if w_the_threads:
-        kw["the_threads"] = the_threads
+    tp_engine = mock.create_autospec(sqla_asyncio.AsyncEngine)
+    if w_tp_engine:
+        kw["thread_persistence_engine"] = tp_engine
 
     if raises:
         with pytest.raises(KeyError):
@@ -1077,10 +1076,10 @@ async def test_installation_get_agent_deps_for_room(
                 assert found.thread_id == RUN_AGENT_INPUT.thread_id
                 assert found.run_id == RUN_AGENT_INPUT.run_id
 
-            if w_the_threads:
-                assert found.the_threads is the_threads
+            if w_tp_engine:
+                assert found.thread_persistence_engine is tp_engine
             else:
-                assert found.the_threads is None
+                assert found.thread_persistence_engine is None
 
 
 @pytest.mark.anyio

--- a/tests/unit/tools/test_agui_run_feedback.py
+++ b/tests/unit/tools/test_agui_run_feedback.py
@@ -7,6 +7,7 @@ import jsonpatch
 import pydantic_ai
 import pytest
 from ag_ui import core as agui_core
+from sqlalchemy.ext import asyncio as sqla_asyncio
 
 from soliplex import agui
 from soliplex import models
@@ -69,9 +70,11 @@ def deps_user():
 def ctx_w_deps(deps_user):
     ctx = mock.Mock(spec_set=["deps"])
     ctx.deps = mock.Mock(
-        spec_set=["state", "the_threads", "user"],
+        spec_set=["state", "thread_persistence_engine", "user"],
         state={},
-        the_threads=mock.create_autospec(agui_persistence.ThreadStorage),
+        thread_persistence_engine=mock.create_autospec(
+            sqla_asyncio.AsyncEngine,
+        ),
         user=deps_user,
     )
     return ctx
@@ -220,6 +223,23 @@ def test_runfeedbackentry_from_dict_wo_nullable_defaults():
 
 
 @pytest.mark.anyio
+@mock.patch("soliplex.agui.persistence.ThreadStorage")
+async def test__get_threads_storage(ts_klass, fake_async_session, ctx_w_deps):
+    engine = ctx_w_deps.deps.thread_persistence_engine
+
+    with mock.patch(
+        "sqlalchemy.ext.asyncio.AsyncSession",
+        new=fake_async_session.cls,
+    ):
+        async with arf_tools._get_threads_storage(ctx_w_deps) as the_threads:
+            assert the_threads is ts_klass.return_value
+
+    ts_klass.assert_called_once_with(fake_async_session.session)
+
+    fake_async_session.cls.assert_called_once_with(bind=engine)
+
+
+@pytest.mark.anyio
 async def test__do_query(
     the_run,
     the_thread,
@@ -228,12 +248,16 @@ async def test__do_query(
     ctx_w_deps,
     rf_query,
 ):
-    lrrf = ctx_w_deps.deps.the_threads.list_recent_run_feedback
+    the_threads = mock.create_autospec(
+        agui_persistence.ThreadStorage,
+        instance=True,
+    )
+    lrrf = the_threads.list_recent_run_feedback
     lrrf.return_value = [the_run] if the_run else []
 
     review_entries, exp_status = the_review_entries
 
-    found = await arf_tools._do_query(ctx_w_deps, rf_query)
+    found = await arf_tools._do_query(the_threads, rf_query)
 
     if exp_status == FRS.RESOLVED:
         if the_run:
@@ -297,7 +321,16 @@ async def test__do_query(
     ],
 )
 @mock.patch("soliplex.tools.agui_run_feedback._do_query")
-async def test_query_recent_feedback(do_query, ctx_w_deps, rf_query, w_state):
+@mock.patch("soliplex.tools.agui_run_feedback._get_threads_storage")
+async def test_query_recent_feedback(
+    gts,
+    do_query,
+    ctx_w_deps,
+    rf_query,
+    w_state,
+):
+    the_threads = gts.return_value.__aenter__.return_value
+
     query_result = arf_tools.RecentRunFeedbackEntries(
         opened=[
             arf_tools.RunFeedbackEntry(
@@ -351,7 +384,9 @@ async def test_query_recent_feedback(do_query, ctx_w_deps, rf_query, w_state):
     assert found.return_value == query_result
     assert deps.state[STATE_NAMESPACE] == exp_state
 
-    do_query.assert_called_once_with(ctx_w_deps, rf_query)
+    do_query.assert_called_once_with(the_threads, rf_query)
+
+    gts.assert_called_once_with(ctx_w_deps)
 
     deltas = found.metadata
 
@@ -474,9 +509,11 @@ MULTI_RUN_MESSAGES = EARLIER_MESSAGES + SINGLE_RUN_MESSAGES
         (SINGLE_RUN_MESSAGES, RS.FINISHED, USER_PROMPT, RESPONSE_MESSAGE, 2),
     ],
 )
+@mock.patch("soliplex.tools.agui_run_feedback._get_threads_storage")
 @mock.patch("soliplex.agui.parser.EventStreamParser")
 async def test_get_feedback_run_info(
     esp,
+    gts,
     run_feedback_entry,
     ctx_w_deps,
     the_thread,
@@ -486,7 +523,7 @@ async def test_get_feedback_run_info(
     exp_response,
     n_invalid,
 ):
-    get_run = ctx_w_deps.deps.the_threads.get_run
+    the_threads = gts.return_value.__aenter__.return_value
 
     rai = agui_constants.FULL_RUN_AGENT_INPUT.model_copy()
     start_event = agui_core.events.RunStartedEvent(
@@ -539,7 +576,7 @@ async def test_get_feedback_run_info(
     )
     run.awaitable_attrs.run_agent_input = _awaitable("run_agent_input", rai)
     run.awaitable_attrs.events = _awaitable("events", db_events)
-    get_run.return_value = run
+    the_threads.get_run.return_value = run
 
     entries = arf_tools.RecentRunFeedbackEntries(
         opened=[run_feedback_entry],
@@ -591,12 +628,15 @@ async def test_get_feedback_run_info(
         (OTHER_RUN_ID, pytest.raises(arf_tools.UnknownFeedback)),
     ],
 )
+@mock.patch("soliplex.tools.agui_run_feedback._get_threads_storage")
 async def test_review_recent_feedback(
+    gts,
     ctx_w_deps,
     run_feedback_entry,
     w_run_id,
     expectation,
 ):
+    the_threads = gts.return_value.__aenter__.return_value
     deps = ctx_w_deps.deps
 
     before_entries = arf_tools.RecentRunFeedbackEntries(
@@ -633,7 +673,7 @@ async def test_review_recent_feedback(
 
     after_feedback_state = deps.state[STATE_NAMESPACE]
 
-    rvw_rf = deps.the_threads.review_run_feedback
+    rvw_rf = the_threads.review_run_feedback
 
     if expected is None:
         assert after_feedback_state == exp_state
@@ -672,10 +712,12 @@ async def test_review_recent_feedback(
         assert (
             jsonpatch.apply_patch(start_agui_state, event.delta) == deps.state
         )
+        gts.assert_called_once_with(ctx_w_deps)
 
     else:
         assert after_feedback_state == before_feedback_state
         rvw_rf.assert_not_awaited()
+        gts.assert_not_called()
 
 
 @pytest.mark.anyio
@@ -687,13 +729,17 @@ async def test_review_recent_feedback(
         (OTHER_RUN_ID, pytest.raises(arf_tools.UnknownFeedback)),
     ],
 )
+@mock.patch("soliplex.tools.agui_run_feedback._get_threads_storage")
 async def test_resolve_recent_feedback(
+    gts,
     ctx_w_deps,
     run_feedback_entry,
     w_run_id,
     expectation,
     w_reviewed,
 ):
+    the_threads = gts.return_value.__aenter__.return_value
+
     if w_reviewed:
         before_entries = arf_tools.RecentRunFeedbackEntries(
             reviewed=[run_feedback_entry],
@@ -741,7 +787,7 @@ async def test_resolve_recent_feedback(
 
     after_feedback_state = deps.state[STATE_NAMESPACE]
 
-    rsv_rf = ctx_w_deps.deps.the_threads.resolve_run_feedback
+    rsv_rf = the_threads.resolve_run_feedback
     if expected is None:
         assert isinstance(found, pydantic_ai.ToolReturn)
 
@@ -784,7 +830,9 @@ async def test_resolve_recent_feedback(
         assert (
             jsonpatch.apply_patch(start_agui_state, event.delta) == deps.state
         )
+        gts.assert_called_once_with(ctx_w_deps)
 
     else:
         assert after_feedback_state == before_feedback_state
         rsv_rf.assert_not_awaited()
+        gts.assert_not_called()

--- a/tests/unit/views/test_agui_views.py
+++ b/tests/unit/views/test_agui_views.py
@@ -1478,7 +1478,6 @@ async def test_post_room_agui_thread_id_run_id_streaming(
     exp_deps = the_installation.get_agent_deps_for_room.return_value
 
     test_run.run_input = None
-    the_threads.get_run.return_value = test_run
 
     # 'add_run_input' now runs on its own short-lived, committed session
     # rather than the request-scoped 'the_threads'. The shared
@@ -1515,7 +1514,6 @@ async def test_post_room_agui_thread_id_run_id_streaming(
             thread_id=TEST_THREAD_ID_UUID,
             run_id=TEST_RUN_ID_UUID,
             the_installation=the_installation,
-            the_threads=the_threads,
             the_room_authz=the_room_authz,
             the_user_claims=THE_USER_CLAIMS,
             the_logger=the_logger,
@@ -1585,7 +1583,7 @@ async def test_post_room_agui_thread_id_run_id_streaming(
             room_id=TEST_ROOM_ID,
             user=USER_PROFILE,
             run_agent_input=exp_adapter.run_input,
-            the_threads=the_threads,
+            thread_persistence_engine=request.state.threads_engine,
             the_logger=the_logger,
         )
 
@@ -1635,7 +1633,6 @@ async def test_post_room_agui_reconnect(
     asei,
     sswk,
     frsr,
-    the_threads,
 ):
     """Reconnect path: Last-Event-ID present."""
     agent = object()
@@ -1669,7 +1666,6 @@ async def test_post_room_agui_reconnect(
         thread_id=TEST_THREAD_ID_UUID,
         run_id=TEST_RUN_ID_UUID,
         the_installation=the_installation,
-        the_threads=the_threads,
         the_room_authz=the_room_authz,
         the_user_claims=THE_USER_CLAIMS,
         the_logger=the_logger,


### PR DESCRIPTION
Each tool uses its own session, committing at tool call exit: prevents unwanted interaction between the tool calls, as well as holding the run request session open for a streaming call.

Closes #1288.