### PR TITLE
feat: register meta-config classes for explicit keys

### DIFF
--- a/docs/config/meta.md
+++ b/docs/config/meta.md
@@ -131,8 +131,7 @@ they can be referenced by their `tool_name`.
 
 The section contains a list of Python "dotted names", i.e. strings which
 can be used to import the configuration class. Each entry may instead be
-a mapping with a single `config_klass` key, whose value is that same
-dotted name.
+a mapping with a `config_klass` key, whose value is that same dotted name.
 
 Example:
 
@@ -141,6 +140,23 @@ meta:
   tool_configs:
   - "my_package.config.MyToolConfig"
 ```
+
+The mapping form also accepts an optional `tool_name` key, naming the
+registry key under which the class is registered. It defaults to the
+`tool_name` declared by the class itself; supplying it explicitly
+registers the class under an additional alias, which is how a renamed
+tool keeps accepting its former name:
+
+```yaml
+meta:
+  tool_configs:
+  - "my_package.config.MyToolConfig"
+  - tool_name: "my_package.tools.old_name"
+    config_klass: "my_package.config.MyToolConfig"
+```
+
+`as_yaml` always emits the mapping form, so aliases survive a
+dump-and-reload of the installation configuration.
 
 By default, Soliplex registers its own tool config class, just as though
 we configured explicitly:
@@ -158,8 +174,11 @@ configuration types so that they can be referenced by their 'kind'.
 
 The section contains a list of Python "dotted names", i.e. strings which
 can be used to import the configuration class. Each entry may instead be
-a mapping with a single `config_klass` key, whose value is that same
-dotted name.
+a mapping with a `config_klass` key, whose value is that same dotted
+name, plus an optional `kind` key naming the registry key under which
+the class is registered. `kind` defaults to the one declared by the
+class itself; supplying it explicitly registers the class under an
+additional alias, and `as_yaml` preserves it.
 
 By default, Soliplex registers its own toolset config classes, just as
 though we configured explicitly:
@@ -178,6 +197,9 @@ The `meta.mcp_server_tool_wrappers` section maps tool configuration classes
 to the equivalent wrapper class, used when offering the tool to external
 MCP clients.
 
+Soliplex registers no tool config wrappers by default: this registry is empty
+unless an installation populates it.
+
 The section contains a list of mappings with keys `config_klass` and
 `wrapper_klass`.  Values for both keys are Python "dotted names", i.e.
 strings which can be used to import the corresponding class.
@@ -191,15 +213,22 @@ meta:
     wrapper_klass: "my_package.config.MyMCPWrapper"
 ```
 
-Soliplex registers no wrappers by default: this registry is empty unless
-an installation populates it.
+Each mapping also accepts an optional `tool_name` key, naming the
+tool config registry key for which the wrapper is registered. It defaults
+to the `tool_name` declared by `config_klass`. Supplying a different
+`tool_name` wraps the tool config registered under that alias, and
+`as_yaml` preserves it. Because wrappers are keyed by tool name rather
+than by class, a tool registered under both its own name and an alias
+requires a separate wrapper entry for each registered tool name.
 
-The class named by `config_klass` must already be registered as a tool
-configuration, either by Soliplex itself or by the `meta.tool_configs`
-section of this same installation configuration; `tool_configs` is
-applied first for exactly that reason. Naming an unregistered class is an
-error, and loading the configuration fails rather than silently skipping
-the wrapper.
+That `tool_name` must already be registered as a tool configuration,
+either by Soliplex itself or by the `meta.tool_configs` section of this
+same installation configuration; `tool_configs` is applied first for
+exactly that reason. Naming an unregistered `tool_name` is an error, and
+loading the configuration fails rather than silently skipping the
+wrapper. Note that it is the name which must be registered, not the
+class: naming a registered class under a `tool_name` which is not itself
+registered fails just the same.
 
 ## Registering Skill Configuration Classes
 
@@ -208,8 +237,21 @@ configuration types so that they can be referenced by their 'kind'.
 
 The section contains a list of Python "dotted names", i.e. strings which
 can be used to import the configuration class. Each entry may instead be
-a mapping with a single `config_klass` key, whose value is that same
-dotted name.
+a mapping with a `config_klass` key, whose value is that same dotted
+name, plus an optional `kind` key naming the registry key under which
+the class is registered. `kind` defaults to the one declared by the
+class itself; supplying it explicitly registers the class under an
+additional alias, and `as_yaml` preserves it. A skill whose `kind` has
+been renamed can therefore keep accepting its former spelling in room
+configurations:
+
+```yaml
+meta:
+  skill_configs:
+  - "my_package.config.MySkillConfig"
+  - kind: "my_package.old_skill_name"
+    config_klass: "my_package.config.MySkillConfig"
+```
 
 By default, Soliplex registers its own skill config classes, just as
 though we configured explicitly:
@@ -234,15 +276,19 @@ class name, not a separate `kind` string.
 
 The section contains a list of Python "dotted names", i.e. strings which
 can be used to import the capability class. Each entry may instead be a
-mapping with a single `config_klass` key, whose value is that same dotted
-name.
-
-Example:
+mapping with a `config_klass` key, whose value is that same dotted name,
+plus an optional `capability_name` key naming the registry key under
+which the class is registered. `capability_name` defaults to the class'
+own `__name__`; supplying it explicitly registers the class under an
+additional alias, and `as_yaml` preserves it. A capability class which
+has been renamed can therefore keep answering to its former class name:
 
 ```yaml
 meta:
   agent_capability_types:
   - "my_package.capabilities.MyCapability"
+  - capability_name: "MyOldCapability"
+    config_klass: "my_package.capabilities.MyCapability"
 ```
 
 By default, Soliplex registers the capability types published by
@@ -257,8 +303,21 @@ they can be referenced by their `kind`.
 
 The section contains a list of Python "dotted names", i.e. strings which
 can be used to import the configuration class. Each entry may instead be
-a mapping with a single `config_klass` key, whose value is that same
-dotted name.
+a mapping with a `config_klass` key, whose value is that same dotted
+name, plus an optional `kind` key naming the registry key under which
+the class is registered. `kind` defaults to the one declared by the
+class itself; supplying it explicitly registers the class under an
+additional alias, and `as_yaml` preserves it. An agent whose `kind` has
+been renamed can therefore keep accepting its former spelling in room
+configurations:
+
+```yaml
+meta:
+  agent_configs:
+  - "my_package.config.MyAgentConfig"
+  - kind: "my_package.old_agent_kind"
+    config_klass: "my_package.config.MyAgentConfig"
+```
 
 By default, Soliplex registers its own agent config classes, just as
 though we configured explicitly:
@@ -283,9 +342,11 @@ which resolve those sources are registered separately, in
 [`meta.secret_getters`](#registering-secret-getter-functions) below.
 
 Like most sections above, it contains a list of Python "dotted names".
-Each entry may instead be a mapping with a single `config_klass` key,
-whose value is that same dotted name. The kind a class is registered
-under is taken from the class itself, not spelled separately.
+Each entry may instead be a mapping with a `config_klass` key, whose
+value is that same dotted name, plus an optional `kind` key naming the
+registry key under which the class is registered. `kind` defaults to the
+one declared by the class itself; supplying it explicitly registers the
+class under an additional alias, and `as_yaml` preserves it.
 
 By default, Soliplex registers its own source classes, just as though we
 configured explicitly:
@@ -351,9 +412,11 @@ meta:
 ```
 
 That is exactly equivalent to writing the two sections out, reading the
-`kind` from `config_klass`. The shorthand is expanded while the `meta`
-section is parsed, so an explicit `secret_getters` entry for the same
-kind takes precedence over one implied by `registered_func`. Note that
+`kind` from `config_klass` -- or from the entry's own `kind` key, when
+it carries one, so that an aliased source and its getter land under the
+same kind. The shorthand is expanded while the `meta` section is parsed,
+so an explicit `secret_getters` entry for the same kind takes precedence
+over one implied by `registered_func`. Note that
 `registered_func` is only meaningful in this combined position: it is not
 accepted anywhere else, and `soliplex-cli config` always dumps the two
 sections separately.
@@ -368,9 +431,13 @@ kind is accepted -- but resolving a secret from it raises
 source, so a secret listing further sources still resolves from the next
 one, and `soliplex-cli audit` reports the miss in its secrets section.
 
-Two configurations reach that state:
+Three configurations reach that state:
 
 - registering a source class alone, with no matching getter;
+
+- registering a source class under an additional `kind` alias without a
+  getter for that alias: getters are keyed by kind, so the getter
+  registered for the class' own kind does not cover the alias;
 
 - clearing `secret_getters` without clearing `secret_sources`, which
   strands every built-in kind whose getter is not re-registered:

--- a/src/soliplex/config/meta.py
+++ b/src/soliplex/config/meta.py
@@ -33,16 +33,20 @@ class ExtraneousKeys(TypeError):
 
 
 class WrapperForUnknownToolConfig(ValueError):
-    def __init__(self, tool_config_klass, wrapper_klass):
+    def __init__(self, tool_name, tool_config_klass, wrapper_klass):
+        self.tool_name = tool_name
         self.tool_config_klass = tool_config_klass
         self.wrapper_klass = wrapper_klass
 
         tck_dotted = _utils._dotted_name(tool_config_klass)
         wk_dotted = _utils._dotted_name(wrapper_klass)
 
+        # It is the *name* which is unregistered: 'tool_config_klass'
+        # may well be registered, under some other name.
         super().__init__(
-            f"Wrapper class '{wk_dotted}' cannot be "
-            f"registered for unregistered tool config class '{tck_dotted}'"
+            f"Wrapper class '{wk_dotted}' cannot be registered for "
+            f"tool config class '{tck_dotted}' under unregistered "
+            f"tool name '{tool_name}'"
         )
 
 
@@ -94,10 +98,35 @@ class AGUI_FeatureConfigMeta:
 
 
 AllowedKeys = typing.ClassVar[frozenset[str]]
+KeyField = typing.ClassVar[str | None]
 
 
 @dataclasses.dataclass(kw_only=True)
-class _ConfigKlassOnlyMeta:
+class _RegistryKeyMeta:
+    """Mixin for meta classes registering 'config_klass' under a key.
+
+    A derived class names that key in '_KEY_FIELD' and declares a
+    matching optional field. The field defaults to the value
+    'config_klass' declares for itself (see '_key_from_config_klass');
+    passing it explicitly registers the class under an alias instead,
+    which 'as_yaml' then preserves.
+    """
+
+    _KEY_FIELD: KeyField = None
+
+    def __post_init__(self):
+        if self._KEY_FIELD is None:  # no registry key of its own
+            return
+
+        if getattr(self, self._KEY_FIELD) is None:
+            setattr(self, self._KEY_FIELD, self._key_from_config_klass())
+
+    def _key_from_config_klass(self) -> str:
+        return getattr(self.config_klass, self._KEY_FIELD)
+
+
+@dataclasses.dataclass(kw_only=True)
+class _ConfigKlassOnlyMeta(_RegistryKeyMeta):
     """Base for config meta classes which take only 'config_klass'
 
     Derived classes may declare ignored, deprecated keys by overriding
@@ -109,6 +138,7 @@ class _ConfigKlassOnlyMeta:
 
     @classmethod
     def from_yaml(cls, yaml_config: _utils.DottedName | dict):
+        extra = {}
 
         if isinstance(yaml_config, _utils.DottedName):
             config_klass = _utils._from_dotted_name(yaml_config)
@@ -121,8 +151,22 @@ class _ConfigKlassOnlyMeta:
             config_klass = _utils._from_dotted_name(
                 yaml_config["config_klass"]
             )
+            # Any remaining allowed key which is also a field of the
+            # derived class is passed through: that is how a category
+            # whose registry key can differ from the one declared by
+            # 'config_klass' (an alias) round-trips.
+            field_names = {
+                field.name
+                for field in dataclasses.fields(cls)
+                if field.name != "config_klass"
+            }
+            extra = {
+                key: value
+                for key, value in yaml_config.items()
+                if key in field_names
+            }
 
-        return cls(config_klass=config_klass)
+        return cls(config_klass=config_klass, **extra)
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -143,19 +187,25 @@ class ToolConfigMeta(_ConfigKlassOnlyMeta):
     'registered_func'
         No-op fossil from 'ConfigMeta'; accepted by 'from_yaml' (see
         '_ALLOWED_KEYS') and otherwise ignored.
+
+    'tool_name'
+        (optional) the registry key under which 'config_klass' is
+        registered. Defaults to the class' own 'tool_name'. Supplying it
+        explicitly registers the class under an additional alias, e.g.
+        for backward compatibility with a renamed tool.
     """
 
     _ALLOWED_KEYS: AllowedKeys = frozenset(
         {
             "config_klass",
+            "tool_name",
             "wrapper_klass",
             "registered_func",
         }
     )
+    _KEY_FIELD: KeyField = "tool_name"
 
-    @property
-    def tool_name(self) -> _utils.DottedName:
-        return self.config_klass.tool_name
+    tool_name: _utils.DottedName | None = None
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -176,23 +226,29 @@ class MCP_ToolsetConfigMeta(_ConfigKlassOnlyMeta):
     'registered_func'
         No-op fossil from 'ConfigMeta'; accepted by 'from_yaml' (see
         '_ALLOWED_KEYS') and otherwise ignored.
+
+    'kind'
+        (optional) the registry key under which 'config_klass' is
+        registered. Defaults to the class' own 'kind'. Supplying it
+        explicitly registers the class under an additional alias, e.g.
+        for backward compatibility with a renamed toolset kind.
     """
 
     _ALLOWED_KEYS: AllowedKeys = frozenset(
         {
             "config_klass",
+            "kind",
             "wrapper_klass",
             "registered_func",
         }
     )
+    _KEY_FIELD: KeyField = "kind"
 
-    @property
-    def kind(self) -> str:
-        return self.config_klass.kind
+    kind: str | None = None
 
 
 @dataclasses.dataclass(kw_only=True)
-class MCP_ServerToolWrapperConfigMeta:
+class MCP_ServerToolWrapperConfigMeta(_RegistryKeyMeta):
     """Meta-config class for registering wrapper classes for MCP server tools
 
     'config_klass'
@@ -211,18 +267,28 @@ class MCP_ServerToolWrapperConfigMeta:
     'registered_func'
         No-op fossil from 'ConfigMeta'; accepted by 'from_yaml' (see
         '_ALLOWED_KEYS') and otherwise ignored.
+
+    'tool_name'
+        (optional) the registry key under which 'wrapper_klass' is
+        registered. Defaults to the 'tool_name' declared by
+        'config_klass'. Supplying it explicitly wraps the tool config
+        registered under that alias, e.g. for backward compatibility
+        with a renamed tool.
     """
 
     _ALLOWED_KEYS: AllowedKeys = frozenset(
         {
             "config_klass",
+            "tool_name",
             "wrapper_klass",
             "registered_func",
         }
     )
+    _KEY_FIELD: KeyField = "tool_name"
 
     config_klass: typing.Any
     wrapper_klass: typing.Any
+    tool_name: _utils.DottedName | None = None
 
     @classmethod
     def from_yaml(cls, yaml_config: _utils.DottedName | dict):
@@ -232,11 +298,8 @@ class MCP_ServerToolWrapperConfigMeta:
         return cls(
             config_klass=config_klass,
             wrapper_klass=wrapper_klass,
+            tool_name=yaml_config.get("tool_name"),
         )
-
-    @property
-    def tool_name(self) -> _utils.DottedName:
-        return self.config_klass.tool_name
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -257,23 +320,29 @@ class SkillConfigMeta(_ConfigKlassOnlyMeta):
     'registered_func'
         No-op fossil from 'ConfigMeta'; accepted by 'from_yaml' (see
         '_ALLOWED_KEYS') and otherwise ignored.
+
+    'kind'
+        (optional) the registry key under which 'config_klass' is
+        registered. Defaults to the class' own 'kind'. Supplying it
+        explicitly registers the class under an additional alias, e.g.
+        for backward compatibility with a renamed skill.
     """
 
     _ALLOWED_KEYS: AllowedKeys = frozenset(
         {
             "config_klass",
+            "kind",
             "wrapper_klass",
             "registered_func",
         }
     )
+    _KEY_FIELD: KeyField = "kind"
 
-    @property
-    def kind(self) -> str:
-        return self.config_klass.kind
+    kind: str | None = None
 
 
 @dataclasses.dataclass(kw_only=True)
-class AgentCapabilityMeta(_ConfigKlassOnlyMeta):
+class AgentCapabilityConfigMeta(_ConfigKlassOnlyMeta):
     """Meta-config class for registering agent capability classes
 
     'config_klass'
@@ -290,19 +359,34 @@ class AgentCapabilityMeta(_ConfigKlassOnlyMeta):
     'registered_func'
         No-op fossil from 'ConfigMeta'; accepted by 'from_yaml' (see
         '_ALLOWED_KEYS') and otherwise ignored.
+
+    'capability_name'
+        (optional) the registry key under which 'config_klass' is
+        registered. Unlike the other categories, it defaults to the
+        class' own '__name__': capability classes declare no name of
+        their own. Supplying it explicitly registers the class under an
+        additional alias, e.g. for backward compatibility with a
+        renamed capability class.
     """
 
     _ALLOWED_KEYS: AllowedKeys = frozenset(
         {
+            "capability_name",
             "config_klass",
             "wrapper_klass",
             "registered_func",
         }
     )
+    _KEY_FIELD: KeyField = "capability_name"
 
-    @property
-    def capability_name(self) -> _utils.DottedName:
+    capability_name: _utils.DottedName | None = None
+
+    def _key_from_config_klass(self) -> str:
         return self.config_klass.__name__
+
+
+# Deprecated backward-compatibiity alias (no warning, no removal scheduled).
+AgentCapabilityMeta = AgentCapabilityConfigMeta
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -323,19 +407,25 @@ class AgentConfigMeta(_ConfigKlassOnlyMeta):
     'registered_func'
         No-op fossil from 'ConfigMeta'; accepted by 'from_yaml' (see
         '_ALLOWED_KEYS') and otherwise ignored.
+
+    'kind'
+        (optional) the registry key under which 'config_klass' is
+        registered. Defaults to the class' own 'kind'. Supplying it
+        explicitly registers the class under an additional alias, e.g.
+        for backward compatibility with a renamed agent kind.
     """
 
     _ALLOWED_KEYS: AllowedKeys = frozenset(
         {
             "config_klass",
+            "kind",
             "wrapper_klass",
             "registered_func",
         }
     )
+    _KEY_FIELD: KeyField = "kind"
 
-    @property
-    def kind(self) -> str:
-        return self.config_klass.kind
+    kind: str | None = None
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -354,11 +444,26 @@ class SecretSourceMeta(_ConfigKlassOnlyMeta):
     may still carry 'registered_func' alongside 'config_klass' as
     shorthand: 'InstallationConfigMeta.from_yaml' desugars it into an
     entry here plus one in 'secret_getters'.
+
+    'kind'
+        (optional) the registry key under which 'config_klass' is
+        registered. Defaults to the class' own 'kind'. Supplying it
+        explicitly registers the class under an additional alias, e.g.
+        for backward compatibility with a renamed source kind. Getters
+        are keyed by the same 'kind', so an aliased source needs its own
+        getter registration (the 'registered_func' shorthand supplies
+        one for whichever 'kind' its entry carries).
     """
 
-    @property
-    def kind(self) -> str:
-        return self.config_klass.kind
+    _ALLOWED_KEYS: AllowedKeys = frozenset(
+        {
+            "config_klass",
+            "kind",
+        }
+    )
+    _KEY_FIELD: KeyField = "kind"
+
+    kind: str | None = None
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -440,7 +545,7 @@ class InstallationConfigMeta:
 
     'agent_capability_types'
         a list consisting of strings (importable dotted names of agent
-        capability classes) or `AgentCapabilityMeta' mappings,
+        capability classes) or `AgentCapabilityConfigMeta' mappings,
         defining additional capability types with which agents can be
         configured.
 
@@ -497,7 +602,7 @@ class InstallationConfigMeta:
     ] = ()
     skill_configs: list[str | SkillConfigMeta | ClearMetaRegistry] = ()
     agent_capability_types: list[
-        str | AgentCapabilityMeta | ClearMetaRegistry
+        str | AgentCapabilityConfigMeta | ClearMetaRegistry
     ] = ()
     agent_configs: list[str | AgentConfigMeta | ClearMetaRegistry] = ()
     secret_sources: list[str | SecretSourceMeta | ClearMetaRegistry] = ()
@@ -561,8 +666,12 @@ class InstallationConfigMeta:
                 config_klass = _utils._from_dotted_name(
                     entry["config_klass"],
                 )
+                # Follow the entry's own key: the getter has to land
+                # under the same 'kind' the source is registered as,
+                # alias or not.
+                kind = entry.get("kind", config_klass.kind)
                 desugared.append(
-                    {"kind": config_klass.kind, "func": registered_func},
+                    {"kind": kind, "func": registered_func},
                 )
 
             sources.append(entry)
@@ -620,7 +729,7 @@ class InstallationConfigMeta:
 
             config_dict["agent_capability_types"] = cls._partition_cmrs(
                 config_dict.get("agent_capability_types", ()),
-                config_klass=AgentCapabilityMeta,
+                config_klass=AgentCapabilityConfigMeta,
             )
 
             config_dict["agent_configs"] = cls._partition_cmrs(
@@ -713,6 +822,7 @@ class InstallationConfigMeta:
         for mstw_meta in self.mcp_server_tool_wrappers:
             if mstw_meta.tool_name not in tc_registry:
                 raise WrapperForUnknownToolConfig(
+                    tool_name=mstw_meta.tool_name,
                     tool_config_klass=mstw_meta.config_klass,
                     wrapper_klass=mstw_meta.wrapper_klass,
                 )
@@ -794,17 +904,29 @@ class InstallationConfigMeta:
 
         tc_registry = config_tools.TOOL_CONFIG_CLASSES_BY_TOOL_NAME
         tool_config_entries = first_clear + [
-            _utils._dotted_name(klass) for klass in tc_registry.values()
+            {
+                "tool_name": tool_name,
+                "config_klass": _utils._dotted_name(klass),
+            }
+            for tool_name, klass in tc_registry.items()
         ]
 
         mcptc_registry = config_tools.MCP_TOOLSET_CONFIG_CLASSES_BY_KIND
         mcp_toolset_config_entries = first_clear + [
-            _utils._dotted_name(klass) for klass in mcptc_registry.values()
+            {
+                "kind": kind,
+                "config_klass": _utils._dotted_name(klass),
+            }
+            for kind, klass in mcptc_registry.items()
         ]
 
         mcptw_registry = config_tools.MCP_TOOL_CONFIG_WRAPPERS_BY_TOOL_NAME
         mcp_server_tool_wrapper_entries = first_clear + [
             {
+                "tool_name": tool_name,
+                # The tool config registered under this same key: an
+                # alias and the name it aliases resolve to one class,
+                # but each keeps its own wrapper registration.
                 "config_klass": _utils._dotted_name(
                     tc_registry[tool_name],
                 ),
@@ -815,22 +937,38 @@ class InstallationConfigMeta:
 
         sc_registry = config_skills.SKILL_CONFIG_CLASSES_BY_KIND
         skill_config_entries = first_clear + [
-            _utils._dotted_name(klass) for klass in sc_registry.values()
+            {
+                "kind": kind,
+                "config_klass": _utils._dotted_name(klass),
+            }
+            for kind, klass in sc_registry.items()
         ]
 
-        cap_registry = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME.values()
+        cap_registry = config_agents.AGENT_CAPABILITY_CLASSES_BY_NAME
         capability_type_entries = first_clear + [
-            _utils._dotted_name(klass) for klass in cap_registry
+            {
+                "capability_name": capability_name,
+                "config_klass": _utils._dotted_name(klass),
+            }
+            for capability_name, klass in cap_registry.items()
         ]
 
         ac_registry = config_agents.AGENT_CONFIG_CLASSES_BY_KIND
         agent_config_entries = first_clear + [
-            _utils._dotted_name(klass) for klass in ac_registry.values()
+            {
+                "kind": kind,
+                "config_klass": _utils._dotted_name(klass),
+            }
+            for kind, klass in ac_registry.items()
         ]
 
         ss_registry = config_secrets.SourceClassesByKind
         secret_source_entries = first_clear + [
-            _utils._dotted_name(klass) for klass in ss_registry.values()
+            {
+                "kind": kind,
+                "config_klass": _utils._dotted_name(klass),
+            }
+            for kind, klass in ss_registry.items()
         ]
 
         sg_registry = config_secrets.SECRET_GETTERS_BY_KIND

--- a/tests/unit/config/test_config_meta.py
+++ b/tests/unit/config/test_config_meta.py
@@ -17,6 +17,15 @@ from soliplex.config import secrets as config_secrets
 from soliplex.config import skills as config_skills
 from soliplex.config import tools as config_tools
 
+# A registry key which is not the one 'DummyToolConfig' declares,
+# standing in for a backward-compatibility alias.
+ALIAS_TOOL_NAME = "_test_metaconfig.legacy_dummy_tool"
+ALIAS_TOOLSET_KIND = "legacy-dummy"
+ALIAS_SKILL_KIND = "LegacyDummySkillConfig"
+ALIAS_CAPABILITY_NAME = "LegacyDummyAgentCapability"
+ALIAS_AGENT_KIND = "legacy-dummy-agent"
+ALIAS_SECRET_KIND = "legacy-dummy-secret"
+
 BOGUS_ICMETA_YAML = """\
 meta:
     tool_configs:
@@ -217,7 +226,7 @@ meta:
 
 W_AGENT_CAPABILITY_ICMETA_KW = BARE_ICMETA_KW | {
     "agent_capability_types": [
-        config_meta.AgentCapabilityMeta(
+        config_meta.AgentCapabilityConfigMeta(
             config_klass=_test_metaconfig.DummyAgentCapability
         ),
     ],
@@ -231,7 +240,7 @@ meta:
 W_AGENT_CAPABILITY_W_CLEAR_ICMETA_KW = BARE_ICMETA_KW | {
     "agent_capability_types": [
         config_meta.ClearMetaRegistry(),
-        config_meta.AgentCapabilityMeta(
+        config_meta.AgentCapabilityConfigMeta(
             config_klass=_test_metaconfig.DummyAgentCapability
         ),
     ],
@@ -437,7 +446,7 @@ FULL_ICMETA_KW = {
         ),
     ],
     "agent_capability_types": [
-        config_meta.AgentCapabilityMeta(
+        config_meta.AgentCapabilityConfigMeta(
             config_klass=_test_metaconfig.DummyAgentCapability,
         ),
     ],
@@ -515,6 +524,16 @@ def test__configklassonlymeta_from_yaml_w_extraneous_key():
         )
 
 
+def test__configklassonlymeta_from_yaml_wo_key_field():
+
+    class _TestMeta(config_meta._ConfigKlassOnlyMeta):
+        pass
+
+    tm_meta = _TestMeta.from_yaml("_test_metaconfig.DummyToolConfig")
+
+    assert tm_meta.config_klass is _test_metaconfig.DummyToolConfig
+
+
 @pytest.mark.parametrize(
     "w_source_kw, exp_source",
     [
@@ -554,6 +573,20 @@ def test_toolconfigmeta_from_yaml(w_bare_str):
     assert found.tool_name == _test_metaconfig.DummyToolConfig.tool_name
 
 
+def test_toolconfigmeta_from_yaml_honors_explicit_tool_name():
+    tc_klass = _test_metaconfig.DummyToolConfig
+
+    tc_meta = config_meta.ToolConfigMeta.from_yaml(
+        {
+            "tool_name": ALIAS_TOOL_NAME,
+            "config_klass": "_test_metaconfig.DummyToolConfig",
+        },
+    )
+
+    assert tc_meta.tool_name == ALIAS_TOOL_NAME
+    assert tc_meta.config_klass is tc_klass
+
+
 @pytest.mark.parametrize("w_bare_str", [False, True])
 def test_mcp_toolsetconfigmeta_from_yaml(w_bare_str):
     tool_config_klassname = "_test_metaconfig.DummyToolConfig"
@@ -571,6 +604,20 @@ def test_mcp_toolsetconfigmeta_from_yaml(w_bare_str):
     assert found.kind == _test_metaconfig.DummyToolConfig.kind
 
 
+def test_mcp_toolsetconfigmeta_from_yaml_honors_explicit_kind():
+    mtc_klass = _test_metaconfig.DummyMCP_ToolsetConfig
+
+    mtc_meta = config_meta.MCP_ToolsetConfigMeta.from_yaml(
+        {
+            "kind": ALIAS_TOOLSET_KIND,
+            "config_klass": "_test_metaconfig.DummyMCP_ToolsetConfig",
+        },
+    )
+
+    assert mtc_meta.kind == ALIAS_TOOLSET_KIND
+    assert mtc_meta.config_klass is mtc_klass
+
+
 def test_mcp_servertoolwrapperconfigmeta_from_yaml():
     tool_config_klassname = "_test_metaconfig.DummyToolConfig"
     wrapper_klassname = "_test_metaconfig.DummyMCPWrapper"
@@ -585,6 +632,21 @@ def test_mcp_servertoolwrapperconfigmeta_from_yaml():
     assert found.config_klass is _test_metaconfig.DummyToolConfig
     assert found.wrapper_klass is _test_metaconfig.DummyMCPWrapper
     assert found.tool_name == _test_metaconfig.DummyToolConfig.tool_name
+
+
+def test_mcp_servertoolwrapperconfigmeta_from_yaml_honors_explicit_name():
+    wrapper_klass = _test_metaconfig.DummyMCPWrapper
+
+    mstw_meta = config_meta.MCP_ServerToolWrapperConfigMeta.from_yaml(
+        {
+            "tool_name": ALIAS_TOOL_NAME,
+            "config_klass": "_test_metaconfig.DummyToolConfig",
+            "wrapper_klass": "_test_metaconfig.DummyMCPWrapper",
+        },
+    )
+
+    assert mstw_meta.tool_name == ALIAS_TOOL_NAME
+    assert mstw_meta.wrapper_klass is wrapper_klass
 
 
 @pytest.mark.parametrize("w_bare_str", [False, True])
@@ -604,6 +666,20 @@ def test_skillconfigmeta_from_yaml(w_bare_str):
     assert found.kind == _test_metaconfig.DummySkillConfig.kind
 
 
+def test_skillconfigmeta_from_yaml_honors_explicit_kind():
+    sc_klass = _test_metaconfig.DummySkillConfig
+
+    sc_meta = config_meta.SkillConfigMeta.from_yaml(
+        {
+            "kind": ALIAS_SKILL_KIND,
+            "config_klass": "_test_metaconfig.DummySkillConfig",
+        },
+    )
+
+    assert sc_meta.kind == ALIAS_SKILL_KIND
+    assert sc_meta.config_klass is sc_klass
+
+
 @pytest.mark.parametrize("w_bare_str", [False, True])
 def test_agentcapabilityconfigmeta_from_yaml(w_bare_str):
     capability_klassname = "_test_metaconfig.DummyAgentCapability"
@@ -614,10 +690,24 @@ def test_agentcapabilityconfigmeta_from_yaml(w_bare_str):
     else:
         yaml_config = {"config_klass": capability_klassname}
 
-    found = config_meta.AgentCapabilityMeta.from_yaml(yaml_config)
+    found = config_meta.AgentCapabilityConfigMeta.from_yaml(yaml_config)
 
     assert found.config_klass is exp_cap_klass
     assert found.capability_name == exp_cap_klass.__name__
+
+
+def test_agentcapabilityconfigmeta_from_yaml_honors_explicit_name():
+    cap_klass = _test_metaconfig.DummyAgentCapability
+
+    found = config_meta.AgentCapabilityConfigMeta.from_yaml(
+        {
+            "capability_name": ALIAS_CAPABILITY_NAME,
+            "config_klass": "_test_metaconfig.DummyAgentCapability",
+        },
+    )
+
+    assert found.capability_name == ALIAS_CAPABILITY_NAME
+    assert found.config_klass is cap_klass
 
 
 @pytest.mark.parametrize("w_bare_str", [False, True])
@@ -633,6 +723,20 @@ def test_agentconfigmeta_from_yaml(w_bare_str):
 
     assert found.config_klass is _test_metaconfig.DummyAgentConfig
     assert found.kind == _test_metaconfig.DummyAgentConfig.kind
+
+
+def test_agentconfigmeta_from_yaml_honors_explicit_kind():
+    ac_klass = _test_metaconfig.DummyAgentConfig
+
+    found = config_meta.AgentConfigMeta.from_yaml(
+        {
+            "kind": ALIAS_AGENT_KIND,
+            "config_klass": "_test_metaconfig.DummyAgentConfig",
+        },
+    )
+
+    assert found.kind == ALIAS_AGENT_KIND
+    assert found.config_klass is ac_klass
 
 
 @pytest.mark.parametrize(
@@ -654,6 +758,20 @@ def test_secretsourcemeta_from_yaml(yaml_config):
 
     assert found.config_klass is _test_metaconfig.DummySecretSource
     assert found.kind == _test_metaconfig.DummySecretSource.kind
+
+
+def test_secretsourcemeta_from_yaml_honors_explicit_kind():
+    ss_klass = _test_metaconfig.DummySecretSource
+
+    found = config_meta.SecretSourceMeta.from_yaml(
+        {
+            "kind": ALIAS_SECRET_KIND,
+            "config_klass": "_test_metaconfig.DummySecretSource",
+        },
+    )
+
+    assert found.kind == ALIAS_SECRET_KIND
+    assert found.config_klass is ss_klass
 
 
 def test_secretgetterconfigmeta_from_yaml():
@@ -745,6 +863,32 @@ def test_installationconfigmeta__partition_cmrs(w_entries, exp_entries):
     )
 
     assert found == exp_entries
+
+
+def test_installationconfigmeta__desugar_secret_sources_w_explicit_kind():
+    icm_klass = config_meta.InstallationConfigMeta
+    source_entries = [
+        {
+            "kind": ALIAS_SECRET_KIND,
+            "config_klass": "_test_metaconfig.DummySecretSource",
+            "registered_func": "_test_metaconfig.dummy_secret_getter",
+        },
+    ]
+
+    sources, getters = icm_klass._desugar_secret_sources(source_entries, [])
+
+    assert sources == [
+        {
+            "kind": ALIAS_SECRET_KIND,
+            "config_klass": "_test_metaconfig.DummySecretSource",
+        },
+    ]
+    assert getters == [
+        {
+            "kind": ALIAS_SECRET_KIND,
+            "func": "_test_metaconfig.dummy_secret_getter",
+        },
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1255,6 +1399,218 @@ def test_installationconfigmeta_from_yaml_w_clear(
         )
 
 
+def test_installationconfigmeta_postinit_registers_tool_configs(
+    patched_tool_configs,
+):
+    tc_klass = _test_metaconfig.DummyToolConfig
+    tc_meta = config_meta.ToolConfigMeta(config_klass=tc_klass)
+
+    config_meta.InstallationConfigMeta(tool_configs=[tc_meta])
+
+    assert patched_tool_configs[tc_klass.tool_name] is tc_klass
+
+
+def test_installationconfigmeta_postinit_registers_mcp_toolset_configs(
+    patched_mcp_toolset_configs,
+):
+    mtc_klass = _test_metaconfig.DummyMCP_ToolsetConfig
+    mtc_meta = config_meta.MCP_ToolsetConfigMeta(config_klass=mtc_klass)
+
+    config_meta.InstallationConfigMeta(mcp_toolset_configs=[mtc_meta])
+
+    assert patched_mcp_toolset_configs[mtc_klass.kind] is mtc_klass
+
+
+@pytest.mark.parametrize(
+    "w_tc_registered, expectation",
+    [
+        (False, pytest.raises(config_meta.WrapperForUnknownToolConfig)),
+        (True, contextlib.nullcontext()),
+    ],
+)
+def test_installationconfigmeta_postinit_registers_mcp_tool_wrappers(
+    patched_tool_configs,
+    patched_mcp_tool_wrappers,
+    w_tc_registered,
+    expectation,
+):
+    cfg_klass = _test_metaconfig.DummyToolConfig
+    if w_tc_registered:
+        patched_tool_configs[cfg_klass.tool_name] = cfg_klass
+
+    wrp_klass = _test_metaconfig.DummyMCPWrapper
+    mstw_meta = config_meta.MCP_ServerToolWrapperConfigMeta(
+        config_klass=cfg_klass,
+        wrapper_klass=wrp_klass,
+    )
+
+    with expectation as expected:
+        config_meta.InstallationConfigMeta(
+            mcp_server_tool_wrappers=[mstw_meta],
+        )
+
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert patched_mcp_tool_wrappers[cfg_klass.tool_name] is wrp_klass
+
+
+def test_installationconfigmeta_postinit_rejects_wrapper_w_unknown_name(
+    patched_tool_configs,
+    patched_mcp_tool_wrappers,
+):
+    # The class is registered; the alias it is named under is not. It is
+    # the name which must be known, not the class.
+    cfg_klass = _test_metaconfig.DummyToolConfig
+    patched_tool_configs[cfg_klass.tool_name] = cfg_klass
+    mstw_meta = config_meta.MCP_ServerToolWrapperConfigMeta(
+        tool_name=ALIAS_TOOL_NAME,
+        config_klass=cfg_klass,
+        wrapper_klass=_test_metaconfig.DummyMCPWrapper,
+    )
+
+    with pytest.raises(config_meta.WrapperForUnknownToolConfig) as exc_info:
+        config_meta.InstallationConfigMeta(
+            mcp_server_tool_wrappers=[mstw_meta],
+        )
+
+    assert exc_info.value.tool_name == ALIAS_TOOL_NAME
+    assert exc_info.value.tool_config_klass is cfg_klass
+    assert not patched_mcp_tool_wrappers
+
+
+def test_installationconfigmeta_postinit_registers_skill_configs(
+    patched_skill_configs,
+):
+    sc_klass = _test_metaconfig.DummySkillConfig
+    sc_meta = config_meta.SkillConfigMeta(config_klass=sc_klass)
+
+    config_meta.InstallationConfigMeta(skill_configs=[sc_meta])
+
+    assert patched_skill_configs[sc_klass.kind] is sc_klass
+
+
+def test_installationconfigmeta_postinit_registers_agent_capabilities(
+    patched_agent_capabilities,
+):
+    cap_klass = _test_metaconfig.DummyAgentCapability
+    ac_meta = config_meta.AgentCapabilityConfigMeta(config_klass=cap_klass)
+
+    config_meta.InstallationConfigMeta(agent_capability_types=[ac_meta])
+
+    assert patched_agent_capabilities[cap_klass.__name__] is cap_klass
+
+
+def test_installationconfigmeta_postinit_registers_agent_configs(
+    patched_agent_configs,
+):
+    ac_klass = _test_metaconfig.DummyAgentConfig
+    ac_meta = config_meta.AgentConfigMeta(config_klass=ac_klass)
+
+    config_meta.InstallationConfigMeta(agent_configs=[ac_meta])
+
+    assert patched_agent_configs[ac_klass.kind] is ac_klass
+
+
+def test_installationconfigmeta_postinit_registers_secret_sources(
+    patched_secret_getters,
+    patched_secret_sources,
+):
+    ss_klass = _test_metaconfig.DummySecretSource
+    ss_meta = config_meta.SecretSourceMeta(config_klass=ss_klass)
+
+    config_meta.InstallationConfigMeta(secret_sources=[ss_meta])
+
+    assert patched_secret_sources[ss_klass.kind] is ss_klass
+    assert patched_secret_getters == {}
+
+
+@pytest.mark.parametrize(
+    "w_ss_registered, expectation",
+    [
+        (False, pytest.raises(config_meta.GetterForUnknownSecretSource)),
+        (True, contextlib.nullcontext()),
+    ],
+)
+def test_installationconfigmeta_postinit_registers_secret_getters(
+    patched_secret_getters,
+    patched_secret_sources,
+    w_ss_registered,
+    expectation,
+):
+    ss_klass = _test_metaconfig.DummySecretSource
+    if w_ss_registered:
+        patched_secret_sources[ss_klass.kind] = ss_klass
+
+    ss_getter = _test_metaconfig.dummy_secret_getter
+    sg_meta = config_meta.SecretGetterConfigMeta(
+        kind=ss_klass.kind,
+        func=ss_getter,
+    )
+
+    with expectation as expected:
+        config_meta.InstallationConfigMeta(secret_getters=[sg_meta])
+
+    if not isinstance(expected, pytest.ExceptionInfo):
+        assert patched_secret_getters[ss_klass.kind] is ss_getter
+
+
+def test_installationconfigmeta_postinit_clearing_sources_clears_getters(
+    patched_secret_getters,
+    patched_secret_sources,
+):
+    # A getter cannot outlive the source class it resolves, so the marker
+    # cascades -- exactly as 'tool_configs' clears the wrapper registry.
+    other_klass = _test_metaconfig.DummyToolConfig
+    patched_secret_sources["stale"] = other_klass
+    patched_secret_getters["stale"] = _test_metaconfig.dummy_secret_getter
+
+    ss_klass = _test_metaconfig.DummySecretSource
+    ss_meta = config_meta.SecretSourceMeta(config_klass=ss_klass)
+
+    config_meta.InstallationConfigMeta(
+        secret_sources=[config_meta.ClearMetaRegistry(), ss_meta],
+    )
+
+    assert patched_secret_sources == {ss_klass.kind: ss_klass}
+    assert patched_secret_getters == {}
+
+
+def test_installationconfigmeta_postinit_clears_secret_getters_only(
+    patched_secret_getters,
+    patched_secret_sources,
+):
+    ss_klass = _test_metaconfig.DummySecretSource
+    patched_secret_sources[ss_klass.kind] = ss_klass
+    patched_secret_getters["stale"] = _test_metaconfig.dummy_secret_getter
+
+    ss_getter = _test_metaconfig.dummy_secret_getter
+    sg_meta = config_meta.SecretGetterConfigMeta(
+        kind=ss_klass.kind,
+        func=ss_getter,
+    )
+
+    config_meta.InstallationConfigMeta(
+        secret_getters=[config_meta.ClearMetaRegistry(), sg_meta],
+    )
+
+    assert patched_secret_sources == {ss_klass.kind: ss_klass}
+    assert patched_secret_getters == {ss_klass.kind: ss_getter}
+
+
+def test_installationconfigmeta_postinit_registers_jsonpath_functions(
+    patched_jsonpath_functions,
+):
+    jp_func = _test_metaconfig.dummy_jsonpath_func
+    jf_meta = config_meta.JSONPathFunctionConfigMeta(
+        name=JSONPATH_FUNCTION_NAME,
+        func=jp_func,
+    )
+
+    config_meta.InstallationConfigMeta(jsonpath_functions=[jf_meta])
+
+    env = authz.the_jsonpath_environment
+    assert env.function_extensions[JSONPATH_FUNCTION_NAME] is jp_func
+
+
 @pytest.mark.parametrize("w_jsonpath", [False, True])
 @pytest.mark.parametrize("w_secret_reg", [False, True])
 @pytest.mark.parametrize("w_agent", [False, True])
@@ -1292,12 +1648,16 @@ def test_installationconfigmeta_as_yaml(
         klass = _test_metaconfig.DummyToolConfig
         patched_tool_configs[klass.tool_name] = klass
         expected["tool_configs"].append(
-            "_test_metaconfig.DummyToolConfig",
+            {
+                "tool_name": "_test_metaconfig.dummy_tool",
+                "config_klass": "_test_metaconfig.DummyToolConfig",
+            },
         )
         wrapper_klass = _test_metaconfig.DummyMCPWrapper
         patched_mcp_tool_wrappers[klass.tool_name] = wrapper_klass
         expected["mcp_server_tool_wrappers"].append(
             {
+                "tool_name": "_test_metaconfig.dummy_tool",
                 "config_klass": "_test_metaconfig.DummyToolConfig",
                 "wrapper_klass": "_test_metaconfig.DummyMCPWrapper",
             }
@@ -1307,28 +1667,40 @@ def test_installationconfigmeta_as_yaml(
         klass = _test_metaconfig.DummyMCP_ToolsetConfig
         patched_mcp_toolset_configs[klass.kind] = klass
         expected["mcp_toolset_configs"].append(
-            "_test_metaconfig.DummyMCP_ToolsetConfig",
+            {
+                "kind": "dummy",
+                "config_klass": "_test_metaconfig.DummyMCP_ToolsetConfig",
+            },
         )
 
     if w_skills:
         klass = _test_metaconfig.DummySkillConfig
         patched_skill_configs[klass.kind] = klass
         expected["skill_configs"].append(
-            "_test_metaconfig.DummySkillConfig",
+            {
+                "kind": "DummySkillConfig",
+                "config_klass": "_test_metaconfig.DummySkillConfig",
+            },
         )
 
     if w_capability:
         klass = _test_metaconfig.DummyAgentCapability
         patched_agent_capabilities[klass.__name__] = klass
         expected["agent_capability_types"].append(
-            "_test_metaconfig.DummyAgentCapability",
+            {
+                "capability_name": "DummyAgentCapability",
+                "config_klass": "_test_metaconfig.DummyAgentCapability",
+            },
         )
 
     if w_agent:
         klass = _test_metaconfig.DummyAgentConfig
         patched_agent_configs[klass.kind] = klass
         expected["agent_configs"].append(
-            "_test_metaconfig.DummyAgentConfig",
+            {
+                "kind": "dummy",
+                "config_klass": "_test_metaconfig.DummyAgentConfig",
+            },
         )
 
     if w_secret_reg:
@@ -1338,7 +1710,10 @@ def test_installationconfigmeta_as_yaml(
         patched_secret_sources[klass.kind] = klass
 
         expected["secret_sources"].append(
-            "_test_metaconfig.DummySecretSource",
+            {
+                "kind": "dummy",
+                "config_klass": "_test_metaconfig.DummySecretSource",
+            },
         )
         expected["secret_getters"].append(
             {
@@ -1508,189 +1883,150 @@ def test_installationconfigmeta_as_yaml_round_trips_registries(
     assert after_second == after_first
 
 
-def test_installationconfigmeta_postinit_registers_tool_configs(
+def test_installationconfigmeta_as_yaml_round_trips_tool_config_alias(
     patched_tool_configs,
+    temp_dir,
 ):
     tc_klass = _test_metaconfig.DummyToolConfig
-    tc_meta = config_meta.ToolConfigMeta(config_klass=tc_klass)
+    patched_tool_configs[tc_klass.tool_name] = tc_klass
+    patched_tool_configs[ALIAS_TOOL_NAME] = tc_klass
+    dumped = config_meta.InstallationConfigMeta().as_yaml
 
-    config_meta.InstallationConfigMeta(tool_configs=[tc_meta])
+    config_meta.InstallationConfigMeta.from_yaml(
+        temp_dir / "installation.yaml",
+        dumped,
+    )
 
-    assert patched_tool_configs[tc_klass.tool_name] is tc_klass
+    assert patched_tool_configs == {
+        tc_klass.tool_name: tc_klass,
+        ALIAS_TOOL_NAME: tc_klass,
+    }
 
 
-def test_installationconfigmeta_postinit_registers_mcp_toolset_configs(
+def test_installationconfigmeta_as_yaml_round_trips_toolset_config_alias(
     patched_mcp_toolset_configs,
+    temp_dir,
 ):
     mtc_klass = _test_metaconfig.DummyMCP_ToolsetConfig
-    mtc_meta = config_meta.MCP_ToolsetConfigMeta(config_klass=mtc_klass)
+    patched_mcp_toolset_configs[mtc_klass.kind] = mtc_klass
+    patched_mcp_toolset_configs[ALIAS_TOOLSET_KIND] = mtc_klass
+    dumped = config_meta.InstallationConfigMeta().as_yaml
 
-    config_meta.InstallationConfigMeta(mcp_toolset_configs=[mtc_meta])
+    config_meta.InstallationConfigMeta.from_yaml(
+        temp_dir / "installation.yaml",
+        dumped,
+    )
 
-    assert patched_mcp_toolset_configs[mtc_klass.kind] is mtc_klass
+    assert patched_mcp_toolset_configs == {
+        mtc_klass.kind: mtc_klass,
+        ALIAS_TOOLSET_KIND: mtc_klass,
+    }
 
 
-@pytest.mark.parametrize(
-    "w_tc_registered, expectation",
-    [
-        (False, pytest.raises(config_meta.WrapperForUnknownToolConfig)),
-        (True, contextlib.nullcontext()),
-    ],
-)
-def test_installationconfigmeta_postinit_registers_mcp_tool_wrappers(
+def test_installationconfigmeta_as_yaml_round_trips_tool_wrapper_alias(
     patched_tool_configs,
     patched_mcp_tool_wrappers,
-    w_tc_registered,
-    expectation,
+    temp_dir,
 ):
-    cfg_klass = _test_metaconfig.DummyToolConfig
-    if w_tc_registered:
-        patched_tool_configs[cfg_klass.tool_name] = cfg_klass
+    # The wrapper is registered under the alias *only*: its key is the
+    # thing which has to survive, not the class it wraps.
+    tc_klass = _test_metaconfig.DummyToolConfig
+    wrapper_klass = _test_metaconfig.DummyMCPWrapper
+    patched_tool_configs[tc_klass.tool_name] = tc_klass
+    patched_tool_configs[ALIAS_TOOL_NAME] = tc_klass
+    patched_mcp_tool_wrappers[ALIAS_TOOL_NAME] = wrapper_klass
+    dumped = config_meta.InstallationConfigMeta().as_yaml
 
-    wrp_klass = _test_metaconfig.DummyMCPWrapper
-    mstw_meta = config_meta.MCP_ServerToolWrapperConfigMeta(
-        config_klass=cfg_klass,
-        wrapper_klass=wrp_klass,
+    config_meta.InstallationConfigMeta.from_yaml(
+        temp_dir / "installation.yaml",
+        dumped,
     )
 
-    with expectation as expected:
-        config_meta.InstallationConfigMeta(
-            mcp_server_tool_wrappers=[mstw_meta],
-        )
-
-    if not isinstance(expected, pytest.ExceptionInfo):
-        assert patched_mcp_tool_wrappers[cfg_klass.tool_name] is wrp_klass
+    assert patched_mcp_tool_wrappers == {ALIAS_TOOL_NAME: wrapper_klass}
 
 
-def test_installationconfigmeta_postinit_registers_skill_configs(
+def test_installationconfigmeta_as_yaml_round_trips_skill_config_alias(
     patched_skill_configs,
+    temp_dir,
 ):
     sc_klass = _test_metaconfig.DummySkillConfig
-    sc_meta = config_meta.SkillConfigMeta(config_klass=sc_klass)
+    patched_skill_configs[sc_klass.kind] = sc_klass
+    patched_skill_configs[ALIAS_SKILL_KIND] = sc_klass
+    dumped = config_meta.InstallationConfigMeta().as_yaml
 
-    config_meta.InstallationConfigMeta(skill_configs=[sc_meta])
+    config_meta.InstallationConfigMeta.from_yaml(
+        temp_dir / "installation.yaml",
+        dumped,
+    )
 
-    assert patched_skill_configs[sc_klass.kind] is sc_klass
+    assert patched_skill_configs == {
+        sc_klass.kind: sc_klass,
+        ALIAS_SKILL_KIND: sc_klass,
+    }
 
 
-def test_installationconfigmeta_postinit_registers_agent_capabilities(
+def test_installationconfigmeta_as_yaml_round_trips_capability_alias(
     patched_agent_capabilities,
+    temp_dir,
 ):
     cap_klass = _test_metaconfig.DummyAgentCapability
-    ac_meta = config_meta.AgentCapabilityMeta(config_klass=cap_klass)
+    patched_agent_capabilities[cap_klass.__name__] = cap_klass
+    patched_agent_capabilities[ALIAS_CAPABILITY_NAME] = cap_klass
+    dumped = config_meta.InstallationConfigMeta().as_yaml
 
-    config_meta.InstallationConfigMeta(agent_capability_types=[ac_meta])
+    config_meta.InstallationConfigMeta.from_yaml(
+        temp_dir / "installation.yaml",
+        dumped,
+    )
 
-    assert patched_agent_capabilities[cap_klass.__name__] is cap_klass
+    assert patched_agent_capabilities == {
+        cap_klass.__name__: cap_klass,
+        ALIAS_CAPABILITY_NAME: cap_klass,
+    }
 
 
-def test_installationconfigmeta_postinit_registers_agent_configs(
+def test_installationconfigmeta_as_yaml_round_trips_agent_config_alias(
     patched_agent_configs,
+    temp_dir,
 ):
     ac_klass = _test_metaconfig.DummyAgentConfig
-    ac_meta = config_meta.AgentConfigMeta(config_klass=ac_klass)
+    patched_agent_configs[ac_klass.kind] = ac_klass
+    patched_agent_configs[ALIAS_AGENT_KIND] = ac_klass
+    dumped = config_meta.InstallationConfigMeta().as_yaml
 
-    config_meta.InstallationConfigMeta(agent_configs=[ac_meta])
-
-    assert patched_agent_configs[ac_klass.kind] is ac_klass
-
-
-def test_installationconfigmeta_postinit_registers_secret_sources(
-    patched_secret_getters,
-    patched_secret_sources,
-):
-    ss_klass = _test_metaconfig.DummySecretSource
-    ss_meta = config_meta.SecretSourceMeta(config_klass=ss_klass)
-
-    config_meta.InstallationConfigMeta(secret_sources=[ss_meta])
-
-    assert patched_secret_sources[ss_klass.kind] is ss_klass
-    assert patched_secret_getters == {}
-
-
-@pytest.mark.parametrize(
-    "w_ss_registered, expectation",
-    [
-        (False, pytest.raises(config_meta.GetterForUnknownSecretSource)),
-        (True, contextlib.nullcontext()),
-    ],
-)
-def test_installationconfigmeta_postinit_registers_secret_getters(
-    patched_secret_getters,
-    patched_secret_sources,
-    w_ss_registered,
-    expectation,
-):
-    ss_klass = _test_metaconfig.DummySecretSource
-    if w_ss_registered:
-        patched_secret_sources[ss_klass.kind] = ss_klass
-
-    ss_getter = _test_metaconfig.dummy_secret_getter
-    sg_meta = config_meta.SecretGetterConfigMeta(
-        kind=ss_klass.kind,
-        func=ss_getter,
+    config_meta.InstallationConfigMeta.from_yaml(
+        temp_dir / "installation.yaml",
+        dumped,
     )
 
-    with expectation as expected:
-        config_meta.InstallationConfigMeta(secret_getters=[sg_meta])
+    assert patched_agent_configs == {
+        ac_klass.kind: ac_klass,
+        ALIAS_AGENT_KIND: ac_klass,
+    }
 
-    if not isinstance(expected, pytest.ExceptionInfo):
-        assert patched_secret_getters[ss_klass.kind] is ss_getter
 
-
-def test_installationconfigmeta_postinit_clearing_sources_clears_getters(
-    patched_secret_getters,
+def test_installationconfigmeta_as_yaml_round_trips_secret_source_alias(
     patched_secret_sources,
-):
-    # A getter cannot outlive the source class it resolves, so the marker
-    # cascades -- exactly as 'tool_configs' clears the wrapper registry.
-    other_klass = _test_metaconfig.DummyToolConfig
-    patched_secret_sources["stale"] = other_klass
-    patched_secret_getters["stale"] = _test_metaconfig.dummy_secret_getter
-
-    ss_klass = _test_metaconfig.DummySecretSource
-    ss_meta = config_meta.SecretSourceMeta(config_klass=ss_klass)
-
-    config_meta.InstallationConfigMeta(
-        secret_sources=[config_meta.ClearMetaRegistry(), ss_meta],
-    )
-
-    assert patched_secret_sources == {ss_klass.kind: ss_klass}
-    assert patched_secret_getters == {}
-
-
-def test_installationconfigmeta_postinit_clears_secret_getters_only(
     patched_secret_getters,
-    patched_secret_sources,
+    temp_dir,
 ):
+    # The getter is keyed by the same 'kind' namespace, and validates
+    # against the source registry: an aliased source has to be there for
+    # a getter registered under the alias to survive alongside it.
     ss_klass = _test_metaconfig.DummySecretSource
+    getter = _test_metaconfig.dummy_secret_getter
     patched_secret_sources[ss_klass.kind] = ss_klass
-    patched_secret_getters["stale"] = _test_metaconfig.dummy_secret_getter
+    patched_secret_sources[ALIAS_SECRET_KIND] = ss_klass
+    patched_secret_getters[ALIAS_SECRET_KIND] = getter
+    dumped = config_meta.InstallationConfigMeta().as_yaml
 
-    ss_getter = _test_metaconfig.dummy_secret_getter
-    sg_meta = config_meta.SecretGetterConfigMeta(
-        kind=ss_klass.kind,
-        func=ss_getter,
+    config_meta.InstallationConfigMeta.from_yaml(
+        temp_dir / "installation.yaml",
+        dumped,
     )
 
-    config_meta.InstallationConfigMeta(
-        secret_getters=[config_meta.ClearMetaRegistry(), sg_meta],
-    )
-
-    assert patched_secret_sources == {ss_klass.kind: ss_klass}
-    assert patched_secret_getters == {ss_klass.kind: ss_getter}
-
-
-def test_installationconfigmeta_postinit_registers_jsonpath_functions(
-    patched_jsonpath_functions,
-):
-    jp_func = _test_metaconfig.dummy_jsonpath_func
-    jf_meta = config_meta.JSONPathFunctionConfigMeta(
-        name=JSONPATH_FUNCTION_NAME,
-        func=jp_func,
-    )
-
-    config_meta.InstallationConfigMeta(jsonpath_functions=[jf_meta])
-
-    env = authz.the_jsonpath_environment
-    assert env.function_extensions[JSONPATH_FUNCTION_NAME] is jp_func
+    assert patched_secret_sources == {
+        ss_klass.kind: ss_klass,
+        ALIAS_SECRET_KIND: ss_klass,
+    }
+    assert patched_secret_getters == {ALIAS_SECRET_KIND: getter}


### PR DESCRIPTION
  ... allowing for aliased registrations, e.g. to support backward compatibility (see PR #1299).

- 'config_meta._RegistryKeyMeta' provides machinery, build around a '_KEY_FIELD' class attribute defined by derived classes.

- 'config_meta.ToolConfigMeta' defines 'tool_name' as its registry key field.

- 'config_meta.MCP_ToolsetConfigMeta' defines 'kind' as its registry key field.

- 'config_meta.MCP_ServerToolWrapperConfigMeta' defines 'tool_name' as its registry key field, to match the tool config registration for which the wrapper applies.

- 'config_meta.SkillConfigMeta' defines 'kind' as its registry key field.

- Renamed 'config_meta.AgentCapabilityMeta' -> 'AgentCapabilityConfigMeta' (deprecated backward-compatible import alias remains, with no warning or scheduled removal).

- 'config_meta.AgentCapabilityConfigMeta' defines 'capability_name' as its registry key field:  by default, that is the base class name of the capability (to match pydantic-ai's non-namespaced convention).

- 'config_meta.AgentConfigMeta' defines 'kind' as its registry key field.

- 'config_meta.SecretSourceMeta' defines 'kind' as its registry key. Note that aliased sources require separate source getter registrations, just as aliased tool configs require separate wrapper registrations.

Closes #1300.