### PR TITLE
Explicit defer loading

### DIFF
--- a/docs/config/agents.md
+++ b/docs/config/agents.md
@@ -121,7 +121,13 @@ agent:
   any registered via the
   [`meta.agent_capability_types`](meta.md) stanza.  Capabilities which
   need configuration, or which a room should advertise, are configured as
-  [skills](rooms.md#skill-configuration) instead.
+  [skills](rooms.md#skill-configuration) instead.  `kwargs` reach the
+  capability's constructor, so a model-facing capability's
+  [deferred loading](rooms.md#deferred-loading) is set there as
+  `defer_loading`.  A capability offering the model no tools or
+  instructions is always loaded eagerly, whatever its `kwargs` ask for:
+  there would be nothing to load, and its hooks would not fire until it
+  was.
 
 ### Example Ollama Configuration
 

--- a/docs/config/rooms.md
+++ b/docs/config/rooms.md
@@ -161,8 +161,9 @@ for configuring an agent.
 
 ### Skill Configuration
 
-- `installation_skill_names` (a list of strings, default empty);  if set,
-  names the installation skills which are enabled for the room.
+- `installation_skill_names` (a list, default empty);  if set, names the
+  installation skills which are enabled for the room.  Each entry is a
+  skill name, or a mapping of `name` and `defer_loading`.
 
 - `skill_configs` (a list of mappings, default empty); if set, configure
   native capabilities locally for the room.
@@ -173,6 +174,9 @@ E.g.:
   skills:
     installation_skill_names:
         - "bare-bones"           # a filesystem skill
+
+        - name: "stanzas"        # loaded up front, not on demand
+          defer_loading: false
 
     skill_configs:
 
@@ -190,11 +194,39 @@ E.g.:
   budgets to spend.  Two kinds over *different* databases is fine, as
   above.
 
+#### Deferred Loading
+
+A deferred skill's tools and instructions stay hidden until the model asks
+for them through its `load_capability` tool, which is offered a catalogue
+of every deferred capability's id and description.  That id is the
+capability's own and need not match the skill name which configured it:
+the `haiku.rag.skills.rag` skill is named `rag`, and its capability's id
+is `haiku-rag`.  An undeferred skill's tools and instructions are in front
+of the model from the first request.
+
+Each entry sets `defer_loading` to choose between the two.  The default
+differs by kind:
+
+| Kind | Default |
+| --- | --- |
+| `haiku.rag.skills.rag` | `false` |
+| `haiku.rag.skills.analysis` | `false` |
+| `bwrap_sandbox` | `false` |
+| `entrypoint` | `true` |
+| filesystem skills, named in `installation_skill_names` | `true` |
+
+Defer a skill to keep its instructions out of a room whose agent rarely
+needs them;  the cost is a model request spent loading it when it does.
+Rooms configuring several instruction-heavy skills are what deferral is
+for.
+
+The evidence kinds below take no `defer_loading`:  they contribute no
+tools or instructions, so there is nothing to load, and a deferred
+capability's hooks do not fire until it is loaded.
+
 #### Evidence Skill Configuration Kinds
 
 Two further kinds take no configuration:  naming one is the whole switch.
-Both are hook-only, so they add no tools and neither affects whether the
-room's other capabilities load eagerly or on demand.
 
 - `haiku.rag.skills.evidence_compaction`:  on each request, replaces
   earlier questions' evidence with a capsule of the evidence that was

--- a/src/soliplex/agents.py
+++ b/src/soliplex/agents.py
@@ -144,18 +144,11 @@ def get_default_agent_from_configs(
         if isinstance(capability, HR_VisionCapabilities):
             capability.vision = agent_config.multimodal
 
-    # A single model-facing capability loads eagerly so its tools are visible;
-    #
-    # Multiple stay deferred so the model routes between them via
-    # 'load_capability'.
-    routing_capabilities = [
-        capability
-        for capability in capabilities
-        if _is_routing_capability(capability)
-    ]
-    defer_loading = len(routing_capabilities) > 1
-    for capability in routing_capabilities:
-        capability.defer_loading = defer_loading
+    # A hook-only capability is never deferred:  nothing would load it, and
+    # its hooks only fire once loaded.
+    for capability in capabilities:
+        if not _is_routing_capability(capability):
+            capability.defer_loading = False
 
     return pydantic_ai.Agent(
         model=model,

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -179,6 +179,22 @@ class FilesystemSkillConfig:
     def extra_parameters(self) -> dict[str, pathlib.Path]:
         return {"path": self.path}
 
+    def with_defer_loading(self, defer_loading: bool) -> FilesystemSkillConfig:
+        """A copy whose capability loads as a room asked.
+
+        Installation skill configs are shared between the rooms which name
+        them, so a room's choice cannot be written onto the capability.
+        """
+        if defer_loading == self._capability.defer_loading:
+            return self
+        return dataclasses.replace(
+            self,
+            _capability=dataclasses.replace(
+                self._capability,
+                defer_loading=defer_loading,
+            ),
+        )
+
 
 @dataclasses.dataclass(kw_only=True)
 class _HaikuRAGCapabilityConfig(
@@ -627,10 +643,35 @@ def extract_skill_configs(
 
 
 @dataclasses.dataclass(kw_only=True)
+class InstallationSkillRef:
+    """A room's reference to one of the installation's skills.
+
+    Spelled as a bare name, or as a mapping when the room sets a flag.
+    """
+
+    name: str
+    defer_loading: bool = True
+
+    @classmethod
+    def from_yaml(cls, entry: str | dict):
+        if isinstance(entry, str):
+            return cls(name=entry)
+        return cls(**entry)
+
+    @property
+    def as_yaml(self) -> str | dict:
+        if self.defer_loading:
+            return self.name
+        return {"name": self.name, "defer_loading": self.defer_loading}
+
+
+@dataclasses.dataclass(kw_only=True)
 class RoomSkillsConfig:
     """Select native capabilities for a room."""
 
-    installation_skill_names: list[str] = _default_list_field()
+    installation_skill_names: list[InstallationSkillRef] = (
+        _default_list_field()
+    )
     _skill_configs: SkillConfigMap = _default_dict_field()
     _installation_config: config_installation.InstallationConfig = (
         _no_repr_no_compare_none()
@@ -641,9 +682,9 @@ class RoomSkillsConfig:
     def _check_installation_skills(
         installation_config: config_installation.InstallationConfig,
         config_path: pathlib.Path,
-        config_dict: dict,
+        refs: typing.Sequence[InstallationSkillRef],
     ) -> None:
-        requested = set(config_dict.get("installation_skill_names", ()))
+        requested = {ref.name for ref in refs}
         available = set(installation_config.skill_configs)
         if missing := requested - available:
             raise MissingSkillNames(
@@ -660,11 +701,16 @@ class RoomSkillsConfig:
         config_dict: dict,
     ):
         try:
+            refs = [
+                InstallationSkillRef.from_yaml(entry)
+                for entry in config_dict.get("installation_skill_names", ())
+            ]
             cls._check_installation_skills(
                 installation_config,
                 config_path,
-                config_dict,
+                refs,
             )
+            config_dict["installation_skill_names"] = refs
             config_dict["_skill_configs"] = extract_skill_configs(
                 installation_config,
                 config_path,
@@ -686,7 +732,9 @@ class RoomSkillsConfig:
     def as_yaml(self) -> dict:
         result = {}
         if self.installation_skill_names:
-            result["installation_skill_names"] = self.installation_skill_names
+            result["installation_skill_names"] = [
+                ref.as_yaml for ref in self.installation_skill_names
+            ]
         if self._skill_configs:
             result["skill_configs"] = [
                 config.as_yaml for config in self._skill_configs.values()
@@ -697,8 +745,10 @@ class RoomSkillsConfig:
     def skill_configs(self) -> SkillConfigMap:
         installation_configs = self._installation_config.skill_configs
         return {
-            name: installation_configs[name]
-            for name in self.installation_skill_names
+            ref.name: installation_configs[ref.name].with_defer_loading(
+                ref.defer_loading
+            )
+            for ref in self.installation_skill_names
         } | self._skill_configs
 
     @property

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -257,15 +257,16 @@ class _HaikuRAGCapabilityConfig(
 
     @property
     def as_yaml(self) -> dict:
-        result = {"kind": self.kind}
+        result = {
+            "kind": self.kind,
+            "defer_loading": self.defer_loading,
+        }
         if self.rag_lancedb_stem is not None:
             result["rag_lancedb_stem"] = self.rag_lancedb_stem
         else:
             result["rag_lancedb_override_path"] = str(
                 self.rag_lancedb_override_path
             )
-        if self.defer_loading:
-            result["defer_loading"] = self.defer_loading
         return result
 
     @property
@@ -449,9 +450,8 @@ class BwrapSandboxSkillConfig:
         result = {
             "kind": self.kind,
             "default_environment": self.default_environment,
+            "defer_loading": self.defer_loading,
         }
-        if self.defer_loading:
-            result["defer_loading"] = self.defer_loading
         if self.id is not None:
             result["id"] = self.id
         if self.allowed_environments is not None:
@@ -571,10 +571,12 @@ class EntrypointCapabilityConfig:
 
     @property
     def as_yaml(self) -> dict:
-        result = {"kind": self.kind, "name": self.name, **self.params}
-        if not self.defer_loading:
-            result["defer_loading"] = self.defer_loading
-        return result
+        return {
+            "kind": self.kind,
+            "name": self.name,
+            "defer_loading": self.defer_loading,
+            **self.params,
+        }
 
     @property
     def extra_parameters(self) -> dict[str, typing.Any]:
@@ -660,8 +662,6 @@ class InstallationSkillRef:
 
     @property
     def as_yaml(self) -> str | dict:
-        if self.defer_loading:
-            return self.name
         return {"name": self.name, "defer_loading": self.defer_loading}
 
 

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -192,6 +192,8 @@ class _HaikuRAGCapabilityConfig(
     state_type: typing.ClassVar[type[pydantic.BaseModel]]
     source: typing.ClassVar[SkillKind] = SkillKind.NATIVE
 
+    defer_loading: bool = False
+
     @classmethod
     def from_yaml(
         cls,
@@ -230,7 +232,7 @@ class _HaikuRAGCapabilityConfig(
         return type(self).capability_factory(
             db_path=self.rag_lancedb_path,
             config=self.haiku_rag_config,
-            defer_loading=True,
+            defer_loading=self.defer_loading,
         )
 
     @property
@@ -246,6 +248,8 @@ class _HaikuRAGCapabilityConfig(
             result["rag_lancedb_override_path"] = str(
                 self.rag_lancedb_override_path
             )
+        if self.defer_loading:
+            result["defer_loading"] = self.defer_loading
         return result
 
     @property
@@ -383,6 +387,7 @@ class BwrapSandboxSkillConfig:
     allowed_environments: bwrap_sandbox.AllowedEnvironments = None
     sandbox_config: bs_config.Config = None
     volumes: bs_models.VolumeMap = _default_dict_field()
+    defer_loading: bool = False
 
     @classmethod
     def from_yaml(
@@ -420,6 +425,7 @@ class BwrapSandboxSkillConfig:
             sandbox_config=self.sandbox_config,
             volumes=self.volumes,
             installation_config=self._installation_config,
+            defer_loading=self.defer_loading,
         )
 
     @property
@@ -428,6 +434,8 @@ class BwrapSandboxSkillConfig:
             "kind": self.kind,
             "default_environment": self.default_environment,
         }
+        if self.defer_loading:
+            result["defer_loading"] = self.defer_loading
         if self.id is not None:
             result["id"] = self.id
         if self.allowed_environments is not None:
@@ -475,6 +483,7 @@ class EntrypointCapabilityConfig:
 
     name: str
     params: dict[str, typing.Any] = _default_dict_field()
+    defer_loading: bool = True
 
     def __post_init__(self) -> None:
         # Register the capability's typed AG-UI state feature so the room can
@@ -500,10 +509,13 @@ class EntrypointCapabilityConfig:
         params = dict(config_dict)
         params.pop("kind", None)
         name = params.pop("name", None)
+        # Soliplex's own flag, not one of the plugin's parameters.
+        defer_loading = params.pop("defer_loading", True)
         try:
             return cls(
                 name=name,
                 params=params,
+                defer_loading=defer_loading,
                 _installation_config=installation_config,
                 _config_path=config_path,
             )
@@ -521,7 +533,7 @@ class EntrypointCapabilityConfig:
     @property
     def capability(self) -> ai_capabilities.AbstractCapability:
         return self._module.create_capability(
-            defer_loading=True, **self.params
+            defer_loading=self.defer_loading, **self.params
         )
 
     @property
@@ -543,7 +555,10 @@ class EntrypointCapabilityConfig:
 
     @property
     def as_yaml(self) -> dict:
-        return {"kind": self.kind, "name": self.name, **self.params}
+        result = {"kind": self.kind, "name": self.name, **self.params}
+        if not self.defer_loading:
+            result["defer_loading"] = self.defer_loading
+        return result
 
     @property
     def extra_parameters(self) -> dict[str, typing.Any]:

--- a/src/soliplex/skills/bwrap_sandbox/__init__.py
+++ b/src/soliplex/skills/bwrap_sandbox/__init__.py
@@ -570,11 +570,12 @@ def create_bwrap_sandbox_capability(
     volumes: bs_models.VolumeMap | None = None,
     max_retries: int = 1,
     installation_config=None,  # noqa F821 cycles
+    defer_loading: bool = False,
 ) -> SandboxCapability:
     return SandboxCapability(
         id=id or SKILL_PROPERTIES.name,
         description=SKILL_PROPERTIES.description.strip(),
-        defer_loading=True,
+        defer_loading=defer_loading,
         default_environment=default_environment,
         allowed_environments=allowed_environments,
         sandbox_config=sandbox_config,

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -61,7 +61,9 @@ _order: {_ORDER}
 
 W_NON_HR_SKILLS_ROOM_CONFIG_KW = BARE_ROOM_CONFIG_KW | {
     "skills": config_skills.RoomSkillsConfig(
-        installation_skill_names=[test_skills.SKILL_NAME],
+        installation_skill_names=[
+            config_skills.InstallationSkillRef(name=test_skills.SKILL_NAME),
+        ],
     ),
 }
 W_NON_HR_SKILLS_ROOM_CONFIG_YAML = f"""\
@@ -187,7 +189,9 @@ FULL_ROOM_CONFIG_KW = {
         ),
     },
     "skills": config_skills.RoomSkillsConfig(
-        installation_skill_names=[test_skills.SKILL_NAME],
+        installation_skill_names=[
+            config_skills.InstallationSkillRef(name=test_skills.SKILL_NAME),
+        ],
     ),
 }
 FULL_ROOM_CONFIG_YAML = f"""\
@@ -541,6 +545,7 @@ def test_roomconfig_skill_configs_bare(installation_config):
 
 def test_roomconfig_skill_configs_w_hit(installation_config):
     skill_config = mock.create_autospec(config_skills.FilesystemSkillConfig)
+    skill_config.with_defer_loading.return_value = skill_config
     installation_config.skill_configs = {
         test_skills.SKILL_NAME: skill_config,
         "other_skill": object(),
@@ -585,15 +590,14 @@ def test_roomconfig_rag_db_paths_w_hit(temp_dir, installation_config):
         rag_lancedb_override_path=OVERRIDE_PATH,
         _haiku_rag_config=HR_CONFIG,
     )
-    installation_config.skill_configs = {
-        test_skills.SKILL_NAME: skill_config,
-        "other_skill": object(),
-    }
+    installation_config.skill_configs = {}
 
     room_config_kw = FULL_ROOM_CONFIG_KW.copy()
     room_config_kw["skills"] = dataclasses.replace(
         room_config_kw["skills"],
+        installation_skill_names=[],
         _installation_config=installation_config,
+        _skill_configs={test_skills.SKILL_NAME: skill_config},
     )
     room_config = config_rooms.RoomConfig(
         **room_config_kw,
@@ -623,7 +627,9 @@ def test_roomconfig_has_sandbox_bare(installation_config):
 
 def test_roomconfig_has_sandbox_w_hit(temp_dir, installation_config):
     installation_config.skill_configs = {
-        "other_skill": object(),
+        "other_skill": config_skills.FilesystemSkillConfig.from_capability(
+            test_skills._filesystem_capability(temp_dir / "other_skill")
+        ),
     }
     sandbox_skill_config = config_skills.BwrapSandboxSkillConfig(
         _installation_config=installation_config,
@@ -632,7 +638,10 @@ def test_roomconfig_has_sandbox_w_hit(temp_dir, installation_config):
     room_config_kw = FULL_ROOM_CONFIG_KW.copy()
     room_config_kw["skills"] = dataclasses.replace(
         room_config_kw["skills"],
-        installation_skill_names=list(installation_config.skill_configs),
+        installation_skill_names=[
+            config_skills.InstallationSkillRef(name=name)
+            for name in installation_config.skill_configs
+        ],
         _installation_config=installation_config,
         _skill_configs={sandbox_skill_config.kind: sandbox_skill_config},
     )

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -23,6 +23,18 @@ SKILL_MODEL_NAME = "removed-skill-model"
 SKILL_STATE_NAMESPACE = "removed-skill-state"
 
 
+# Omitted, explicitly true, and explicitly false: the three states each
+# configurable skill kind must carry through to its capability, and back
+# out through 'as_yaml'.
+def _defer_loading_states(default):
+    """The three YAML states, against a kind's own default."""
+    return [
+        ({}, default),
+        ({"defer_loading": True}, True),
+        ({"defer_loading": False}, False),
+    ]
+
+
 def _filesystem_capability(path):
     return cap_fs.FilesystemCapability(
         id=path.name,
@@ -134,6 +146,7 @@ def test_haiku_rag_capability_config(
     assert config.as_yaml == {
         "kind": config.kind,
         "rag_lancedb_override_path": str(db_path),
+        "defer_loading": False,
     }
 
 
@@ -152,6 +165,7 @@ def test_haiku_rag_capability_config_with_stem(
     assert config.as_yaml == {
         "kind": config.kind,
         "rag_lancedb_stem": "example",
+        "defer_loading": False,
     }
 
 
@@ -224,6 +238,40 @@ def test_haiku_rag_capability_config_wraps_yaml_errors(
         )
 
 
+@pytest.mark.parametrize(
+    "w_yaml, exp_defer_loading", _defer_loading_states(False)
+)
+@pytest.mark.parametrize(
+    "config_class",
+    [
+        config_skills.HR_RAG_SkillConfig,
+        config_skills.HR_Analysis_SkillConfig,
+    ],
+)
+def test_haiku_rag_capability_config_defer_loading(
+    temp_dir,
+    installation_config,
+    config_class,
+    w_yaml,
+    exp_defer_loading,
+):
+    db_path = temp_dir / "rag.lancedb"
+    db_path.mkdir()
+    config = config_class.from_yaml(
+        installation_config,
+        temp_dir / "room.yaml",
+        {
+            "kind": config_class.kind,
+            "rag_lancedb_override_path": str(db_path),
+            **w_yaml,
+        },
+    )
+
+    assert config.defer_loading is exp_defer_loading
+    assert config.capability.defer_loading is exp_defer_loading
+    assert config.as_yaml["defer_loading"] is exp_defer_loading
+
+
 def test_bwrap_sandbox_config_registered_kind():
     assert (
         config_skills.SKILL_CONFIG_CLASSES_BY_KIND[
@@ -289,6 +337,7 @@ def test_bwrap_sandbox_config_minimal(installation_config):
     assert config.as_yaml == {
         "kind": bwrap_sandbox.SKILL_PROPERTIES.name,
         "default_environment": "bare",
+        "defer_loading": False,
     }
     assert config.extra_parameters == {"default_environment": "bare"}
 
@@ -323,7 +372,11 @@ def test_bwrap_sandbox_config_as_yaml_round_trips(
             "id": "sandbox-id",
             "default_environment": "python",
             "allowed_environments": ["python"],
-            "sandbox_config": {"max_output_chars": 1234},
+            "sandbox_config": {
+                "environments_pathname": "test-environments",
+                "execution_timeout_seconds": 66.0,
+                "max_output_chars": 1234,
+            },
             "volumes": {
                 "data": {
                     "host_path": str(temp_dir / "volume"),
@@ -355,6 +408,26 @@ def test_bwrap_sandbox_config_wraps_yaml_errors(
                 "volumes": {"data": {"unknown": True}},
             },
         )
+
+
+@pytest.mark.parametrize(
+    "w_yaml, exp_defer_loading", _defer_loading_states(False)
+)
+def test_bwrap_sandbox_config_defer_loading(
+    installation_config,
+    temp_dir,
+    w_yaml,
+    exp_defer_loading,
+):
+    config = config_skills.BwrapSandboxSkillConfig.from_yaml(
+        installation_config,
+        temp_dir / "room.yaml",
+        {"kind": bwrap_sandbox.SKILL_PROPERTIES.name, **w_yaml},
+    )
+
+    assert config.defer_loading is exp_defer_loading
+    assert config.capability.defer_loading is exp_defer_loading
+    assert config.as_yaml["defer_loading"] is exp_defer_loading
 
 
 def test_extract_skill_configs(installation_config, temp_dir):
@@ -443,8 +516,25 @@ def test_room_skills_config_combines_capabilities(
     assert len(config.capabilities) == 3
     assert config.rag_db_paths == {"haiku-rag": str(db_path)}
     assert config.has_sandbox is True
-    assert config.as_yaml["installation_skill_names"] == [SKILL_NAME]
-    assert len(config.as_yaml["skill_configs"]) == 2
+    assert config.as_yaml["installation_skill_names"] == [
+        {"name": SKILL_NAME, "defer_loading": True},
+    ]
+    hrsc_yaml, bws_yaml = config.as_yaml["skill_configs"]
+    assert hrsc_yaml == {
+        "kind": config_skills.HR_RAG_SkillConfig.kind,
+        "rag_lancedb_override_path": str(db_path),
+        "defer_loading": False,
+    }
+    assert bws_yaml == {
+        "kind": bwrap_sandbox.SKILL_PROPERTIES.name,
+        "default_environment": "bare",
+        "sandbox_config": {
+            "environments_pathname": "environments",
+            "execution_timeout_seconds": 30.0,
+            "max_output_chars": 100000,
+        },
+        "defer_loading": False,
+    }
 
 
 def test_empty_room_skills_config(installation_config):
@@ -584,6 +674,7 @@ def test_entrypoint_capability_config_stateful(
         "kind": "entrypoint",
         "name": "my-cap",
         "foo": "bar",
+        "defer_loading": True,
     }
     assert config.capability == {
         "defer_loading": True,
@@ -668,6 +759,34 @@ def test_entrypoint_capability_config_unknown_entry_point(
 
 
 @pytest.mark.parametrize(
+    "w_yaml, exp_defer_loading", _defer_loading_states(True)
+)
+def test_entrypoint_capability_config_defer_loading(
+    monkeypatch,
+    installation_config,
+    temp_dir,
+    w_yaml,
+    exp_defer_loading,
+):
+    _patch_entry_points(monkeypatch, {"my-cap": _stateless_module()})
+    config = config_skills.EntrypointCapabilityConfig.from_yaml(
+        installation_config,
+        temp_dir / "room.yaml",
+        {"kind": "entrypoint", "name": "my-cap", "foo": "bar", **w_yaml},
+    )
+
+    assert config.defer_loading is exp_defer_loading
+    # The flag is Soliplex's, not the plugin's:  it reaches
+    # 'create_capability' as its own argument, never as a parameter.
+    assert config.params == {"foo": "bar"}
+    assert config.capability == {
+        "defer_loading": exp_defer_loading,
+        "params": {"foo": "bar"},
+    }
+    assert config.as_yaml["defer_loading"] is exp_defer_loading
+
+
+@pytest.mark.parametrize(
     "klass, exp_kind, exp_namespace",
     [
         (
@@ -734,100 +853,6 @@ def test_haiku_rag_evidence_skill_config_wraps_yaml_errors(
         )
 
 
-# Omitted, explicitly true, and explicitly false: the three states each
-# configurable skill kind must carry through to its capability, and back
-# out through 'as_yaml'.
-def _defer_loading_states(default):
-    """The three YAML states, against a kind's own default."""
-    return [
-        ({}, default),
-        ({"defer_loading": True}, True),
-        ({"defer_loading": False}, False),
-    ]
-
-
-@pytest.mark.parametrize(
-    "w_yaml, exp_defer_loading", _defer_loading_states(False)
-)
-@pytest.mark.parametrize(
-    "config_class",
-    [
-        config_skills.HR_RAG_SkillConfig,
-        config_skills.HR_Analysis_SkillConfig,
-    ],
-)
-def test_haiku_rag_capability_config_defer_loading(
-    temp_dir,
-    installation_config,
-    config_class,
-    w_yaml,
-    exp_defer_loading,
-):
-    db_path = temp_dir / "rag.lancedb"
-    db_path.mkdir()
-    config = config_class.from_yaml(
-        installation_config,
-        temp_dir / "room.yaml",
-        {
-            "kind": config_class.kind,
-            "rag_lancedb_override_path": str(db_path),
-            **w_yaml,
-        },
-    )
-
-    assert config.defer_loading is exp_defer_loading
-    assert config.capability.defer_loading is exp_defer_loading
-    assert config.as_yaml.get("defer_loading", False) is exp_defer_loading
-
-
-@pytest.mark.parametrize(
-    "w_yaml, exp_defer_loading", _defer_loading_states(False)
-)
-def test_bwrap_sandbox_config_defer_loading(
-    installation_config,
-    temp_dir,
-    w_yaml,
-    exp_defer_loading,
-):
-    config = config_skills.BwrapSandboxSkillConfig.from_yaml(
-        installation_config,
-        temp_dir / "room.yaml",
-        {"kind": bwrap_sandbox.SKILL_PROPERTIES.name, **w_yaml},
-    )
-
-    assert config.defer_loading is exp_defer_loading
-    assert config.capability.defer_loading is exp_defer_loading
-    assert config.as_yaml.get("defer_loading", False) is exp_defer_loading
-
-
-@pytest.mark.parametrize(
-    "w_yaml, exp_defer_loading", _defer_loading_states(True)
-)
-def test_entrypoint_capability_config_defer_loading(
-    monkeypatch,
-    installation_config,
-    temp_dir,
-    w_yaml,
-    exp_defer_loading,
-):
-    _patch_entry_points(monkeypatch, {"my-cap": _stateless_module()})
-    config = config_skills.EntrypointCapabilityConfig.from_yaml(
-        installation_config,
-        temp_dir / "room.yaml",
-        {"kind": "entrypoint", "name": "my-cap", "foo": "bar", **w_yaml},
-    )
-
-    assert config.defer_loading is exp_defer_loading
-    # The flag is Soliplex's, not the plugin's:  it reaches
-    # 'create_capability' as its own argument, never as a parameter.
-    assert config.params == {"foo": "bar"}
-    assert config.capability == {
-        "defer_loading": exp_defer_loading,
-        "params": {"foo": "bar"},
-    }
-    assert config.as_yaml.get("defer_loading", True) is exp_defer_loading
-
-
 @pytest.mark.parametrize(
     "w_entry, exp_name, exp_defer_loading",
     [
@@ -851,7 +876,7 @@ def test_installation_skill_ref_from_yaml(
 @pytest.mark.parametrize(
     "w_defer_loading, exp_yaml",
     [
-        (True, SKILL_NAME),
+        (True, {"name": SKILL_NAME, "defer_loading": True}),
         (False, {"name": SKILL_NAME, "defer_loading": False}),
     ],
 )

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -122,7 +122,7 @@ def test_haiku_rag_capability_config(
     capability = config.capability
     assert isinstance(capability, capability_class)
     assert capability.db_path == db_path
-    assert capability.defer_loading is True
+    assert capability.defer_loading is False
 
     assert config.state_namespace == state_namespace
     assert config.agui_feature_names == (state_namespace,)
@@ -732,3 +732,97 @@ def test_haiku_rag_evidence_skill_config_wraps_yaml_errors(
             temp_dir / "room_config.yaml",
             {"kind": klass.kind, "bogus": "nonesuch"},
         )
+
+
+# Omitted, explicitly true, and explicitly false: the three states each
+# configurable skill kind must carry through to its capability, and back
+# out through 'as_yaml'.
+def _defer_loading_states(default):
+    """The three YAML states, against a kind's own default."""
+    return [
+        ({}, default),
+        ({"defer_loading": True}, True),
+        ({"defer_loading": False}, False),
+    ]
+
+
+@pytest.mark.parametrize(
+    "w_yaml, exp_defer_loading", _defer_loading_states(False)
+)
+@pytest.mark.parametrize(
+    "config_class",
+    [
+        config_skills.HR_RAG_SkillConfig,
+        config_skills.HR_Analysis_SkillConfig,
+    ],
+)
+def test_haiku_rag_capability_config_defer_loading(
+    temp_dir,
+    installation_config,
+    config_class,
+    w_yaml,
+    exp_defer_loading,
+):
+    db_path = temp_dir / "rag.lancedb"
+    db_path.mkdir()
+    config = config_class.from_yaml(
+        installation_config,
+        temp_dir / "room.yaml",
+        {
+            "kind": config_class.kind,
+            "rag_lancedb_override_path": str(db_path),
+            **w_yaml,
+        },
+    )
+
+    assert config.defer_loading is exp_defer_loading
+    assert config.capability.defer_loading is exp_defer_loading
+    assert config.as_yaml.get("defer_loading", False) is exp_defer_loading
+
+
+@pytest.mark.parametrize(
+    "w_yaml, exp_defer_loading", _defer_loading_states(False)
+)
+def test_bwrap_sandbox_config_defer_loading(
+    installation_config,
+    temp_dir,
+    w_yaml,
+    exp_defer_loading,
+):
+    config = config_skills.BwrapSandboxSkillConfig.from_yaml(
+        installation_config,
+        temp_dir / "room.yaml",
+        {"kind": bwrap_sandbox.SKILL_PROPERTIES.name, **w_yaml},
+    )
+
+    assert config.defer_loading is exp_defer_loading
+    assert config.capability.defer_loading is exp_defer_loading
+    assert config.as_yaml.get("defer_loading", False) is exp_defer_loading
+
+
+@pytest.mark.parametrize(
+    "w_yaml, exp_defer_loading", _defer_loading_states(True)
+)
+def test_entrypoint_capability_config_defer_loading(
+    monkeypatch,
+    installation_config,
+    temp_dir,
+    w_yaml,
+    exp_defer_loading,
+):
+    _patch_entry_points(monkeypatch, {"my-cap": _stateless_module()})
+    config = config_skills.EntrypointCapabilityConfig.from_yaml(
+        installation_config,
+        temp_dir / "room.yaml",
+        {"kind": "entrypoint", "name": "my-cap", "foo": "bar", **w_yaml},
+    )
+
+    assert config.defer_loading is exp_defer_loading
+    # The flag is Soliplex's, not the plugin's:  it reaches
+    # 'create_capability' as its own argument, never as a parameter.
+    assert config.params == {"foo": "bar"}
+    assert config.capability == {
+        "defer_loading": exp_defer_loading,
+        "params": {"foo": "bar"},
+    }
+    assert config.as_yaml.get("defer_loading", True) is exp_defer_loading

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -826,3 +826,101 @@ def test_entrypoint_capability_config_defer_loading(
         "params": {"foo": "bar"},
     }
     assert config.as_yaml.get("defer_loading", True) is exp_defer_loading
+
+
+@pytest.mark.parametrize(
+    "w_entry, exp_name, exp_defer_loading",
+    [
+        (SKILL_NAME, SKILL_NAME, True),
+        ({"name": SKILL_NAME}, SKILL_NAME, True),
+        ({"name": SKILL_NAME, "defer_loading": True}, SKILL_NAME, True),
+        ({"name": SKILL_NAME, "defer_loading": False}, SKILL_NAME, False),
+    ],
+)
+def test_installation_skill_ref_from_yaml(
+    w_entry,
+    exp_name,
+    exp_defer_loading,
+):
+    ref = config_skills.InstallationSkillRef.from_yaml(w_entry)
+
+    assert ref.name == exp_name
+    assert ref.defer_loading is exp_defer_loading
+
+
+@pytest.mark.parametrize(
+    "w_defer_loading, exp_yaml",
+    [
+        (True, SKILL_NAME),
+        (False, {"name": SKILL_NAME, "defer_loading": False}),
+    ],
+)
+def test_installation_skill_ref_as_yaml(w_defer_loading, exp_yaml):
+    ref = config_skills.InstallationSkillRef(
+        name=SKILL_NAME,
+        defer_loading=w_defer_loading,
+    )
+
+    assert ref.as_yaml == exp_yaml
+
+
+@pytest.mark.parametrize("w_defer_loading", [True, False])
+def test_room_skills_config_installation_skill_defer_loading(
+    installation_config,
+    temp_dir,
+    w_defer_loading,
+):
+    filesystem = config_skills.FilesystemSkillConfig.from_capability(
+        _filesystem_capability(temp_dir / SKILL_NAME)
+    )
+    installation_config.skill_configs = {SKILL_NAME: filesystem}
+
+    config = config_skills.RoomSkillsConfig.from_yaml(
+        installation_config,
+        temp_dir / "room.yaml",
+        {
+            "installation_skill_names": [
+                {"name": SKILL_NAME, "defer_loading": w_defer_loading},
+            ],
+        },
+    )
+
+    (capability,) = config.capabilities
+    assert capability.defer_loading is w_defer_loading
+
+    # Installation skill configs are shared between rooms:  a room's
+    # choice is a copy, never a write to the discovered capability.
+    assert filesystem.capability.defer_loading is True
+    if w_defer_loading:
+        assert capability is filesystem.capability
+    else:
+        assert capability is not filesystem.capability
+
+
+@pytest.mark.parametrize(
+    "w_entry, exp_cause",
+    [
+        ({"nombre": SKILL_NAME}, TypeError),
+        ({"defer_loading": False}, TypeError),
+        ({"name": "missing"}, config_skills.MissingSkillNames),
+    ],
+)
+def test_room_skills_config_rejects_bad_installation_skill_entry(
+    installation_config,
+    temp_dir,
+    w_entry,
+    exp_cause,
+):
+    filesystem = config_skills.FilesystemSkillConfig.from_capability(
+        _filesystem_capability(temp_dir / SKILL_NAME)
+    )
+    installation_config.skill_configs = {SKILL_NAME: filesystem}
+
+    with pytest.raises(config_exc.FromYamlException) as raised:
+        config_skills.RoomSkillsConfig.from_yaml(
+            installation_config,
+            temp_dir / "room.yaml",
+            {"installation_skill_names": [w_entry]},
+        )
+
+    assert isinstance(raised.value.__cause__, exp_cause)

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -935,7 +935,7 @@ def test_create_bwrap_sandbox_capability(
     assert capability.id == w_kwargs.get(
         "id", skills_bwrap_sandbox.SKILL_PROPERTIES.name
     )
-    assert capability.defer_loading is True
+    assert capability.defer_loading is False
     assert "sandbox" in capability.get_instructions().lower()
     assert capability.get_toolset() is csts.return_value
 
@@ -953,6 +953,19 @@ def test_create_bwrap_sandbox_capability(
     )
 
     csts.assert_called_once_with(**exp_toolset_kw)
+
+
+@pytest.mark.parametrize("w_defer_loading", [True, False])
+@mock.patch("soliplex.skills.bwrap_sandbox.create_sandbox_toolset")
+def test_create_bwrap_sandbox_capability_defer_loading(
+    csts,
+    w_defer_loading,
+):
+    capability = skills_bwrap_sandbox.create_bwrap_sandbox_capability(
+        defer_loading=w_defer_loading,
+    )
+
+    assert capability.defer_loading is w_defer_loading
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -13,7 +13,6 @@ from pydantic_ai import toolsets as ai_toolsets
 from soliplex import agents
 from soliplex import mcp_client
 from soliplex import tools
-from soliplex.capabilities import rag_audit as cap_rag_audit
 from soliplex.config import agents as config_agents
 from soliplex.config import installation as config_installation
 from soliplex.config import tools as config_tools
@@ -262,6 +261,7 @@ def test_get_default_agent_from_configs(
         assert audit_capability.db_paths == {
             "haiku-rag": RAG_LANCEDB_OVERRIDE_PATH
         }
+        assert audit_capability.defer_loading is False
     assert found_capabilities == exp_capabilities
     assert akc_kw["retries"] == exp_retries
 
@@ -377,95 +377,28 @@ def _w_toolset(cap_id: str) -> ai_caps.Capability:
     )
 
 
-@pytest.mark.parametrize("w_audit", [False, True])
+@pytest.mark.parametrize("w_defer_loading", [False, True])
 @pytest.mark.parametrize(
-    "w_caps, exp_defers",
+    "make_capability, is_routing",
     [
-        ([], []),
-        # Single hook cap: don't defer
-        ([hr_caps_compaction.EvidenceCompactionCapability()], False),
-        ([hr_caps_policy.CitationPolicyCapability()], False),
         (
-            # Multiple hook caps: don't defer
-            [
-                hr_caps_compaction.EvidenceCompactionCapability(),
-                hr_caps_policy.CitationPolicyCapability(),
-            ],
-            False,
+            lambda: hr_caps_rag.create_capability(
+                db_path="/tmp/kb.lancedb",
+                config=hr_models.AppConfig(),
+            ),
+            True,
         ),
-        (
-            # Single non-hook cap: don't defer
-            [
-                hr_caps_rag.create_capability(
-                    db_path="/tmp/kb.lancedb",
-                    config=hr_models.AppConfig(),
-                ),
-            ],
-            False,
-        ),
-        (
-            # Single non-hook cap: don't defer, nor hook sibs
-            [
-                hr_caps_rag.create_capability(
-                    db_path="/tmp/kb.lancedb",
-                    config=hr_models.AppConfig(),
-                ),
-                hr_caps_compaction.EvidenceCompactionCapability(),
-                hr_caps_policy.CitationPolicyCapability(),
-            ],
-            False,
-        ),
-        (
-            # Multiple non-hook caps: defer each
-            [
-                hr_caps_rag.create_capability(
-                    db_path="/tmp/foo.lancedb",
-                    config=hr_models.AppConfig(),
-                ),
-                hr_caps_rag.create_capability(
-                    db_path="/tmp/bar.lancedb",
-                    config=hr_models.AppConfig(),
-                ),
-            ],
-            [True, True],
-        ),
-        (
-            [
-                # Multiple non-hook caps: defer each, but not -hook sibs
-                hr_caps_rag.create_capability(
-                    db_path="/tmp/foo.lancedb",
-                    config=hr_models.AppConfig(),
-                ),
-                hr_caps_rag.create_capability(
-                    db_path="/tmp/bar.lancedb",
-                    config=hr_models.AppConfig(),
-                ),
-                hr_caps_compaction.EvidenceCompactionCapability(),
-                hr_caps_policy.CitationPolicyCapability(),
-            ],
-            [True, True, False, False],
-        ),
-        # Capabilities named nowhere in this module, classified by what
-        # they offer the model rather than by their type (#1270).
-        ([_instructions_only("one")], False),
-        ([_instructions_only("one"), _instructions_only("two")], [True, True]),
-        ([_tools_only("one")], False),
-        ([_tools_only("one"), _tools_only("two")], [True, True]),
+        (lambda: _instructions_only("one"), True),
+        (lambda: _tools_only("one"), True),
         # A toolset built elsewhere.
-        ([_w_toolset("one"), _w_toolset("two")], [True, True]),
+        (lambda: _w_toolset("one"), True),
         # Native tools are neither instructions nor a toolset.
-        ([ai_caps.WebSearch(id="one")], False),
-        (
-            [ai_caps.WebSearch(id="one"), ai_caps.WebSearch(id="two")],
-            [True, True],
-        ),
+        (lambda: ai_caps.WebSearch(id="one"), True),
         # Offering nothing to load: hook-only, whatever the type.
-        ([ai_caps.Capability(id="bare")], False),
-        ([ai_caps.Thinking(id="thinking")], False),
-        (
-            [_instructions_only("one"), ai_caps.Capability(id="bare")],
-            False,
-        ),
+        (hr_caps_compaction.EvidenceCompactionCapability, False),
+        (hr_caps_policy.CitationPolicyCapability, False),
+        (lambda: ai_caps.Capability(id="bare"), False),
+        (lambda: ai_caps.Thinking(id="thinking"), False),
     ],
 )
 @mock.patch("soliplex.config.agents.get_model_from_config")
@@ -473,12 +406,12 @@ def _w_toolset(cap_id: str) -> ai_caps.Capability:
 def test_get_default_agent_from_configs_w_caps_defer_loading(
     agent_klass,
     gmfc,
-    w_caps,
-    exp_defers,
-    w_audit,
+    make_capability,
+    is_routing,
+    w_defer_loading,
 ):
-    if exp_defers is False:
-        exp_defers = [False] * len(w_caps)
+    capability = make_capability()
+    capability.defer_loading = w_defer_loading
 
     agent_config = mock.create_autospec(
         config_agents.AgentConfig,
@@ -491,22 +424,9 @@ def test_get_default_agent_from_configs_w_caps_defer_loading(
     agent_config.get_system_prompt.return_value = SYSTEM_PROMPT
 
     capability_config = mock.Mock(
-        capabilities=w_caps,
-        rag_db_paths=(
-            {"haiku-rag": RAG_LANCEDB_OVERRIDE_PATH} if w_audit else {}
-        ),
+        capabilities=[capability],
+        rag_db_paths={},
     )
-
-    exp_caps = w_caps[:]
-
-    if w_audit:
-        exp_caps.append(
-            cap_rag_audit.RAGAccessAuditCapability(
-                id="soliplex-rag-access-audit",
-                db_paths={"haiku-rag": RAG_LANCEDB_OVERRIDE_PATH},
-            )
-        )
-        exp_defers.append(False)
 
     found = agents.get_default_agent_from_configs(
         agent_config=agent_config,
@@ -518,8 +438,8 @@ def test_get_default_agent_from_configs_w_caps_defer_loading(
     assert found is agent_klass.return_value
     agent_klass.assert_called_once()
 
-    for exp_cap, exp_defer in zip(exp_caps, exp_defers, strict=True):
-        assert exp_cap.defer_loading == exp_defer
+    exp_defer = w_defer_loading if is_routing else False
+    assert capability.defer_loading is exp_defer
 
 
 @pytest.mark.parametrize("w_room_capabilities", [False, True])

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -836,7 +836,9 @@ def test_room_from_config_w_fs_skills(
         description=ROOM_DESCRIPTION,
         agent_config=default_agent,
         skills=config_skills.RoomSkillsConfig(
-            installation_skill_names=[SKILL_NAME],
+            installation_skill_names=[
+                config_skills.InstallationSkillRef(name=SKILL_NAME),
+            ],
             _installation_config=room_ic,
         ),
         _installation_config=room_ic,


### PR DESCRIPTION
Replaces the policy which derived capability deferral from how many
"routing" capabilities a room configured.

Deferral is now per-entry configuration. Every `skills.skill_configs`
entry takes `defer_loading`, passed straight to the capability
constructor, and `installation_skill_names` entries may be a mapping to
carry the same flag:

```yaml
skills:
  installation_skill_names:
    - "bare-bones"
    - name: "stanzas"
      defer_loading: false

  skill_configs:
    - kind: "haiku.rag.skills.rag"
      rag_lancedb_stem: "rag"
      defer_loading: true
```

## Defaults

| Kind | `defer_loading` |
| --- | --- |
| `haiku.rag.skills.rag`, `haiku.rag.skills.analysis` | `false` |
| `bwrap_sandbox` | `false` |
| `entrypoint` | `true` |
| filesystem skills, via `installation_skill_names` | `true` |

## Hook-only capabilities

`_is_routing_capability` is kept, no longer to choose a policy but to
enforce an invariant: a capability offering the model no tools or
instructions is never deferred. 

Closes #1297
