### PR TITLE
fix: tolerate bare skill names in 'RoomSkillsConfig'

### DIFF
--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -655,7 +655,9 @@ class InstallationSkillRef:
     defer_loading: bool = True
 
     @classmethod
-    def from_yaml(cls, entry: str | dict):
+    def from_yaml(cls, entry: str | dict | InstallationSkillRef):
+        if isinstance(entry, cls):
+            return entry
         if isinstance(entry, str):
             return cls(name=entry)
         return cls(**entry)
@@ -677,6 +679,14 @@ class RoomSkillsConfig:
         _no_repr_no_compare_none()
     )
     _config_path: pathlib.Path = None
+
+    def __post_init__(self) -> None:
+        # Callers which build the config directly, rather than via
+        # 'from_yaml', may spell the entries as bare names.
+        self.installation_skill_names = [
+            InstallationSkillRef.from_yaml(entry)
+            for entry in self.installation_skill_names
+        ]
 
     @staticmethod
     def _check_installation_skills(

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -685,8 +685,12 @@ def test_roomconfig_has_thread_uploads_w_sandbox(
     else:
         installation_config.threads_upload_path = None
 
+    other_skill_config = mock.create_autospec(
+        config_skills.FilesystemSkillConfig
+    )
+    other_skill_config.with_defer_loading.return_value = other_skill_config
     installation_config.skill_configs = {
-        "other_skill": object(),
+        "other_skill": other_skill_config,
     }
     sandbox_skill_config = config_skills.BwrapSandboxSkillConfig(
         _installation_config=installation_config,
@@ -739,8 +743,12 @@ def test_roomconfig_has_room_uploads_w_sandbox(
     else:
         installation_config.rooms_upload_path = None
 
+    other_skill_config = mock.create_autospec(
+        config_skills.FilesystemSkillConfig
+    )
+    other_skill_config.with_defer_loading.return_value = other_skill_config
     installation_config.skill_configs = {
-        "other_skill": object(),
+        "other_skill": other_skill_config,
     }
     sandbox_skill_config = config_skills.BwrapSandboxSkillConfig(
         _installation_config=installation_config,

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -537,6 +537,36 @@ def test_room_skills_config_combines_capabilities(
     }
 
 
+@pytest.mark.parametrize(
+    "w_entry",
+    [
+        SKILL_NAME,
+        {"name": SKILL_NAME},
+        config_skills.InstallationSkillRef(name=SKILL_NAME),
+    ],
+    ids=["bare-name", "mapping", "ref"],
+)
+def test_room_skills_config_ctor_normalizes_installation_skill_names(
+    installation_config,
+    temp_dir,
+    w_entry,
+):
+    filesystem = config_skills.FilesystemSkillConfig.from_capability(
+        _filesystem_capability(temp_dir / SKILL_NAME)
+    )
+    installation_config.skill_configs = {SKILL_NAME: filesystem}
+
+    config = config_skills.RoomSkillsConfig(
+        installation_skill_names=[w_entry],
+        _installation_config=installation_config,
+    )
+
+    assert config.installation_skill_names == [
+        config_skills.InstallationSkillRef(name=SKILL_NAME),
+    ]
+    assert config.skill_configs == {SKILL_NAME: filesystem}
+
+
 def test_empty_room_skills_config(installation_config):
     config = config_skills.RoomSkillsConfig(
         _installation_config=installation_config


### PR DESCRIPTION
'config.rooms.RoomSkillsConfig.__post_init__' now normalizes 'installation_skill_names' entries through 'InstallationSkillRef.from_yaml', so that callers which build the config directly (rather than via 'from_yaml') may still spell the entries as bare names or mappings.

'InstallationSkillRef.from_yaml' is now idempotent: an entry which is already an instance passes through untouched.

Repair the semantic merge conflict between #1303 (whose upload tests predate the change) and #1305, which left four unit tests failing on 'main' although CI was green for each PR.

Closes #1307.