### PR TITLE
fix: add guardrails to 'bwrap_sandbox' skill

### DIFF
--- a/src/soliplex/skills/bwrap_sandbox/SKILL.md
+++ b/src/soliplex/skills/bwrap_sandbox/SKILL.md
@@ -55,11 +55,30 @@ Do NOT use the sandbox if **any** of these is true:
 - `run_python(script, environment_name=None, timeout=None)` — run a Python
   script. `script` is the full source as one string.
 
-When calling `run` and `run_python`, `environment_name` and `timeout` are both
-optional and fall back to the values this skill was configured with.
-Always pass `environment_name` explicitly, using a name that
-`list_environments` returned — the configured default is not visible to you
-and may not be the environment you want.
+## Environment names come only from `list_environments`
+
+**Never guess an environment name.** The only values `environment_name`
+accepts are the exact `name` strings that a `list_environments` call
+returned **to you, in this conversation**.
+
+- Call `list_environments` before the first `run` or `run_python` of a
+  turn. It is cheap; skipping it is the most common way this skill fails.
+- Every environment name written in this document is a placeholder —
+  `<name from list_environments>` — standing in for a name you have yet to
+  look up. No placeholder names a real environment.
+- A name that appears in a task, a filename, a library you plan to import,
+  or an earlier conversation is not an environment name. Neither is the
+  name of a package: an environment's `name` and its `dependencies` are
+  different things, and are usually spelled differently.
+- Passing a name that was not in the `list_environments` result fails the
+  call. The failure names the environments you may actually use — call
+  `list_environments` and retry with one of those, rather than guessing
+  again.
+
+`environment_name` and `timeout` are both optional and fall back to the
+values this skill was configured with. Always pass `environment_name`
+explicitly: the configured default is not visible to you and may not be
+the environment you want.
 
 ## Workflow
 
@@ -68,9 +87,9 @@ and may not be the environment you want.
 
    ```python
    {
-      "name": "pandas",
-      "description": "Minimal Python with Pandas",
-      "dependencies": ["pandas"],
+      "name": "<name from list_environments>",
+      "description": "<what this environment is for>",
+      "dependencies": ["<installed package>"],
    }
    ```
 
@@ -78,10 +97,11 @@ and may not be the environment you want.
    - If the list is empty, stop and tell the user the skill
      is not configured — do not proceed.
    - If the list contains exactly one environment, use its `name`.
-   - Otherwise, pick the `name` of the first environment whose `dependencies`
-     include a library the task needs (e.g. `pandas` for tabular data,
-     `numpy` for numeric work, `pillow` for images).  If no environments
-     match, use the `name` of the first entry in the list.
+   - Otherwise, compare the task against each entry's `dependencies` —
+     a `pandas` dependency suits tabular data, `numpy` numeric work,
+     `pillow` images — and use the `name` of the first entry that matches.
+     Use the entry's `name`, not the name of the dependency that matched.
+     If no entry matches, use the `name` of the first entry in the list.
 
 2. **List files in both volumes.**  This step is mandatory — do not skip it,
    even if the task seems to involve one volume.  Run both:
@@ -113,7 +133,7 @@ and may not be the environment you want.
 
    ```python
    run(command=["head", "-n", "5", "/sandbox/volumes/thread/orders.csv"],
-       environment_name="<selected-environment>")
+       environment_name="<name from list_environments>")
    ```
 
    (or `["wc", "-l", <path>]`, `["file", <path>]`, etc.).  For anything
@@ -125,7 +145,8 @@ and may not be the environment you want.
    argument to `run_python`:
 
    ```python
-   run_python(script="<python source>", environment_name="<selected-environment>")
+   run_python(script="<python source>",
+              environment_name="<name from list_environments>")
    ```
 
    Write the whole program as a single string, and use real newlines between
@@ -147,7 +168,10 @@ and may not be the environment you want.
    ```
 
 5. **On failure.**
-   - Change exactly one thing per retry.
+   - If the failure says the environment is not available, you guessed a
+     name. Call `list_environments` and retry with a name it returned —
+     do not try a different guess.
+   - Otherwise change exactly one thing per retry.
    - After 3 failed runs, stop. Report the error to the user (paste the
      `Exited with code: <N>` line and any traceback), instead of retrying
      further.
@@ -168,8 +192,10 @@ and may not be the environment you want.
 Task: user uploads `orders.csv` and asks "what's the total order value?".
 A full run looks like:
 
-1. `list_environments()` — shows one environment named `pandas`
-   with `pandas` in its dependencies. Use it.
+1. `list_environments()` — returns exactly one environment, whose
+   `dependencies` include `pandas`. Use that entry's `name`; in step 3 it
+   is written as `<name from list_environments>`, because what the name
+   actually is can only be read off this call's result.
 
 2. `list_volume_files("thread")` — returns
    `["/sandbox/volumes/thread/orders.csv"]`.
@@ -184,7 +210,7 @@ A full run looks like:
    df = pd.read_csv('/sandbox/volumes/thread/orders.csv')
    print(f"Total: {df['amount'].sum():.2f}")
    """,
-       environment_name="pandas",
+       environment_name="<name from list_environments>",
    )
    ```
 

--- a/src/soliplex/skills/bwrap_sandbox/__init__.py
+++ b/src/soliplex/skills/bwrap_sandbox/__init__.py
@@ -31,6 +31,10 @@ SANDBOX_WORKDIR_PATH = SKILL_PROPERTIES.metadata["sandbox_workdir_path"]
 LIST_ENVIRONMENTS_DESCRIPTION = """
 Return a list of information about available sandbox environments
 
+Call this tool before the first ``run`` or ``run_python`` of a turn: \
+their ``environment_name`` argument accepts nothing but the names \
+returned here.
+
 Each entry will contain these fields:
 - 'name' (string) pass this value to the ``run`` and ``run_python`` \
 tools to run the tool in the environment.
@@ -55,6 +59,164 @@ async def skill_list_environments(
         return candidates
 
 
+class UnknownEnvironment(pydantic_ai.ModelRetry):
+    def __init__(self, name, choices):
+        self.name = name
+        self.choices = choices
+        c_list = ", ".join(repr(name) for name in choices)
+        super().__init__(
+            f"{name!r} is not an available sandbox environment. "
+            "Environment names cannot be guessed or copied from examples: "
+            "call 'list_environments' and pass one of the names it returns. "
+            f"Available environments: {c_list}."
+        )
+
+
+class NoEnvironmentsConfigured(pydantic_ai.ToolFailed):
+    def __init__(self, name):
+        self.name = name
+        super().__init__(
+            f"{name!r} is not an available sandbox environment, "
+            "and this room has none configured. "
+            "Tell the user the sandbox skill is not configured."
+        )
+
+
+async def check_environment_name(
+    *,
+    bwrap_sandbox: bs_sandbox.BwrapSandbox,
+    environment_name: str | None,
+    allowed_environments: AllowedEnvironments = None,
+) -> None:
+    """Reject an 'environment_name' the model invented, before anything runs.
+
+    Guards 'run' / 'run_python' against a name the model guessed rather than
+    read from a 'list_environments' result. Without it, an unknown name
+    aborts the whole agent run, and a name which exists but is *not* in
+    'allowed_environments' runs anyway -- 'allowed_environments' otherwise
+    only filters what 'list_environments' reports.
+
+    The two failures differ in whether the model can do anything about them,
+    so they are reported differently. A name outside the choices is fixable
+    by calling 'list_environments' and passing one of them, which is what
+    'ModelRetry' asks for (and matches how 'pydantic_ai' itself reports an
+    unknown *tool* name). A room with no environments at all is the
+    operator's to fix: 'ToolFailed' shows the model a failed call to report
+    rather than one to retry, and spends none of the tool's retry budget.
+
+    'None' passes through unchecked: it selects the environment the skill was
+    configured with, which is the operator's choice rather than the model's.
+    """
+    if environment_name is None:
+        return
+
+    available = [
+        env.name
+        for env in await skill_list_environments(
+            bwrap_sandbox=bwrap_sandbox,
+            allowed_environments=allowed_environments,
+        )
+    ]
+
+    if environment_name in available:
+        return
+
+    if not available:
+        raise NoEnvironmentsConfigured(name=environment_name)
+
+    raise UnknownEnvironment(
+        name=environment_name,
+        choices=available,
+    )
+
+
+def _environment_label(environment_name):
+    """Name the environment a run asked for, without leaking host paths.
+
+    'bubble_sandbox' builds its messages from the resolved filesystem path
+    ("Environment not found: PosixPath('/app/sandbox/environments/...')"),
+    which is meaningless inside the sandbox and not something to put in
+    front of the model. The requested name says the same thing.
+    """
+    if environment_name is None:
+        return "the environment this room uses by default"
+    return f"the {environment_name!r} environment"
+
+
+class EnvironmentMissing(pydantic_ai.ToolFailed):
+    def __init__(self, environment_name):
+        self.environment_name = environment_name
+        super().__init__(
+            f"The sandbox cannot run: {_environment_label(environment_name)} "
+            "is not installed on this server. Report this to the user as a "
+            "sandbox configuration problem; retrying will not fix it."
+        )
+
+
+class EnvironmentNotBuilt(pydantic_ai.ToolFailed):
+    def __init__(self, environment_name):
+        self.environment_name = environment_name
+        super().__init__(
+            f"The sandbox cannot run: {_environment_label(environment_name)} "
+            "is installed but its Python virtualenv is missing. Report this "
+            "to the user as a sandbox configuration problem; retrying will "
+            "not fix it."
+        )
+
+
+class EnvironmentNameInvalid(pydantic_ai.ToolFailed):
+    def __init__(self, environment_name):
+        self.environment_name = environment_name
+        super().__init__(
+            f"The sandbox cannot run: {_environment_label(environment_name)} "
+            "is not a usable environment name. Report this to the user as a "
+            "sandbox configuration problem; retrying will not fix it."
+        )
+
+
+class SandboxUnavailable(pydantic_ai.ToolFailed):
+    def __init__(self, environment_name, reason):
+        self.environment_name = environment_name
+        self.reason = reason
+        super().__init__(
+            "The sandbox could not be started in "
+            f"{_environment_label(environment_name)}: {reason}. Report this "
+            "to the user; retrying will not fix it."
+        )
+
+
+# 'bubble_sandbox' reports a bad environment name with 'ValueError' and
+# 'FileNotFoundError' subclasses, not 'RuntimeError'; letting one escape
+# aborts the agent run (soliplex#1306) instead of handing the model an
+# error it can act on.
+EXECUTION_ERRORS = (
+    RuntimeError,
+    OSError,
+    bs_config.InvalidEnvironmentName,
+)
+
+
+def translate_execution_error(exc, *, environment_name):
+    """Return the error the model should see for a failed sandbox start.
+
+    Every case here is the operator's to fix rather than the model's --
+    'check_environment_name' has already rejected any name the model could
+    have chosen differently -- so each maps to a 'ToolFailed' subclass: the
+    model sees a failed call to report, spends none of the tool's retry
+    budget, and is told plainly that retrying will not help.
+    """
+    if isinstance(exc, bs_config.EnvironmentNotFound):
+        return EnvironmentMissing(environment_name)
+
+    if isinstance(exc, bs_config.EnvironmentNotInitialized):
+        return EnvironmentNotBuilt(environment_name)
+
+    if isinstance(exc, bs_config.InvalidEnvironmentName):
+        return EnvironmentNameInvalid(environment_name)
+
+    return SandboxUnavailable(environment_name, str(exc))
+
+
 RUN_DESCRIPTION = f"""\
 Run a shell command inside the bubblewrap sandbox.
 
@@ -69,8 +231,10 @@ pass ``command`` as a single string; it is run via "sh -c".
 - Otherwise pass ``command`` as a list of strings: the executable name \
 or path first, then one element per argument. This form needs no \
 quoting and is the safer default.
-- ``environment_name`` selects the environment to run in; omit it to \
-use the configured default. Call ``list_environments`` for the choices.
+- ``environment_name`` selects the environment to run in. Pass only a \
+``name`` that ``list_environments`` returned in this conversation -- \
+never a guessed name, a package name, or a name copied from an example. \
+Omit it to use the configured default.
 - ``timeout`` caps the run in seconds; omit it to use the configured \
 default.
 - Paths must be absolute and sandbox-visible: read inputs from \
@@ -159,8 +323,11 @@ async def skill_run(
             timeout=timeout,
             extra_volumes=extra_volumes,
         )
-    except RuntimeError as e:
-        return f"Error: {e}"
+    except EXECUTION_ERRORS as exc:
+        raise translate_execution_error(
+            exc,
+            environment_name=environment_name,
+        ) from exc
 
     output = result.output
     if result.truncated:
@@ -182,9 +349,10 @@ Do NOT pass shell commands — use the ``run`` tool for those.
 - Pass a complete, self-contained Python script as the ``script`` string.
 - The script runs via the Python interpreter built into the chosen \
 environment, with access to its pre-installed packages.
-- Use ``list_environments`` first to discover available environments \
-and their installed packages. ``environment_name`` selects one; omit \
-it to use the configured default.
+- Call ``list_environments`` first to discover available environments \
+and their installed packages. ``environment_name`` must be one of the \
+``name`` values it returned -- never a guessed name, a package name, or \
+a name copied from an example. Omit it to use the configured default.
 - ``timeout`` caps the run in seconds; omit it to use the configured \
 default.
 - Print results to stdout — the output is captured and returned.
@@ -235,8 +403,11 @@ async def skill_run_python(
             timeout=timeout,
             extra_volumes=extra_volumes,
         )
-    except RuntimeError as e:
-        return f"Error: {e}"
+    except EXECUTION_ERRORS as exc:
+        raise translate_execution_error(
+            exc,
+            environment_name=environment_name,
+        ) from exc
 
     output = result.output
     if result.truncated:
@@ -434,6 +605,12 @@ def create_sandbox_toolset(
         environment_name: str | None = None,
         timeout: float | None = None,  # seconds
     ) -> str:
+        await check_environment_name(
+            bwrap_sandbox=bwrap_sandbox,
+            environment_name=environment_name,
+            allowed_environments=allowed_environments,
+        )
+
         deps = ctx.deps
         workdir = get_workdir(
             workdirs_path,
@@ -486,6 +663,12 @@ def create_sandbox_toolset(
         environment_name: str | None = None,
         timeout: float | None = None,  # seconds
     ) -> str:
+        await check_environment_name(
+            bwrap_sandbox=bwrap_sandbox,
+            environment_name=environment_name,
+            allowed_environments=allowed_environments,
+        )
+
         deps = ctx.deps
         workdir = get_workdir(
             workdirs_path,

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -4,6 +4,7 @@ import pathlib
 import uuid
 from unittest import mock
 
+import pydantic_ai
 import pytest
 from bubble_sandbox import config as bs_config
 from bubble_sandbox import models as bs_models
@@ -36,6 +37,28 @@ ANOTHER_ENVIRONMENT = mock.create_autospec(bs_models.EnvironmentInfo)
 ANOTHER_ENVIRONMENT.name = "another"  # mock quirk
 
 ALL_ENVIRONMENTS = [ONE_ENVIRONMENT, ANOTHER_ENVIRONMENT]
+
+# 'bubble_sandbox' signals a bad environment name with a 'ValueError' or a
+# 'FileNotFoundError' subclass rather than a 'RuntimeError'. Each must come
+# back as an error string the model can act on: one escaping the tool aborts
+# the whole agent run (soliplex#1306).
+EXECUTION_ERROR_CASES = [
+    (
+        bs_config.EnvironmentNotFound(pathlib.Path("/environments/pandas")),
+        skills_bwrap_sandbox.EnvironmentMissing,
+    ),
+    (
+        bs_config.EnvironmentNotInitialized(
+            "one", pathlib.Path("/environments/one/.venv/bin/python")
+        ),
+        skills_bwrap_sandbox.EnvironmentNotBuilt,
+    ),
+    (
+        bs_config.InvalidEnvironmentName("../escape"),
+        skills_bwrap_sandbox.EnvironmentNameInvalid,
+    ),
+    (RuntimeError("test"), skills_bwrap_sandbox.SandboxUnavailable),
+]
 
 
 @pytest.fixture
@@ -150,6 +173,80 @@ async def test_skill_list_environments(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
+    "w_environments, w_name, w_allowed",
+    [
+        (ALL_ENVIRONMENTS, None, None),
+        (ALL_ENVIRONMENTS, "one", None),
+        (ALL_ENVIRONMENTS, "one", ["one"]),
+    ],
+)
+async def test_check_environment_name_w_usable_name(
+    bwrap_sandbox,
+    w_environments,
+    w_name,
+    w_allowed,
+):
+    bwrap_sandbox.config.list_environments.return_value = w_environments
+
+    found = await skills_bwrap_sandbox.check_environment_name(
+        bwrap_sandbox=bwrap_sandbox,
+        environment_name=w_name,
+        allowed_environments=w_allowed,
+    )
+
+    assert found is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "w_name, w_allowed, exp_choices",
+    [
+        # A name the room does not allow is refused even though it exists:
+        # 'allowed_environments' otherwise only filters 'list_environments'.
+        ("another", ["one"], ["one"]),
+        ("pandas", None, ["one", "another"]),
+    ],
+)
+async def test_check_environment_name_w_guessed_name(
+    bwrap_sandbox,
+    w_name,
+    w_allowed,
+    exp_choices,
+):
+    bwrap_sandbox.config.list_environments.return_value = ALL_ENVIRONMENTS
+
+    with pytest.raises(pydantic_ai.ModelRetry) as exc_info:
+        await skills_bwrap_sandbox.check_environment_name(
+            bwrap_sandbox=bwrap_sandbox,
+            environment_name=w_name,
+            allowed_environments=w_allowed,
+        )
+
+    assert isinstance(exc_info.value, skills_bwrap_sandbox.UnknownEnvironment)
+    assert exc_info.value.name == w_name
+    assert exc_info.value.choices == exp_choices
+
+
+@pytest.mark.anyio
+async def test_check_environment_name_wo_any_environment(bwrap_sandbox):
+    bwrap_sandbox.config.list_environments.return_value = []
+
+    with pytest.raises(pydantic_ai.ToolFailed) as exc_info:
+        await skills_bwrap_sandbox.check_environment_name(
+            bwrap_sandbox=bwrap_sandbox,
+            environment_name="pandas",
+            allowed_environments=None,
+        )
+
+    assert isinstance(
+        exc_info.value,
+        skills_bwrap_sandbox.NoEnvironmentsConfigured,
+    )
+    assert exc_info.value.name == "pandas"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
     "volume, expected",
     [
         ("thread", [f"{SANDBOX_VOLUMES_PATH}/thread/thread_file.txt"]),
@@ -197,7 +294,6 @@ async def test_skill_list_volume_files_wo_configured_path(volume):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("w_att_rte", [False, True])
 @pytest.mark.parametrize("w_exit_code", [0, None, 42])
 @pytest.mark.parametrize("w_truncated", [False, True])
 @pytest.mark.parametrize(
@@ -207,32 +303,27 @@ async def test_skill_list_volume_files_wo_configured_path(volume):
         (["/bin/true"], ["/bin/true"]),
     ],
 )
-async def test_skill_run_w_errors_truncation(
+async def test_skill_run_w_exit_code_truncation(
     ctx_w_deps,
     bwrap_sandbox,
     w_command,
     exp_cmd_args,
     w_truncated,
     w_exit_code,
-    w_att_rte,
 ):
-    if w_att_rte:
-        bwrap_sandbox.execute.side_effect = RuntimeError("test")
-        expected = "Error: test"
+    bwrap_sandbox.execute.return_value = mock.create_autospec(
+        bs_models.ExecuteResult,
+        output="test output",
+        exit_code=w_exit_code,
+        truncated=w_truncated,
+    )
+    if w_truncated:
+        expected = "test output\n\n... (output truncated)"
     else:
-        bwrap_sandbox.execute.return_value = mock.create_autospec(
-            bs_models.ExecuteResult,
-            output="test output",
-            exit_code=w_exit_code,
-            truncated=w_truncated,
-        )
-        if w_truncated:
-            expected = "test output\n\n... (output truncated)"
-        else:
-            expected = "test output"
+        expected = "test output"
 
-        if w_exit_code not in [None, 0]:
-            expected = f"Command failed (exit code {w_exit_code}):\n{expected}"
+    if w_exit_code not in [None, 0]:
+        expected = f"Command failed (exit code {w_exit_code}):\n{expected}"
 
     found = await skills_bwrap_sandbox.skill_run(
         bwrap_sandbox=bwrap_sandbox,
@@ -248,6 +339,28 @@ async def test_skill_run_w_errors_truncation(
         timeout=None,
         extra_volumes=None,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("w_error, exp_klass", EXECUTION_ERROR_CASES)
+async def test_skill_run_w_execution_error(
+    bwrap_sandbox,
+    w_error,
+    exp_klass,
+):
+    bwrap_sandbox.execute.side_effect = w_error
+
+    with pytest.raises(exp_klass) as exc_info:
+        await skills_bwrap_sandbox.skill_run(
+            bwrap_sandbox=bwrap_sandbox,
+            command=["/bin/true"],
+            environment_name="one",
+        )
+
+    assert exc_info.value.__cause__ is w_error
+    assert exc_info.value.environment_name == "one"
+    # The host path 'bubble_sandbox' reports must not reach the model.
+    assert "/environments/" not in exc_info.value.message
 
 
 @pytest.mark.asyncio
@@ -311,33 +424,27 @@ async def test_skill_run_w_extra_args(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("w_att_rte", [False, True])
 @pytest.mark.parametrize("w_exit_code", [0, None, 42])
 @pytest.mark.parametrize("w_truncated", [False, True])
-async def test_skill_run_python_w_errors_truncation(
+async def test_skill_run_python_w_exit_code_truncation(
     ctx_w_deps,
     bwrap_sandbox,
     w_truncated,
     w_exit_code,
-    w_att_rte,
 ):
-    if w_att_rte:
-        bwrap_sandbox.execute_python.side_effect = RuntimeError("test")
-        expected = "Error: test"
+    bwrap_sandbox.execute_python.return_value = mock.create_autospec(
+        bs_models.ExecuteResult,
+        output="test output",
+        exit_code=w_exit_code,
+        truncated=w_truncated,
+    )
+    if w_truncated:
+        expected = "test output\n\n... (output truncated)"
     else:
-        bwrap_sandbox.execute_python.return_value = mock.create_autospec(
-            bs_models.ExecuteResult,
-            output="test output",
-            exit_code=w_exit_code,
-            truncated=w_truncated,
-        )
-        if w_truncated:
-            expected = "test output\n\n... (output truncated)"
-        else:
-            expected = "test output"
+        expected = "test output"
 
-        if w_exit_code not in [None, 0]:
-            expected = f"Command failed (exit code {w_exit_code}):\n{expected}"
+    if w_exit_code not in [None, 0]:
+        expected = f"Command failed (exit code {w_exit_code}):\n{expected}"
 
     found = await skills_bwrap_sandbox.skill_run_python(
         bwrap_sandbox=bwrap_sandbox,
@@ -353,6 +460,50 @@ async def test_skill_run_python_w_errors_truncation(
         timeout=None,
         extra_volumes=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_skill_run_w_execution_error_wo_environment_name(
+    bwrap_sandbox,
+):
+    # The room's configured default is the operator's choice, so the model
+    # is told which environment failed without being handed a name it never
+    # passed -- nor the host path 'bubble_sandbox' names.
+    bwrap_sandbox.execute.side_effect = bs_config.EnvironmentNotFound(
+        pathlib.Path("/environments/bare")
+    )
+
+    with pytest.raises(skills_bwrap_sandbox.EnvironmentMissing) as exc_info:
+        await skills_bwrap_sandbox.skill_run(
+            bwrap_sandbox=bwrap_sandbox,
+            command=["/bin/true"],
+        )
+
+    assert exc_info.value.environment_name is None
+    assert "this room uses by default" in exc_info.value.message
+    assert "/environments/" not in exc_info.value.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("w_error, exp_klass", EXECUTION_ERROR_CASES)
+async def test_skill_run_python_w_execution_error(
+    bwrap_sandbox,
+    w_error,
+    exp_klass,
+):
+    bwrap_sandbox.execute_python.side_effect = w_error
+
+    with pytest.raises(exp_klass) as exc_info:
+        await skills_bwrap_sandbox.skill_run_python(
+            bwrap_sandbox=bwrap_sandbox,
+            script="print('hello')",
+            environment_name="one",
+        )
+
+    assert exc_info.value.__cause__ is w_error
+    assert exc_info.value.environment_name == "one"
+    # The host path 'bubble_sandbox' reports must not reach the model.
+    assert "/environments/" not in exc_info.value.message
 
 
 @pytest.mark.asyncio
@@ -682,7 +833,7 @@ async def test_create_sandbox_toolset_list_volume_files_wo_upload_paths(
     "w_kw",
     [
         {},
-        {"environment_name": "test-environment"},
+        {"environment_name": "one"},
         {"timeout": 17},
     ],
 )
@@ -705,6 +856,9 @@ async def test_create_sandbox_toolset_run(
     w_iconfig,
     audit_records,
 ):
+    bs_klass.return_value.config.list_environments.return_value = (
+        ALL_ENVIRONMENTS
+    )
     if w_iconfig:
         toolset = skills_bwrap_sandbox.create_sandbox_toolset(
             installation_config=i_config,
@@ -793,7 +947,7 @@ async def test_create_sandbox_toolset_run(
     "w_kw",
     [
         {},
-        {"environment_name": "test-environment"},
+        {"environment_name": "one"},
         {"timeout": 17},
     ],
 )
@@ -816,6 +970,9 @@ async def test_create_sandbox_toolset_run_python(
     w_iconfig,
     audit_records,
 ):
+    bs_klass.return_value.config.list_environments.return_value = (
+        ALL_ENVIRONMENTS
+    )
     if w_iconfig:
         toolset = skills_bwrap_sandbox.create_sandbox_toolset(
             installation_config=i_config,
@@ -891,6 +1048,70 @@ async def test_create_sandbox_toolset_run_python(
             ROOM_ID,
             str(THREAD_ID),
         )
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.skills.bwrap_sandbox.skill_run")
+@mock.patch("bubble_sandbox.sandbox.BwrapSandbox")
+async def test_create_sandbox_toolset_run_w_disallowed_environment(
+    bs_klass,
+    skill_run,
+    ctx_w_deps,
+    audit_records,
+):
+    bs_klass.return_value.config.list_environments.return_value = (
+        ALL_ENVIRONMENTS
+    )
+    toolset = skills_bwrap_sandbox.create_sandbox_toolset(
+        allowed_environments=["one"],
+    )
+    tool = toolset.tools["run"]
+
+    with pytest.raises(pydantic_ai.ModelRetry) as exc_info:
+        await tool.function(
+            ctx=ctx_w_deps,
+            command=["/bin/true"],
+            environment_name="another",
+        )
+
+    assert isinstance(exc_info.value, skills_bwrap_sandbox.UnknownEnvironment)
+    assert exc_info.value.name == "another"
+    assert exc_info.value.choices == ["one"]
+
+    skill_run.assert_not_called()
+    assert audit_records == []
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.skills.bwrap_sandbox.skill_run_python")
+@mock.patch("bubble_sandbox.sandbox.BwrapSandbox")
+async def test_create_sandbox_toolset_run_python_w_disallowed_environment(
+    bs_klass,
+    skill_run_python,
+    ctx_w_deps,
+    audit_records,
+):
+    bs_klass.return_value.config.list_environments.return_value = (
+        ALL_ENVIRONMENTS
+    )
+    toolset = skills_bwrap_sandbox.create_sandbox_toolset(
+        allowed_environments=["one"],
+    )
+    tool = toolset.tools["run_python"]
+
+    with pytest.raises(pydantic_ai.ModelRetry) as exc_info:
+        await tool.function(
+            ctx=ctx_w_deps,
+            script="print('hello')",
+            environment_name="another",
+        )
+
+    assert isinstance(exc_info.value, skills_bwrap_sandbox.UnknownEnvironment)
+    assert exc_info.value.name == "another"
+    assert exc_info.value.choices == ["one"]
+
+    skill_run_python.assert_not_called()
+    assert audit_records == []
 
 
 @pytest.mark.parametrize("w_iconfig", [False, True])
@@ -984,9 +1205,10 @@ async def test_create_sandbox_toolset_run_audits_failure(
     audit_records,
 ):
     # An exception escaping the tool body is recorded as a failure and
-    # re-raised (the skill's own 'skill_run' swallows 'RuntimeError', so this
-    # mocks it to raise). The transcript is written before execution, so its
-    # ref still lands on the failure record.
+    # re-raised -- which is now the live path for a sandbox that cannot
+    # start, since 'skill_run' translates those into 'ToolFailed' subclasses
+    # rather than swallowing them. The transcript is written before
+    # execution, so its ref still lands on the failure record.
     skill_run.side_effect = RuntimeError("boom")
     toolset = skills_bwrap_sandbox.create_sandbox_toolset(
         installation_config=i_config,


### PR DESCRIPTION
- Replace examples using "real" environment names in the skill instructions with clear placeholders.  The earlier examples lead some models to guess the name from the example, rather than calling 'list_environments'.

- Enforce that an 'environment_name' passed by the agent is valid for the skill (exists in the environment, and named in 'allowed_environments' if configured.

- Refactor errors returned from the tools to match 'pydantic_ai' patterns:  'ModelRetry' with suggestions to repair the retried request (e.g., including the available environment names); 'TooFailure' for non-retryable errors (sandbox environment misconfigured, etc.).

- Suppress display of host-side environment paths in agent-visible error messages.

Closes #1306.