### PR TITLE
fix: 'config.agents.AgentConfig.llm_model_name'

### DIFF
--- a/docs/config/agents.md
+++ b/docs/config/agents.md
@@ -32,6 +32,11 @@ agent:
 - `model_name`: a string, should be the identifier of an LLM model for the
   agent.
 
+  The value can
+  [interpolate](installation.md#installation-secret-environment-interpolation)
+  installation configuration environment variables, e.g.,
+  `"env:MY_CHAT_MODEL"`.
+
   **NOTE**: this value was previously optional, defaulting to the value
             of the now-removed `DEFAULT_AGENT_MODEL` key in the
             installation environment.

--- a/docs/config/installation.md
+++ b/docs/config/installation.md
@@ -89,6 +89,9 @@ installation secrets:
 The value may embed one or more `env:` markers, resolved from the
 installation environment:
 
+- `model_name`, in the `agent_configs:` stanza of the main installation
+  configuration, or in the `agent_config:` stanza of a completion, room,
+  or skill configuration.
 - `provider_base_url`, in the `agent_configs:` stanza of the main
   installation configuration, or in the `agent_config:` stanza of a
   completion, room, or skill configuration.

--- a/src/soliplex/config/agents.py
+++ b/src/soliplex/config/agents.py
@@ -272,6 +272,16 @@ class AgentConfig:
             pass
 
     @property
+    def llm_model_name(self) -> str | None:
+        model_name = self.model_name
+        i_config = self._installation_config
+
+        if i_config is not None:
+            model_name = i_config.interpolate_environment(model_name)
+
+        return model_name
+
+    @property
     def llm_provider_base_url(self) -> str | None:
         ic = self._installation_config
 
@@ -324,7 +334,7 @@ class AgentConfig:
         return {
             "id": self.id,
             "kind": self.kind,
-            "model_name": self.model_name,
+            "model_name": self.model_name,  # not interpolated
             "retries": self.retries,
             "system_prompt": prompt,
             "model_settings": self.model_settings,
@@ -478,6 +488,7 @@ def get_model_from_config(
     provider_kw = agent_config.llm_provider_kw
 
     model_settings_kw = {}
+    model_name = agent_config.llm_model_name
 
     if agent_config.model_settings:
         model_settings_kw["settings"] = ai_settings.ModelSettings(
@@ -487,7 +498,7 @@ def get_model_from_config(
     if agent_config.provider_type == LLMProviderType.GOOGLE:
         provider = google_providers.GoogleProvider(**provider_kw)
         return google_models.GoogleModel(
-            model_name=agent_config.model_name,
+            model_name=model_name,
             provider=provider,
             **model_settings_kw,
         )
@@ -496,7 +507,7 @@ def get_model_from_config(
         provider_kw["api_key"] = "dummy"
         provider = ollama_providers.OllamaProvider(**provider_kw)
         return openai_models.OpenAIChatModel(
-            model_name=agent_config.model_name,
+            model_name=model_name,
             provider=provider,
             profile=_OPENAI_COMPAT_PROFILE,
             **model_settings_kw,
@@ -510,7 +521,7 @@ def get_model_from_config(
         )
         provider = openai_providers.OpenAIProvider(**provider_kw)
         return openai_models.OpenAIChatModel(
-            model_name=agent_config.model_name,
+            model_name=model_name,
             provider=provider,
             **profile_kw,
             **model_settings_kw,

--- a/src/soliplex/installation.py
+++ b/src/soliplex/installation.py
@@ -178,7 +178,7 @@ class Installation:
                 type_info = found.setdefault(provider_type, {})
                 base_url = agent_config.llm_provider_base_url
                 url_models = type_info.setdefault(base_url, set())
-                url_models.add(agent_config.model_name)
+                url_models.add(agent_config.llm_model_name)
 
         return found
 

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -174,7 +174,7 @@ ConfiguredSkills = dict[str, Skill]
 
 class DefaultAgent(pydantic.BaseModel):
     id: str
-    model_name: str
+    model_name: str | None
     retries: int
     system_prompt: str | None
     provider_type: config_agents.LLMProviderType  # enum, not dataclass
@@ -187,7 +187,7 @@ class DefaultAgent(pydantic.BaseModel):
         llm_provider_kw = agent_config.llm_provider_kw
         return cls(
             id=agent_config.id,
-            model_name=agent_config.model_name,
+            model_name=agent_config.llm_model_name,
             retries=agent_config.retries,
             system_prompt=agent_config.get_system_prompt(),
             provider_type=agent_config.provider_type,

--- a/src/soliplex/quizzes.py
+++ b/src/soliplex/quizzes.py
@@ -52,7 +52,7 @@ def get_quiz_judge_agent(quiz: config_quizzes.QuizConfig):
         model_provider = ollama_providers.OllamaProvider(**llm_provider_kw)
 
     ollama_model = openai_models.OpenAIChatModel(
-        model_name=quiz.judge_agent.model_name,
+        model_name=quiz.judge_agent.llm_model_name,
         provider=model_provider,
     )
 

--- a/tests/unit/config/test_config_agents.py
+++ b/tests/unit/config/test_config_agents.py
@@ -746,6 +746,59 @@ def test_agentconfig_get_system_prompt_w_non_ascii(temp_dir):
 
 @pytest.mark.parametrize("w_iconfig", [False, True])
 @pytest.mark.parametrize(
+    "kw, expected",
+    [
+        ({}, None),
+        (
+            {"model_name": MODEL_NAME},
+            MODEL_NAME,
+        ),
+        (
+            {"model_name": "env:CHAT_MODEL_NAME"},
+            MODEL_NAME,
+        ),
+    ],
+)
+def test_agentconfig_llm_model_name(
+    installation_config,
+    kw,
+    expected,
+    w_iconfig,
+):
+    ic_environ = {
+        "CHAT_MODEL_NAME": MODEL_NAME,
+    }
+
+    def _interpolate_environment(maybe_key):
+        if maybe_key is not None:
+            return (
+                ic_environ[maybe_key[4:]]
+                if maybe_key.startswith("env:")
+                else maybe_key
+            )
+
+    installation_config.interpolate_environment = _interpolate_environment
+
+    if w_iconfig:
+        w_iconfig_kwargs = {"_installation_config": installation_config}
+    else:
+        w_iconfig_kwargs = {}
+        expected = kw.get("model_name")
+
+    aconfig = config_agents.AgentConfig(
+        id="test-agent",
+        system_prompt="You are a test",
+        **w_iconfig_kwargs,
+        **kw,
+    )
+
+    found = aconfig.llm_model_name
+
+    assert found == expected
+
+
+@pytest.mark.parametrize("w_iconfig", [False, True])
+@pytest.mark.parametrize(
     "provider_type, kw, expected",
     [
         (config_agents.LLMProviderType.OLLAMA, {}, OLLAMA_BASE_URL),
@@ -1495,10 +1548,13 @@ def test_get_model_from_config(
     llm_provider_kw,
     w_model_settings,
 ):
+    exp_model_name = f"interpolated-{MODEL}"
+
     agent_config = mock.create_autospec(config_agents.AgentConfig)
     agent_config.kind = "default"
     agent_config.id = AGENT_ID
     agent_config.model_name = MODEL
+    agent_config.llm_model_name = exp_model_name
     agent_config.get_system_prompt.return_value = SYSTEM_PROMPT
     agent_config.model_settings = w_model_settings
     agent_config.provider_type = provider_type
@@ -1510,13 +1566,13 @@ def test_get_model_from_config(
         assert model is google_model_klass.return_value
         if w_model_settings:
             google_model_klass.assert_called_once_with(
-                model_name=MODEL,
+                model_name=exp_model_name,
                 settings=w_model_settings,
                 provider=google_provider_klass.return_value,
             )
         else:
             google_model_klass.assert_called_once_with(
-                model_name=MODEL,
+                model_name=exp_model_name,
                 provider=google_provider_klass.return_value,
             )
         google_provider_klass.assert_called_once_with(**llm_provider_kw)
@@ -1533,7 +1589,7 @@ def test_get_model_from_config(
         if llm_provider_kw.get("base_url"):
             expected_kw["profile"] = config_agents._OPENAI_COMPAT_PROFILE
         oai_model_klass.assert_called_once_with(
-            model_name=MODEL,
+            model_name=exp_model_name,
             provider=oai_provider_klass.return_value,
             **expected_kw,
         )
@@ -1549,7 +1605,7 @@ def test_get_model_from_config(
         if w_model_settings:
             expected_kw["settings"] = w_model_settings
         oai_model_klass.assert_called_once_with(
-            model_name=MODEL,
+            model_name=exp_model_name,
             provider=oll_provider_klass.return_value,
             **expected_kw,
         )

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -266,7 +266,7 @@ def rooms_with_agents(request, room_quizzes):
             id="room-agent",
             provider_type=config_agents.LLMProviderType.OLLAMA,
             llm_provider_base_url=OLLAMA_BASE_URL,
-            model_name="room-model",
+            llm_model_name="room-model",
         )
         room_config = mock.create_autospec(
             config_rooms.RoomConfig,
@@ -290,7 +290,7 @@ def completions_with_agents(request):
             id="completion-agent",
             provider_type=config_agents.LLMProviderType.OLLAMA,
             llm_provider_base_url=OLLAMA_BASE_URL,
-            model_name="completion-model",
+            llm_model_name="completion-model",
         )
         completion_config = mock.create_autospec(
             config_completions.CompletionConfig,
@@ -375,7 +375,7 @@ def test_installation_agent_provider_info(
             url_models = type_urls.setdefault(
                 agent.llm_provider_base_url, set()
             )
-            url_models.add(agent.model_name)
+            url_models.add(agent.llm_model_name)
 
     if standalone_agents["agent_configs"]:
         for agent in standalone_agents["agent_configs"]:
@@ -494,7 +494,7 @@ def test_installation_all_provider_info_wo_already(
             url_models = type_urls.setdefault(
                 agent.llm_provider_base_url, set()
             )
-            url_models.add(agent.model_name)
+            url_models.add(agent.llm_model_name)
 
     if standalone_agents["agent_configs"]:
         for agent in standalone_agents["agent_configs"]:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -527,6 +527,14 @@ def installation_config():
 
 
 @pytest.mark.parametrize(
+    "agent_model_kw",
+    [
+        {},
+        {"model_name": AGENT_MODEL},
+        {"model_name": "env:CHAT_MODEL"},
+    ],
+)
+@pytest.mark.parametrize(
     "agent_provider_kw, exp_base",
     [
         (  # Ollama, default URL
@@ -568,14 +576,15 @@ def test_defaultagent_from_config(
     installation_config,
     agent_provider_kw,
     exp_base,
+    agent_model_kw,
 ):
     agent_config = config_agents.AgentConfig(
         id=AGENT_ID,
-        model_name=AGENT_MODEL,
         system_prompt=AGENT_PROMPT,
         _installation_config=installation_config,
         **agent_retries,
         **agent_provider_kw,
+        **agent_model_kw,
     )
 
     if not agent_retries:
@@ -586,7 +595,7 @@ def test_defaultagent_from_config(
     agent_model = models.DefaultAgent.from_config(agent_config)
 
     assert agent_model.id == AGENT_ID
-    assert agent_model.model_name == AGENT_MODEL
+    assert agent_model.model_name == agent_config.llm_model_name
     assert agent_model.retries == exp_retries
     assert agent_model.system_prompt == AGENT_PROMPT
     assert agent_model.provider_base_url == exp_base

--- a/tests/unit/test_quizzes.py
+++ b/tests/unit/test_quizzes.py
@@ -128,7 +128,7 @@ def test_get_quiz_judge_agent(
 
     if is_openai:
         model_klass.assert_called_once_with(
-            model_name=a_quiz.judge_agent.model_name,
+            model_name=a_quiz.judge_agent.llm_model_name,
             provider=openai_provider_klass.return_value,
         )
         openai_provider_klass.assert_called_once_with(
@@ -137,7 +137,7 @@ def test_get_quiz_judge_agent(
         ollama_provider_klass.assert_not_called()
     else:
         model_klass.assert_called_once_with(
-            model_name=a_quiz.judge_agent.model_name,
+            model_name=a_quiz.judge_agent.llm_model_name,
             provider=ollama_provider_klass.return_value,
         )
         openai_provider_klass.assert_not_called()


### PR DESCRIPTION
... interpolates installation environment into configured 'model_name'.

Closes #1311.