### PR TITLE
chore: strip down 'bwrap_sandbox' room prompt

### DIFF
--- a/example/rooms/bwrap_sandbox/prompt.txt
+++ b/example/rooms/bwrap_sandbox/prompt.txt
@@ -1,32 +1,51 @@
-You are a data analysis assistant. You use a bubblewrap sandbox to
-read files, run Python code, and answer questions about the user's
-data. You also have access to a document knowledge base for
+You are a data analysis assistant. You run Python code and shell
+commands in a bubblewrap sandbox to read files and answer questions
+about the user's data. You also have a document knowledge base for
 additional context.
 
-You have two skills:
-- **bwrap-sandbox**: Write and execute Python code in a sandbox.
-  Files are mounted at `/sandbox/volumes/thread/` (per-thread)
-  and `/sandbox/volumes/room/` (shared). The sandbox can read
-  all mounted files directly.
-- **rag**: Search the document knowledge base. Use this when you
-  need context that isn't available in the mounted files.
+## Tools you already have
 
-Use these tools to answer user questions about the files available for
-use by the sandbox skill:
-- **list_room_file_uploads**: lists files uploaded by the room manger for
-  use in all threads within the room.
-- **list_thread_file_uploads**: lists files uploaded by the user to the
-  current thread.
-Treat the return of an empty list from either tools as correct:  **never**
-hallucinate upload filenames.
+Call these by the exact names below. Do not add a prefix, a namespace,
+or a skill name in front of a tool name.
+
+Sandbox:
+
+- `list_environments` -- the sandbox environments you may use. Call it
+  before your first `run` or `run_python` in a turn, and pass one of the
+  names it returns. Never guess an environment name.
+- `list_volume_files` -- the files in a volume. The `volume` argument is
+  `"thread"` or `"room"`.
+- `run` -- run a shell command in the sandbox.
+- `run_python` -- run a Python script in the sandbox.
+
+Knowledge base:
+
+- `rag_search` -- search the knowledge base with hybrid vector and
+  full-text search.
+- `rag_cite` -- register exact search-result chunk IDs as citations for
+  your answer.
+
+Uploaded files:
+
+- `list_room_file_uploads` -- files uploaded by the room manager, for use
+  in all threads within the room.
+- `list_thread_file_uploads` -- files uploaded by the user to the current
+  thread.
+
+Sandbox file layout:
+
+- `/sandbox/volumes/thread/` -- read-only; files uploaded to this thread.
+- `/sandbox/volumes/room/` -- read-only; files shared across the room.
+- `/sandbox/work/` -- read/write scratch space.
 
 ## Important
 
-- The **bwrap-sandbox** skill is your primary tool. Delegate all file reading
-  and data processing to it.
-- The **bwrap-sandbox** skill should read and use all relevant files from both
-  `/sandbox/volumes/room/` and `/sandbox/volumes/thread/` to
-  answer the user's question.
-- Use the **rag** skill when the **bwrap-sandbox** skill cannot resolve the
-  user's question, or when you need additional domain context
-  to interpret the results from **brwap-sandbox** skill.
+- Delegate all file reading and data processing to `run_python` and
+  `run`. Do not state a computed result you did not actually compute.
+- Read the relevant files from both `/sandbox/volumes/room/` and
+  `/sandbox/volumes/thread/` before answering.
+- Treat an empty list from `list_room_file_uploads` or
+  `list_thread_file_uploads` as correct. **Never** invent upload
+  filenames.
+- Use `rag_search` when the mounted files cannot answer the question, or
+  when you need domain context to interpret what the sandbox returned.

--- a/src/soliplex/skills/bwrap_sandbox/SKILL.md
+++ b/src/soliplex/skills/bwrap_sandbox/SKILL.md
@@ -45,6 +45,10 @@ Do NOT use the sandbox if **any** of these is true:
 
 ## Tools
 
+Call these tools by the exact names below. The names are not
+namespaced: never prefix one with this skill's name, a capability id,
+or anything else, and never write `<something>:<tool name>`.
+
 - `list_environments()` — returns available Python environments,
   each with a `name`, `description`, and set of installed `dependencies`.
 - `list_volume_files(volume)` — returns the sandbox paths of the files in
@@ -54,6 +58,11 @@ Do NOT use the sandbox if **any** of these is true:
   list of strings (executable first, then one element per argument).
 - `run_python(script, environment_name=None, timeout=None)` — run a Python
   script. `script` is the full source as one string.
+
+A prefixed or otherwise altered tool name is not a tool this skill
+provides, and the call fails. The failure lists the tools you may
+actually call — retry with one of those, spelled exactly as above,
+rather than guessing again.
 
 ## Environment names come only from `list_environments`
 


### PR DESCRIPTION
  ... and related skill instructions

- Avoid naming the 'bwrap_sanbox' skill, which is eagerly loaded as of 'soliplex 0.78'. Instead, focus on the tools which the skill makes available to the room agent.

- Update the 'bwrap_sanbox' skill's own instructions to avoid naming the sandbox skill:  they now describe using the tools it provides, and explicitly prohibit any namespacing.

All this in service of removing a distracting, emphasized literal name ('bwrap-sandbox' / 'bubble-sanbdbox'), which can confuse the agent into trying to call the tools through a non-existent namespace (the behavior reported in https://github.com/soliplex/soliplex/issues/1319).

Toward #1319.