### PR TITLE
feat: rooms can name several LanceDB databases

### DIFF
--- a/docs/config/rag.md
+++ b/docs/config/rag.md
@@ -48,9 +48,18 @@ names one database the same way, taking its name from the file's stem, so
 `papers.lancedb` is `papers`.  That name is what the room's endpoints
 report as `database`.
 
-Because `haiku.rag` treats `lancedb.uri` and `lancedb.databases` as
-mutually exclusive, naming databases this way clears any inherited
-`uri`.
+A config naming no database of its own reads the ones this file places in
+`lancedb.databases`, under the names it gives them:
+
+```yaml
+lancedb:
+  databases:
+    medic: "s3://bucket/lancedb/medic.lancedb"
+```
+
+This is the only way to read a database that is not a local directory.
+`lancedb.databases` is where `haiku.rag` places every database; a
+configuration carrying the older `lancedb.uri` fails to load.
 
 Candidates from the covered databases are combined by the configured
 reranker.  Without one, they are ordered by cosine similarity to the

--- a/docs/config/rag.md
+++ b/docs/config/rag.md
@@ -37,12 +37,20 @@ reranking:
 ## Searching Several Databases
 
 A RAG skill or tool which configures `rag_databases` (see
-[rooms](rooms.md)) reads them as one set.  Soliplex resolves each entry's
-path and writes the result into the client configuration's
-`lancedb.databases`, as a mapping of name to location, then opens a single
-client over the set.  Because `haiku.rag` treats `lancedb.uri` and
-`lancedb.databases` as mutually exclusive, naming databases this way
-clears any inherited `uri`.
+[rooms](rooms.md)) reads them as one set.  Soliplex resolves the path of
+every database a config names and writes them into the client
+configuration's `lancedb.databases`, as a mapping of name to location,
+then opens a single client over the set.  A config naming one database
+this way is read as one database, not as a set of one.
+
+A config written with `rag_lancedb_stem` or `rag_lancedb_override_path`
+names one database the same way, taking its name from the file's stem, so
+`papers.lancedb` is `papers`.  That name is what the room's endpoints
+report as `database`.
+
+Because `haiku.rag` treats `lancedb.uri` and `lancedb.databases` as
+mutually exclusive, naming databases this way clears any inherited
+`uri`.
 
 Candidates from the covered databases are combined by the configured
 reranker.  Without one, they are ordered by cosine similarity to the

--- a/docs/config/rag.md
+++ b/docs/config/rag.md
@@ -33,3 +33,25 @@ reranking:
     name: "gpt-oss:20b"
     provider: "ollama"
 ```
+
+## Searching Several Databases
+
+A RAG skill or tool which configures `rag_databases` (see
+[rooms](rooms.md)) reads them as one set.  Soliplex resolves each entry's
+path and writes the result into the client configuration's
+`lancedb.databases`, as a mapping of name to location, then opens a single
+client over the set.  Because `haiku.rag` treats `lancedb.uri` and
+`lancedb.databases` as mutually exclusive, naming databases this way
+clears any inherited `uri`.
+
+Candidates from the covered databases are combined by the configured
+reranker.  Without one, they are ordered by cosine similarity to the
+query: the databases in a set share an embedding model, so similarity in
+that one space compares across them, where each database's own retrieval
+scores do not.  A full-text search, which has no query vector, orders by
+retrieval score instead.  A result carries the name of the database it
+came from, never its location.
+
+Chunk IDs are unique within a database but repeat between copies of one,
+so the room's chunk endpoint asks each covered database in turn and the
+first one holding the ID answers.

--- a/docs/config/rooms.md
+++ b/docs/config/rooms.md
@@ -269,6 +269,31 @@ configuring the RAG database and RAG client:
   - `rag_lancedb_override_path`: a string, a pathname, including the
     suffix, of the LanceDB directory.
 
+  - `rag_databases`: a list of mappings, to search several databases at
+    once.  Each entry carries a `name`, plus exactly one of
+    `rag_lancedb_stem` or `rag_lancedb_override_path`, resolved the same
+    way as above.  Names must be unique within the list.
+
+    ```yaml
+    skills:
+      skill_configs:
+        - kind: "haiku.rag.skills.rag"
+          rag_databases:
+            - name: "papers"
+              rag_lancedb_stem: "papers"
+            - name: "wiki"
+              rag_lancedb_override_path: "../wiki.lancedb"
+    ```
+
+    The name is how a database identifies itself outside the
+    configuration: it is what the agent sees as the collection a result
+    came from, what the room's search, document and chunk endpoints
+    return as `database`, and what audit records name.  The location
+    stays in the configuration.
+
+    All the databases in a list must have been written with the same
+    embedding model, since one query is embedded once for all of them.
+
 - `haiku_rag_config`: a path to the `haiku.rag.yaml` file used to configure
   the RAG client.  If not absolute, this path is resolved relative to
   the directory containing the room configuration file.  If passed,
@@ -321,8 +346,11 @@ any additional options.
 
 ## Location of RAG database files
 
-Rooms using the `haiku_chat` agent kind need to be able to find the
-LanceDB database containing the chunks and embeddings extracted by
-Haiku-RAG.  At present, there should be a single database per room,
-named by convention `<stem>.lancedb`, and stored in the `db/rag/`
-subdirectory of the project root.
+Rooms need to be able to find the LanceDB database containing the chunks
+and embeddings extracted by Haiku-RAG.  A database is named by convention
+`<stem>.lancedb`, and stored in the `db/rag/` subdirectory of the project
+root.
+
+A room's RAG skill or tool reads one such database, or several named ones
+through `rag_databases` (see above), in which case a search covers them
+all and each result reports the database it came from.

--- a/docs/config/rooms.md
+++ b/docs/config/rooms.md
@@ -259,7 +259,9 @@ one of kind `haiku.rag.skills.rag` and one of kind
 `haiku.rag.skills.analysis`.  Both of these configurations have options for
 configuring the RAG database and RAG client:
 
-- One of the following (exactly one must be provided):
+- At most one of the following.  A configuration providing none of them
+  reads the databases its `haiku.rag.yaml` places in `lancedb.databases`,
+  which is how a room reads a database that is not a local directory.
 
   - `rag_lancedb_stem`: a string, the "base name" (without path or
     `.lancedb` suffix) of the LanceDB file containing the RAG document
@@ -293,6 +295,16 @@ configuring the RAG database and RAG client:
 
     All the databases in a list must have been written with the same
     embedding model, since one query is embedded once for all of them.
+
+  Naming a database here while the `haiku.rag` configuration read by the
+  room already places one in `lancedb.databases` is two placements for
+  one room, and the room fails when it is used.  The configuration may
+  be the room's own `haiku.rag.yaml` or the installation's, since the
+  room reads the two merged.  Name every database in one place: move the
+  room's own into `lancedb.databases`, or drop whichever side is the
+  duplicate.  A configuration carrying the older `lancedb.uri` fails to
+  load instead, with the replacement spelled out.  `soliplex-cli audit`
+  reports either ahead of time.
 
 - `haiku_rag_config`: a path to the `haiku.rag.yaml` file used to configure
   the RAG client.  If not absolute, this path is resolved relative to

--- a/docs/config/rooms.md
+++ b/docs/config/rooms.md
@@ -272,9 +272,12 @@ configuring the RAG database and RAG client:
     suffix, of the LanceDB directory.
 
   - `rag_databases`: a list of mappings, to search several databases at
-    once.  Each entry carries a `name`, plus exactly one of
-    `rag_lancedb_stem` or `rag_lancedb_override_path`, resolved the same
-    way as above.  Names must be unique within the list.
+    once.  Each entry carries exactly one of `rag_lancedb_stem` or
+    `rag_lancedb_override_path`, resolved the same way as above, plus an
+    optional `name`.  An entry naming none is named for whichever option
+    placed it, so `rag_lancedb_stem: "papers"` and
+    `rag_lancedb_override_path: "../wiki.lancedb"` are `papers` and
+    `wiki`.  Names must be unique within the list.
 
     ```yaml
     skills:
@@ -292,6 +295,12 @@ configuring the RAG database and RAG client:
     came from, what the room's search, document and chunk endpoints
     return as `database`, and what audit records name.  The location
     stays in the configuration.
+
+    `rag_lancedb_stem` and `rag_lancedb_override_path` written directly
+    on the skill or tool are shorthand for a one-entry `rag_databases`,
+    kept for configurations written before the list existed.  They are
+    read into that list as the config loads, so a config written either
+    way behaves the same from there on, and is exported as the list.
 
     All the databases in a list must have been written with the same
     embedding model, since one query is embedded once for all of them.

--- a/example/haiku.rag.yaml
+++ b/example/haiku.rag.yaml
@@ -8,28 +8,45 @@ storage:
   auto_vacuum: true
   vacuum_retention_seconds: 86400
 
-# This section is for configuring LanceDB in various "remote" modes.
-# Leave it commented out to use local filesystem databases.
+# Every database is named here, and its location is a local path or a
+# URI.  Leave the section out to use the default local database.  The
+# name is what results and citations carry, and what a room reports as
+# 'database'; the location stays here.
 #lancedb:
+#  databases:
+#    papers: /path/to/papers.lancedb
+
 # Configure LanceDB Cloud
-# uri: ''
-# api_key: ''
-# region: ''
+#lancedb:
+#  databases:
+#    papers: db://your-database-name
+#  api_key: ''
+#  region: ''
 
 # Configure Amazon S3
 # Use AWS credentials or IAM roles
-# uri: s3://my-bucket/my-table
+#lancedb:
+#  databases:
+#    papers: s3://my-bucket/papers.lancedb
+#  storage_options:
+#    region: us-east-1
 
 # Configure Azure Blob Storage
 # Use Azure credentials
-# uri: az://my-bucket/my-table
+#lancedb:
+#  databases:
+#    papers: az://my-bucket/papers.lancedb
 
 # Google Cloud Storage
 # Use GCP credentials
-# uri: gs://my-bucket/my-table
+#lancedb:
+#  databases:
+#    papers: gs://my-bucket/papers.lancedb
 
 # Configure Hadoop file system
-# uri: hdfs://namenode:port/path/to/table
+#lancedb:
+#  databases:
+#    papers: hdfs://namenode:port/path/to/papers.lancedb
 
 embeddings:
   model:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "fastmcp >= 3.3.0, < 3.4",
     "fakeredis != 2.35.0",  # brownbag
     "greenlet",
-    "haiku.rag-slim >= 0.78.0, < 0.79",
+    "haiku.rag-slim >= 0.82.0, < 0.83",
     "idna >= 3.15",
     "itsdangerous",
     "joserfc >= 1.6.7, < 1.7",  # CVE-2026-48990

--- a/src/soliplex/cli/audit.py
+++ b/src/soliplex/cli/audit.py
@@ -408,6 +408,22 @@ def _iter_room_rag_candidates(room_config):
             yield f"tool:{tool_config.tool_name}", tool_config
 
 
+def _rag_db_probes(source, cfg):
+    """Yield ``(label, cfg)`` for each database a config names.
+
+    A candidate is only known to expose ``haiku_rag_config``, so a config
+    carrying no database at all yields itself and reports its own error
+    from inside the caller's ``try``.
+    """
+    rag_databases = getattr(cfg, "rag_databases", None)
+
+    if rag_databases:
+        for entry in rag_databases:
+            yield f"{source}#{entry.name}", entry
+    else:
+        yield source, cfg
+
+
 def _invalid_room_agui_features(
     the_installation: installation.Installation,
 ) -> dict:
@@ -437,10 +453,11 @@ def _invalid_room_rag_dbs(
         per_room: dict[str, str] = {}
 
         for source, cfg in _iter_room_rag_candidates(room_config):
-            try:
-                _ = cfg.rag_lancedb_path  # property raises
-            except Exception as exc:
-                per_room[source] = str(exc)
+            for label, probe in _rag_db_probes(source, cfg):
+                try:
+                    _ = probe.rag_lancedb_path  # property raises
+                except Exception as exc:
+                    per_room[label] = str(exc)
 
         if per_room:
             rag_errors[room_config.id] = per_room
@@ -505,12 +522,22 @@ def _audit_rooms_section(
             tc_print()
             tc_print("   Haiku Rag DBs")
             for source, cfg in candidates:
-                exc = per_room_rag.get(source)
-                if exc is not None:
-                    tc_print(f"   - {source:20}: ERROR: {exc}")
+                failed = next(
+                    (
+                        (label, per_room_rag[label])
+                        for label, _ in _rag_db_probes(source, cfg)
+                        if label in per_room_rag
+                    ),
+                    None,
+                )
+                if failed is not None:
+                    failed_label, exc = failed
+                    tc_print(f"   - {failed_label:20}: ERROR: {exc}")
                 else:
                     rag = hr_client.HaikuRAG(
-                        db_path=cfg.rag_lancedb_path,
+                        db_path=(
+                            None if cfg.rag_databases else cfg.rag_lancedb_path
+                        ),
                         config=cfg.haiku_rag_config,
                         read_only=True,
                     )
@@ -522,7 +549,7 @@ def _audit_rooms_section(
                         room_rag_errors[source] = count_error
                     tc_print(
                         f"   - {source:20}: "
-                        f"{str(cfg.rag_lancedb_path):30} {count_display}"
+                        f"{cfg.rag_db_audit_path:30} {count_display}"
                     )
                 tc_print()
         tc_line()

--- a/src/soliplex/cli/audit.py
+++ b/src/soliplex/cli/audit.py
@@ -411,16 +411,18 @@ def _iter_room_rag_candidates(room_config):
 def _rag_db_probes(source, cfg):
     """Yield ``(label, cfg)`` for each database a config names.
 
-    A candidate is only known to expose ``haiku_rag_config``, so a config
-    carrying no database at all yields itself and reports its own error
-    from inside the caller's ``try``.
+    A probe checks a path this config places, so a config deferring
+    placement to its haiku.rag config yields nothing: opening it for the
+    document count is what checks it.  A candidate is only known to expose
+    ``haiku_rag_config``, so one that cannot place a database at all yields
+    itself and reports its own error from inside the caller's ``try``.
     """
     rag_databases = getattr(cfg, "rag_databases", None)
 
     if rag_databases:
         for entry in rag_databases:
             yield f"{source}#{entry.name}", entry
-    else:
+    elif getattr(cfg, "names_own_databases", True):
         yield source, cfg
 
 
@@ -453,6 +455,14 @@ def _invalid_room_rag_dbs(
         per_room: dict[str, str] = {}
 
         for source, cfg in _iter_room_rag_candidates(room_config):
+            try:
+                cfg.haiku_rag_config  # noqa B018
+            except Exception as exc:
+                # A config that will not build says why; what it
+                # names is unanswerable until that is fixed.
+                per_room[source] = str(exc)
+                continue
+
             for label, probe in _rag_db_probes(source, cfg):
                 try:
                     _ = probe.rag_lancedb_path  # property raises
@@ -522,14 +532,19 @@ def _audit_rooms_section(
             tc_print()
             tc_print("   Haiku Rag DBs")
             for source, cfg in candidates:
-                failed = next(
-                    (
-                        (label, per_room_rag[label])
-                        for label, _ in _rag_db_probes(source, cfg)
-                        if label in per_room_rag
-                    ),
-                    None,
-                )
+                # A config that will not build is recorded under its own
+                # source, which the per-database labels never match.
+                if source in per_room_rag:
+                    failed = (source, per_room_rag[source])
+                else:
+                    failed = next(
+                        (
+                            (label, per_room_rag[label])
+                            for label, _ in _rag_db_probes(source, cfg)
+                            if label in per_room_rag
+                        ),
+                        None,
+                    )
                 if failed is not None:
                     failed_label, exc = failed
                     tc_print(f"   - {failed_label:20}: ERROR: {exc}")

--- a/src/soliplex/cli/audit.py
+++ b/src/soliplex/cli/audit.py
@@ -456,7 +456,7 @@ def _invalid_room_rag_dbs(
 
         for source, cfg in _iter_room_rag_candidates(room_config):
             try:
-                cfg.haiku_rag_config  # noqa B018
+                _ = cfg.haiku_rag_config  # property raises
             except Exception as exc:
                 # A config that will not build says why; what it
                 # names is unanswerable until that is fixed.

--- a/src/soliplex/cli/audit.py
+++ b/src/soliplex/cli/audit.py
@@ -535,9 +535,6 @@ def _audit_rooms_section(
                     tc_print(f"   - {failed_label:20}: ERROR: {exc}")
                 else:
                     rag = hr_client.HaikuRAG(
-                        db_path=(
-                            None if cfg.rag_databases else cfg.rag_lancedb_path
-                        ),
                         config=cfg.haiku_rag_config,
                         read_only=True,
                     )

--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -168,23 +168,22 @@ class _RAGConfigBase:
     ) -> hr_config.AppConfig:
         """Name this config's databases in 'lancedb.databases'
 
-        'rag_databases' comes from '_RAGDatabaseBase', which DB-bearing
-        configs mix in alongside this class.  haiku.rag treats 'lancedb.uri'
-        and 'lancedb.databases' as mutually exclusive, so naming databases
-        clears the URI.  Copies rather than mutates: the installation's own
-        config object is shared with every other room.
+        'rag_lancedb_databases' comes from '_RAGDatabaseBase', which
+        DB-bearing configs mix in alongside this class.  haiku.rag treats
+        'lancedb.uri' and 'lancedb.databases' as mutually exclusive, so
+        naming databases clears the URI.  Copies rather than mutates: the
+        installation's own config object is shared with every other room.
         """
-        rag_databases = getattr(self, "rag_databases", None)
+        databases = getattr(self, "rag_lancedb_databases", None)
 
-        if not rag_databases:
+        if not databases:
             return room_hr_config
 
         lancedb = room_hr_config.lancedb.model_copy(
             update={
                 "uri": "",
                 "databases": {
-                    entry.name: str(entry.rag_lancedb_path)
-                    for entry in rag_databases
+                    name: str(path) for name, path in databases.items()
                 },
             },
         )
@@ -270,6 +269,36 @@ class _RAGDatabaseBase:
             return rspdb
 
     @property
+    def database_name(self) -> str:
+        """The name this database answers to, marked when it is missing.
+
+        A config written with a stem or an override path names no database,
+        so the file's stem is its name.
+        """
+        try:
+            return self.rag_lancedb_path.stem
+        except RagDbFileNotFound as exc:
+            return f"MISSING: {exc.rag_db_filename.stem}"
+
+    @property
+    def rag_lancedb_databases(self) -> dict[str, pathlib.Path]:
+        """Every database this config names, keyed by name"""
+        if self.rag_databases:
+            return {
+                entry.name: entry.rag_lancedb_path
+                for entry in self.rag_databases
+            }
+
+        return {self.database_name: self.rag_lancedb_path}
+
+    @property
+    def rag_database_names(self) -> list[str]:
+        if self.rag_databases:
+            return [entry.database_name for entry in self.rag_databases]
+
+        return [self.database_name]
+
+    @property
     def rag_db_audit_path(self) -> str:
         """Identify the database(s) this config reads, for audit records"""
         if self.rag_databases:
@@ -281,27 +310,7 @@ class _RAGDatabaseBase:
         return str(self.rag_lancedb_path)
 
     def get_extra_parameters(self) -> dict:
-        if self.rag_databases:
-            return {
-                "rag_lancedb_paths": {
-                    entry.name: entry.get_extra_parameters()[
-                        "rag_lancedb_path"
-                    ]
-                    for entry in self.rag_databases
-                },
-            }
-
-        try:
-            rag_lancedb_path = self.rag_lancedb_path
-        except RagDbFileNotFound as exc:
-            missing = exc.rag_db_filename
-            db_name = f"MISSING: {missing.stem}"
-        else:
-            db_name = rag_lancedb_path.stem
-
-        return {
-            "database_names": [db_name],
-        }
+        return {"database_names": self.rag_database_names}
 
 
 def adjust_yaml_rag_databases(
@@ -338,6 +347,15 @@ class RAGDatabaseEntry(_RAGDatabaseBase):
     """
 
     name: str = None
+
+    @property
+    def database_name(self) -> str:
+        try:
+            self.rag_lancedb_path  # noqa B018
+        except RagDbFileNotFound:
+            return f"MISSING: {self.name}"
+
+        return self.name
 
     def __post_init__(self):
         if not self.name or not self.name.strip():

--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -44,6 +44,56 @@ class RagDbFileNotFound(ValueError):
         )
 
 
+class RagDbSingleAndMultiConflict(TypeError):
+    def __init__(self, _config_path):
+        self._config_path = _config_path
+        super().__init__(
+            f"Configure either 'rag_databases' or a single database via "
+            f"'rag_lancedb_stem' / 'rag_lancedb_override_path', not both "
+            f"(configured in {_config_path})"
+        )
+
+
+class RagDbDuplicateDatabaseName(TypeError):
+    def __init__(self, name, _config_path):
+        self.name = name
+        self._config_path = _config_path
+        super().__init__(
+            f"Duplicate name in 'rag_databases': {name!r} "
+            f"(configured in {_config_path})"
+        )
+
+
+class RagDbEntryRequiresName(TypeError):
+    def __init__(self, _config_path):
+        self._config_path = _config_path
+        super().__init__(
+            f"Each entry in 'rag_databases' needs a 'name' "
+            f"(configured in {_config_path})"
+        )
+
+
+class RagDbNamesSeveralDatabases(ValueError):
+    """Raised on a valid config, so it names the accessor, not the file"""
+
+    def __init__(self, _config_path):
+        self._config_path = _config_path
+        super().__init__(
+            f"The config from {_config_path} names several databases in "
+            f"'rag_databases', which have no single path"
+        )
+
+
+class RagDbNestedDatabases(TypeError):
+    def __init__(self, _config_path):
+        self._config_path = _config_path
+        super().__init__(
+            f"An entry in 'rag_databases' names one database, so it cannot "
+            f"carry 'rag_databases' of its own "
+            f"(configured in {_config_path})"
+        )
+
+
 @typing.runtime_checkable
 class RAGConfigProtocol(typing.Protocol):
     """Expose a haiku-rag configuration"""
@@ -63,17 +113,6 @@ class SingleRAGDatabaseProtocol(typing.Protocol):
     @abc.abstractmethod
     def rag_lancedb_path(self) -> pathlib.Path:
         """Compute the path for the room's RAG rag_lancedb_path database"""
-        ...
-
-
-@typing.runtime_checkable
-class MultipleRAGDatabasesProtocol(typing.Protocol):
-    """Expose a list of lancedb paths"""
-
-    @property
-    @abc.abstractmethod
-    def rag_lancedb_paths(self) -> list[pathlib.Path]:
-        """Compute the paths for the room's RAG rag_lancedb_path databases"""
         ...
 
 
@@ -113,22 +152,56 @@ class _RAGConfigBase:
                     room_config_yaml,
                 )
 
-                self._haiku_rag_config = hr_config.AppConfig.model_validate(
+                room_hr_config = hr_config.AppConfig.model_validate(
                     merged_config_yaml
                 )
             else:
-                self._haiku_rag_config = base_config
+                room_hr_config = base_config
+
+            self._haiku_rag_config = self._name_rag_databases(room_hr_config)
 
         return self._haiku_rag_config
+
+    def _name_rag_databases(
+        self,
+        room_hr_config: hr_config.AppConfig,
+    ) -> hr_config.AppConfig:
+        """Name this config's databases in 'lancedb.databases'
+
+        'rag_databases' comes from '_RAGDatabaseBase', which DB-bearing
+        configs mix in alongside this class.  haiku.rag treats 'lancedb.uri'
+        and 'lancedb.databases' as mutually exclusive, so naming databases
+        clears the URI.  Copies rather than mutates: the installation's own
+        config object is shared with every other room.
+        """
+        rag_databases = getattr(self, "rag_databases", None)
+
+        if not rag_databases:
+            return room_hr_config
+
+        lancedb = room_hr_config.lancedb.model_copy(
+            update={
+                "uri": "",
+                "databases": {
+                    entry.name: str(entry.rag_lancedb_path)
+                    for entry in rag_databases
+                },
+            },
+        )
+
+        return room_hr_config.model_copy(update={"lancedb": lancedb})
 
 
 @dataclasses.dataclass(kw_only=True)
 class _RAGDatabaseBase:
     """Base class for configs which expose a 'rag_lancedb_path' property"""
 
-    # One of these two options must be specified
+    # One of these two options must be specified, unless 'rag_databases'
+    # names several databases instead.
     rag_lancedb_stem: str = None
     rag_lancedb_override_path: str = None
+
+    rag_databases: list[RAGDatabaseEntry] = _utils._default_list_field()
 
     # Normally set via subclass 'from_yaml'
     _installation_config: config_installation.InstallationConfig = (
@@ -137,6 +210,23 @@ class _RAGDatabaseBase:
     _config_path: pathlib.Path = None
 
     def __post_init__(self):
+        if self.rag_databases:
+            if self.rag_lancedb_stem or self.rag_lancedb_override_path:
+                raise RagDbSingleAndMultiConflict(self._config_path)
+
+            seen = set()
+
+            for entry in self.rag_databases:
+                if entry.name in seen:
+                    raise RagDbDuplicateDatabaseName(
+                        entry.name,
+                        self._config_path,
+                    )
+
+                seen.add(entry.name)
+
+            return
+
         exclusive_required = [
             self.rag_lancedb_stem,
             self.rag_lancedb_override_path,
@@ -149,6 +239,9 @@ class _RAGDatabaseBase:
     @property
     def rag_lancedb_path(self) -> pathlib.Path:
         """Compute the path for the database"""
+        if self.rag_databases:
+            raise RagDbNamesSeveralDatabases(self._config_path)
+
         if self.rag_lancedb_override_path is not None:
             # Expanded before joining: a '~' resolved against the room
             # directory is a literal directory name, never a home.
@@ -176,7 +269,28 @@ class _RAGDatabaseBase:
 
             return rspdb
 
+    @property
+    def rag_db_audit_path(self) -> str:
+        """Identify the database(s) this config reads, for audit records"""
+        if self.rag_databases:
+            return ", ".join(
+                f"{entry.name}={entry.rag_lancedb_path}"
+                for entry in self.rag_databases
+            )
+
+        return str(self.rag_lancedb_path)
+
     def get_extra_parameters(self) -> dict:
+        if self.rag_databases:
+            return {
+                "rag_lancedb_paths": {
+                    entry.name: entry.get_extra_parameters()[
+                        "rag_lancedb_path"
+                    ]
+                    for entry in self.rag_databases
+                },
+            }
+
         try:
             rag_lancedb_path = self.rag_lancedb_path
         except RagDbFileNotFound as exc:
@@ -191,11 +305,53 @@ class _RAGDatabaseBase:
 
 
 @dataclasses.dataclass(kw_only=True)
-class _MultiRAGDatabasesBase:
-    """Base class for configs which expose a 'rag_lancedb_paths' property"""
+class RAGDatabaseEntry(_RAGDatabaseBase):
+    """One named database in a config's 'rag_databases'
 
-    db_configs: list[SingleRAGDatabaseProtocol] = _utils._default_list_field()
+    The name is haiku.rag's identity for the database: it travels in search
+    results, documents and citations, where a location must not.
+    """
+
+    name: str = None
+
+    def __post_init__(self):
+        if not self.name or not self.name.strip():
+            raise RagDbEntryRequiresName(self._config_path)
+
+        if self.rag_databases:
+            raise RagDbNestedDatabases(self._config_path)
+
+        super().__post_init__()
+
+    @classmethod
+    def from_yaml(
+        cls,
+        installation_config: InstallationConfig,  # noqa F821 cycle
+        config_path: pathlib.Path,
+        config_dict: dict,
+    ) -> RAGDatabaseEntry:
+        config_dict = dict(config_dict)
+
+        rldb_override_path = config_dict.pop("rag_lancedb_override_path", None)
+
+        if rldb_override_path is not None:
+            config_dict["rag_lancedb_override_path"] = pathlib.Path(
+                rldb_override_path
+            )
+
+        config_dict["_installation_config"] = installation_config
+        config_dict["_config_path"] = config_path
+        return cls(**config_dict)
 
     @property
-    def rag_lancedb_paths(self):
-        return [cfg.rag_lancedb_path for cfg in self.db_configs]
+    def as_yaml(self) -> dict:
+        result = {"name": self.name}
+
+        if self.rag_lancedb_stem is not None:
+            result["rag_lancedb_stem"] = self.rag_lancedb_stem
+        else:
+            result["rag_lancedb_override_path"] = str(
+                self.rag_lancedb_override_path
+            )
+
+        return result

--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -304,6 +304,31 @@ class _RAGDatabaseBase:
         }
 
 
+def adjust_yaml_rag_databases(
+    installation_config: InstallationConfig,  # noqa F821 cycle
+    config_path: pathlib.Path,
+    config_dict: dict,
+) -> None:
+    """Replace 'rag_databases' mappings with 'RAGDatabaseEntry's, in place
+
+    A key with nothing under it parses as None, which is the field's
+    default spelled out, so it is dropped rather than passed along.
+    """
+    rag_databases = config_dict.pop("rag_databases", None)
+
+    if rag_databases is None:
+        return
+
+    config_dict["rag_databases"] = [
+        RAGDatabaseEntry.from_yaml(
+            installation_config,
+            config_path,
+            entry_dict,
+        )
+        for entry_dict in rag_databases
+    ]
+
+
 @dataclasses.dataclass(kw_only=True)
 class RAGDatabaseEntry(_RAGDatabaseBase):
     """One named database in a config's 'rag_databases'

--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -117,28 +117,6 @@ class RagDbEntryRequiresName(TypeError):
         )
 
 
-class RagDbNamesSeveralDatabases(ValueError):
-    """Raised on a valid config, so it names the accessor, not the file"""
-
-    def __init__(self, _config_path):
-        self._config_path = _config_path
-        super().__init__(
-            f"The config from {_config_path} names several databases in "
-            f"'rag_databases', which have no single path"
-        )
-
-
-class RagDbNamesNoDatabase(ValueError):
-    """Raised on a valid config, so it names the accessor, not the file"""
-
-    def __init__(self, _config_path):
-        self._config_path = _config_path
-        super().__init__(
-            f"The config from {_config_path} names no database of its own, "
-            f"so its databases are the ones its haiku.rag config places"
-        )
-
-
 class RagDbNestedDatabases(TypeError):
     def __init__(self, _config_path):
         self._config_path = _config_path
@@ -168,6 +146,17 @@ class SingleRAGDatabaseProtocol(typing.Protocol):
     @abc.abstractmethod
     def rag_lancedb_path(self) -> pathlib.Path:
         """Compute the path for the room's RAG rag_lancedb_path database"""
+        ...
+
+
+@typing.runtime_checkable
+class RAGDatabasesProtocol(typing.Protocol):
+    """Expose the databases a config covers, keyed by name"""
+
+    @property
+    @abc.abstractmethod
+    def rag_lancedb_databases(self) -> dict[str, pathlib.Path | str]:
+        """Every database this config covers, keyed by name"""
         ...
 
 
@@ -223,7 +212,7 @@ class _RAGConfigBase:
     ) -> hr_config.AppConfig:
         """Name this config's databases in 'lancedb.databases'
 
-        'names_own_databases' comes from '_RAGDatabaseBase', which
+        'names_own_databases' comes from '_RAGDatabasesBase', which
         DB-bearing configs mix in alongside this class.  A config naming
         none defers to the haiku.rag config, which is returned untouched.
         Copies rather than mutates: the installation's own config object is
@@ -256,15 +245,20 @@ class _RAGConfigBase:
 
 
 @dataclasses.dataclass(kw_only=True)
-class _RAGDatabaseBase:
-    """Base class for configs which expose a 'rag_lancedb_path' property"""
+class _RAGDatabasesBase:
+    """Base class for configs which expose a 'rag_databases' list
 
-    # One of these two options must be specified, unless 'rag_databases'
-    # names several databases instead.
-    rag_lancedb_stem: str = None
-    rag_lancedb_override_path: str = None
+    Every database a config names lands in that list, whichever way the
+    YAML spelled it: the two singular options are backward-compatible
+    sugar for a one-entry list, normalized away here so nothing
+    downstream has to know which spelling was used.
+    """
 
     rag_databases: list[RAGDatabaseEntry] = _utils._default_list_field()
+
+    # Sugar for a single unnamed database, folded into 'rag_databases'.
+    rag_lancedb_stem: dataclasses.InitVar[str] = None
+    rag_lancedb_override_path: dataclasses.InitVar[str] = None
 
     # Normally set via subclass 'from_yaml'
     _installation_config: config_installation.InstallationConfig = (
@@ -272,9 +266,15 @@ class _RAGDatabaseBase:
     )
     _config_path: pathlib.Path = None
 
-    def __post_init__(self):
+    def __post_init__(
+        self,
+        rag_lancedb_stem: str | None,
+        rag_lancedb_override_path: str | None,
+    ):
+        names_one = bool(rag_lancedb_stem or rag_lancedb_override_path)
+
         if self.rag_databases:
-            if self.rag_lancedb_stem or self.rag_lancedb_override_path:
+            if names_one:
                 raise RagDbSingleAndMultiConflict(self._config_path)
 
             seen = set()
@@ -290,73 +290,27 @@ class _RAGDatabaseBase:
 
             return
 
-        if self.rag_lancedb_stem and self.rag_lancedb_override_path:
-            raise RagDbStemAndOverrideConflict(self._config_path)
-
-    @property
-    def rag_lancedb_path(self) -> pathlib.Path:
-        """Compute the path for the database"""
-        if self.rag_databases:
-            raise RagDbNamesSeveralDatabases(self._config_path)
-
-        if not (self.rag_lancedb_stem or self.rag_lancedb_override_path):
-            raise RagDbNamesNoDatabase(self._config_path)
-
-        if self.rag_lancedb_override_path is not None:
-            # Expanded before joining: a '~' resolved against the room
-            # directory is a literal directory name, never a home.
-            rsop = pathlib.Path(self.rag_lancedb_override_path).expanduser()
-
-            if self._config_path is not None:
-                rsop = (self._config_path.parent / rsop).resolve()
-            else:
-                rsop = rsop.resolve()
-
-            if not rsop.is_dir():
-                raise RagDbFileNotFound(rsop, self._config_path)
-
-            return rsop
-        else:
-            db_rag_dir = pathlib.Path(
-                self._installation_config.get_environment(
-                    "RAG_LANCE_DB_PATH",
+        if names_one:
+            # The entry names itself after whichever option placed it,
+            # and raises on the pair being spelled out together.
+            self.rag_databases.append(
+                RAGDatabaseEntry(
+                    rag_lancedb_stem=rag_lancedb_stem,
+                    rag_lancedb_override_path=rag_lancedb_override_path,
+                    _installation_config=self._installation_config,
+                    _config_path=self._config_path,
                 )
             )
-            rspdb = (db_rag_dir / f"{self.rag_lancedb_stem}.lancedb").resolve()
-
-            if not rspdb.is_dir():
-                raise RagDbFileNotFound(rspdb, self._config_path)
-
-            return rspdb
-
-    @property
-    def database_name(self) -> str:
-        """The name this database answers to, marked when it is missing.
-
-        A config written with a stem or an override path names no database,
-        so the file's stem is its name.
-        """
-        try:
-            return self.rag_lancedb_path.stem
-        except RagDbFileNotFound as exc:
-            return f"MISSING: {exc.rag_db_filename.stem}"
 
     @property
     def names_own_databases(self) -> bool:
         """Whether this config places databases, before resolving any"""
-        return bool(
-            self.rag_databases
-            or self.rag_lancedb_stem
-            or self.rag_lancedb_override_path
-        )
+        return bool(self.rag_databases)
 
     @property
     def _declared_names(self) -> list[str]:
         """The names this config writes down, before any path resolves"""
-        if self.rag_databases:
-            return [entry.name for entry in self.rag_databases]
-
-        return [self.rag_lancedb_stem or str(self.rag_lancedb_override_path)]
+        return [entry.name for entry in self.rag_databases]
 
     @property
     def _declared_databases(self) -> dict[str, pathlib.Path]:
@@ -366,13 +320,9 @@ class _RAGDatabaseBase:
         Read by 'haiku_rag_config' while it builds, so this must never
         consult the built config.
         """
-        if self.rag_databases:
-            return {
-                entry.name: entry.rag_lancedb_path
-                for entry in self.rag_databases
-            }
-
-        return {self.database_name: self.rag_lancedb_path}
+        return {
+            entry.name: entry.rag_lancedb_path for entry in self.rag_databases
+        }
 
     @property
     def rag_lancedb_databases(self) -> dict[str, pathlib.Path | str]:
@@ -390,9 +340,6 @@ class _RAGDatabaseBase:
     def rag_database_names(self) -> list[str]:
         if self.rag_databases:
             return [entry.database_name for entry in self.rag_databases]
-
-        if self.names_own_databases:
-            return [self.database_name]
 
         return list(_configured_databases(self.haiku_rag_config))
 
@@ -434,35 +381,99 @@ def adjust_yaml_rag_databases(
 
 
 @dataclasses.dataclass(kw_only=True)
-class RAGDatabaseEntry(_RAGDatabaseBase):
-    """One named database in a config's 'rag_databases'
+class RAGDatabaseEntry:
+    """One named database, whether or not a config spells out its name
 
     The name is haiku.rag's identity for the database: it travels in search
-    results, documents and citations, where a location must not.
+    results, documents and citations, where a location must not.  An entry
+    written without one takes the name from whichever option placed it, so
+    every database has a name before any path resolves.
     """
 
     name: str = None
 
+    # Exactly one of these two options places the database.
+    rag_lancedb_stem: str = None
+    rag_lancedb_override_path: str = None
+
+    # Normally set via 'from_yaml'
+    _installation_config: config_installation.InstallationConfig = (
+        _utils._no_repr_no_compare_none()
+    )
+    _config_path: pathlib.Path = None
+
+    def __post_init__(self):
+        if self.rag_lancedb_override_path is not None:
+            # However it arrived -- YAML string, sugar on the owning
+            # config, or a caller's own Path -- an entry holds a Path, so
+            # two spellings of one database compare equal.
+            self.rag_lancedb_override_path = pathlib.Path(
+                self.rag_lancedb_override_path
+            )
+
+        if self.rag_lancedb_stem and self.rag_lancedb_override_path:
+            raise RagDbStemAndOverrideConflict(self._config_path)
+
+        if not (self.rag_lancedb_stem or self.rag_lancedb_override_path):
+            raise RagDbEntryRequiresDatabase(self._config_path)
+
+        if self.name is None:
+            self.name = self._placed_name
+        elif not self.name.strip():
+            # Spelled out, but empty: a typo, not a request to derive one.
+            raise RagDbEntryRequiresName(self._config_path)
+
+    @property
+    def _placed_name(self) -> str:
+        """Name the database after whichever option placed it
+
+        Reads what the config wrote down rather than the resolved path: a
+        database that is missing still answers to a name.
+        """
+        if self.rag_lancedb_stem:
+            return self.rag_lancedb_stem
+
+        return pathlib.Path(self.rag_lancedb_override_path).stem
+
+    @property
+    def rag_lancedb_path(self) -> pathlib.Path:
+        """Compute the path for the database"""
+        if self.rag_lancedb_override_path is not None:
+            # Expanded before joining: a '~' resolved against the room
+            # directory is a literal directory name, never a home.
+            rsop = pathlib.Path(self.rag_lancedb_override_path).expanduser()
+
+            if self._config_path is not None:
+                rsop = (self._config_path.parent / rsop).resolve()
+            else:
+                rsop = rsop.resolve()
+
+            if not rsop.is_dir():
+                raise RagDbFileNotFound(rsop, self._config_path)
+
+            return rsop
+
+        db_rag_dir = pathlib.Path(
+            self._installation_config.get_environment(
+                "RAG_LANCE_DB_PATH",
+            )
+        )
+        rspdb = (db_rag_dir / f"{self.rag_lancedb_stem}.lancedb").resolve()
+
+        if not rspdb.is_dir():
+            raise RagDbFileNotFound(rspdb, self._config_path)
+
+        return rspdb
+
     @property
     def database_name(self) -> str:
+        """The name this database answers to, marked when it is missing"""
         try:
             _ = self.rag_lancedb_path  # property raises
         except RagDbFileNotFound:
             return f"MISSING: {self.name}"
 
         return self.name
-
-    def __post_init__(self):
-        if not self.name or not self.name.strip():
-            raise RagDbEntryRequiresName(self._config_path)
-
-        if self.rag_databases:
-            raise RagDbNestedDatabases(self._config_path)
-
-        super().__post_init__()
-
-        if not (self.rag_lancedb_stem or self.rag_lancedb_override_path):
-            raise RagDbEntryRequiresDatabase(self._config_path)
 
     @classmethod
     def from_yaml(
@@ -473,12 +484,11 @@ class RAGDatabaseEntry(_RAGDatabaseBase):
     ) -> RAGDatabaseEntry:
         config_dict = dict(config_dict)
 
-        rldb_override_path = config_dict.pop("rag_lancedb_override_path", None)
-
-        if rldb_override_path is not None:
-            config_dict["rag_lancedb_override_path"] = pathlib.Path(
-                rldb_override_path
-            )
+        # An entry places one database, so it cannot nest a list of them.
+        # Checked here rather than in '__post_init__': the field is gone,
+        # and a bare TypeError names the keyword, not the mistake.
+        if "rag_databases" in config_dict:
+            raise RagDbNestedDatabases(config_path)
 
         config_dict["_installation_config"] = installation_config
         config_dict["_config_path"] = config_path

--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -409,7 +409,7 @@ class _RAGDatabaseBase:
 
 
 def adjust_yaml_rag_databases(
-    installation_config: InstallationConfig,  # noqa F821 cycle
+    installation_config: config_installation.InstallationConfig,
     config_path: pathlib.Path,
     config_dict: dict,
 ) -> None:
@@ -446,7 +446,7 @@ class RAGDatabaseEntry(_RAGDatabaseBase):
     @property
     def database_name(self) -> str:
         try:
-            self.rag_lancedb_path  # noqa B018
+            _ = self.rag_lancedb_path  # property raises
         except RagDbFileNotFound:
             return f"MISSING: {self.name}"
 
@@ -467,7 +467,7 @@ class RAGDatabaseEntry(_RAGDatabaseBase):
     @classmethod
     def from_yaml(
         cls,
-        installation_config: InstallationConfig,  # noqa F821 cycle
+        installation_config: config_installation.InstallationConfig,
         config_path: pathlib.Path,
         config_dict: dict,
     ) -> RAGDatabaseEntry:

--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -5,6 +5,7 @@ import dataclasses
 import pathlib
 import typing
 
+from haiku.rag import client as hr_client
 from haiku.rag import config as hr_config
 
 from . import _utils
@@ -24,13 +25,56 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return out
 
 
-class RagDbExactlyOneOfStemOrOverride(TypeError):
+def _configured_databases(
+    hr_config_obj: hr_config.AppConfig,
+) -> dict[str, pathlib.Path | str]:
+    """Every database a haiku.rag config places, keyed by name
+
+    'DatabaseScope.resolve' answers for the configuration as written and
+    for what it leaves to defaults, without opening anything.
+    """
+    scope = hr_client.DatabaseScope.resolve(hr_config_obj)
+
+    return {ref.name: ref.location for ref in scope.databases}
+
+
+class RagDbStemAndOverrideConflict(TypeError):
     def __init__(self, _config_path):
         self._config_path = _config_path
         super().__init__(
-            f"Configure exactly one of 'rag_lancedb_stem' or "
+            f"Configure at most one of 'rag_lancedb_stem' or "
             f"'rag_lancedb_override_path' "
             f"(configured in {_config_path})"
+        )
+
+
+class RagDbEntryRequiresDatabase(TypeError):
+    def __init__(self, _config_path):
+        self._config_path = _config_path
+        super().__init__(
+            f"Each entry in 'rag_databases' names one database, via "
+            f"'rag_lancedb_stem' or 'rag_lancedb_override_path' "
+            f"(configured in {_config_path})"
+        )
+
+
+class RagDbTwoPlacements(ValueError):
+    """Raised where a config names databases its haiku.rag config places
+
+    The haiku.rag configuration may be the room's own or the
+    installation's, since the room reads the two merged.
+    """
+
+    def __init__(self, declared, configured, _config_path):
+        self.declared = declared
+        self.configured = configured
+        self._config_path = _config_path
+        super().__init__(
+            f"{_config_path} names {', '.join(declared)}, and the haiku.rag "
+            f"configuration it reads places {', '.join(configured)} in "
+            f"'lancedb.databases'. Name every database in one place: move "
+            f"the room's own into 'lancedb.databases', or drop whichever "
+            f"side is the duplicate"
         )
 
 
@@ -81,6 +125,17 @@ class RagDbNamesSeveralDatabases(ValueError):
         super().__init__(
             f"The config from {_config_path} names several databases in "
             f"'rag_databases', which have no single path"
+        )
+
+
+class RagDbNamesNoDatabase(ValueError):
+    """Raised on a valid config, so it names the accessor, not the file"""
+
+    def __init__(self, _config_path):
+        self._config_path = _config_path
+        super().__init__(
+            f"The config from {_config_path} names no database of its own, "
+            f"so its databases are the ones its haiku.rag config places"
         )
 
 
@@ -168,20 +223,29 @@ class _RAGConfigBase:
     ) -> hr_config.AppConfig:
         """Name this config's databases in 'lancedb.databases'
 
-        'rag_lancedb_databases' comes from '_RAGDatabaseBase', which
-        DB-bearing configs mix in alongside this class.  haiku.rag treats
-        'lancedb.uri' and 'lancedb.databases' as mutually exclusive, so
-        naming databases clears the URI.  Copies rather than mutates: the
-        installation's own config object is shared with every other room.
+        'names_own_databases' comes from '_RAGDatabaseBase', which
+        DB-bearing configs mix in alongside this class.  A config naming
+        none defers to the haiku.rag config, which is returned untouched.
+        Copies rather than mutates: the installation's own config object is
+        shared with every other room.
         """
-        databases = getattr(self, "rag_lancedb_databases", None)
-
-        if not databases:
+        if not getattr(self, "names_own_databases", False):
             return room_hr_config
+
+        # Before resolving anything: the database named beside a configured
+        # one is typically a placeholder that was never created, and its
+        # absence is not the diagnosis.
+        if room_hr_config.lancedb.databases:
+            raise RagDbTwoPlacements(
+                self._declared_names,
+                list(room_hr_config.lancedb.databases),
+                self._config_path,
+            )
+
+        databases = self._declared_databases
 
         lancedb = room_hr_config.lancedb.model_copy(
             update={
-                "uri": "",
                 "databases": {
                     name: str(path) for name, path in databases.items()
                 },
@@ -226,20 +290,17 @@ class _RAGDatabaseBase:
 
             return
 
-        exclusive_required = [
-            self.rag_lancedb_stem,
-            self.rag_lancedb_override_path,
-        ]
-        passed = list(filter(None, exclusive_required))
-
-        if len(list(passed)) != 1:
-            raise RagDbExactlyOneOfStemOrOverride(self._config_path)
+        if self.rag_lancedb_stem and self.rag_lancedb_override_path:
+            raise RagDbStemAndOverrideConflict(self._config_path)
 
     @property
     def rag_lancedb_path(self) -> pathlib.Path:
         """Compute the path for the database"""
         if self.rag_databases:
             raise RagDbNamesSeveralDatabases(self._config_path)
+
+        if not (self.rag_lancedb_stem or self.rag_lancedb_override_path):
+            raise RagDbNamesNoDatabase(self._config_path)
 
         if self.rag_lancedb_override_path is not None:
             # Expanded before joining: a '~' resolved against the room
@@ -281,8 +342,30 @@ class _RAGDatabaseBase:
             return f"MISSING: {exc.rag_db_filename.stem}"
 
     @property
-    def rag_lancedb_databases(self) -> dict[str, pathlib.Path]:
-        """Every database this config names, keyed by name"""
+    def names_own_databases(self) -> bool:
+        """Whether this config places databases, before resolving any"""
+        return bool(
+            self.rag_databases
+            or self.rag_lancedb_stem
+            or self.rag_lancedb_override_path
+        )
+
+    @property
+    def _declared_names(self) -> list[str]:
+        """The names this config writes down, before any path resolves"""
+        if self.rag_databases:
+            return [entry.name for entry in self.rag_databases]
+
+        return [self.rag_lancedb_stem or str(self.rag_lancedb_override_path)]
+
+    @property
+    def _declared_databases(self) -> dict[str, pathlib.Path]:
+        """Every database this config names itself, resolved
+
+        Resolves paths, so callers guard on 'names_own_databases' first.
+        Read by 'haiku_rag_config' while it builds, so this must never
+        consult the built config.
+        """
         if self.rag_databases:
             return {
                 entry.name: entry.rag_lancedb_path
@@ -292,22 +375,34 @@ class _RAGDatabaseBase:
         return {self.database_name: self.rag_lancedb_path}
 
     @property
+    def rag_lancedb_databases(self) -> dict[str, pathlib.Path | str]:
+        """Every database this config covers, keyed by name
+
+        A config naming none covers whatever its haiku.rag config places,
+        the installation's default database included.
+        """
+        if self.names_own_databases:
+            return self._declared_databases
+
+        return _configured_databases(self.haiku_rag_config)
+
+    @property
     def rag_database_names(self) -> list[str]:
         if self.rag_databases:
             return [entry.database_name for entry in self.rag_databases]
 
-        return [self.database_name]
+        if self.names_own_databases:
+            return [self.database_name]
+
+        return list(_configured_databases(self.haiku_rag_config))
 
     @property
     def rag_db_audit_path(self) -> str:
         """Identify the database(s) this config reads, for audit records"""
-        if self.rag_databases:
-            return ", ".join(
-                f"{entry.name}={entry.rag_lancedb_path}"
-                for entry in self.rag_databases
-            )
-
-        return str(self.rag_lancedb_path)
+        return ", ".join(
+            f"{name}={location}"
+            for name, location in self.rag_lancedb_databases.items()
+        )
 
     def get_extra_parameters(self) -> dict:
         return {"database_names": self.rag_database_names}
@@ -365,6 +460,9 @@ class RAGDatabaseEntry(_RAGDatabaseBase):
             raise RagDbNestedDatabases(self._config_path)
 
         super().__post_init__()
+
+        if not (self.rag_lancedb_stem or self.rag_lancedb_override_path):
+            raise RagDbEntryRequiresDatabase(self._config_path)
 
     @classmethod
     def from_yaml(

--- a/src/soliplex/config/rooms.py
+++ b/src/soliplex/config/rooms.py
@@ -303,29 +303,22 @@ class RoomConfig:
         )
 
         for source, cfg in candidates:
-            if isinstance(cfg, config_rag.RAGConfigProtocol):
-                haiku_rag_config = cfg.haiku_rag_config
+            if not isinstance(cfg, config_rag.RAGConfigProtocol):
+                continue
 
-                if isinstance(cfg, config_rag.SingleRAGDatabaseProtocol):
-                    rag_lancedb_paths = [cfg.rag_lancedb_path]
-                elif isinstance(
-                    cfg, config_rag.MultipleRAGDatabasesProtocol
-                ):  # pragma: NO COVER
-                    rag_lancedb_paths = cfg.rag_lancedb_paths
-                else:  # pragma: NO COVER
-                    rag_lancedb_path = ()
+            if not isinstance(cfg, config_rag.SingleRAGDatabaseProtocol):
+                continue
 
-                for rag_lancedb_path in rag_lancedb_paths:
-                    hrc_kw = {
-                        "db_path": rag_lancedb_path,
-                        "config": haiku_rag_config,
-                        "read_only": True,
-                    }
+            hrc_kw = {
+                "db_path": cfg.rag_lancedb_path,
+                "config": cfg.haiku_rag_config,
+                "read_only": True,
+            }
 
-                    if include_source:
-                        hrc_kw["source"] = source
+            if include_source:
+                hrc_kw["source"] = source
 
-                    yield hrc_kw
+            yield hrc_kw
 
 
 RoomConfigMap = dict[str, RoomConfig]

--- a/src/soliplex/config/rooms.py
+++ b/src/soliplex/config/rooms.py
@@ -283,8 +283,8 @@ class RoomConfig:
         - Tool configs defined in the room
 
         For each candidate: if it derives from `config.rag._RAGConfigBase`
-        (has `haiku_rag_config`/`rag_lancedb_path` attributes), return
-        the corresponding kwargs dict.
+        (has `haiku_rag_config`/`rag_lancedb_databases` attributes),
+        return the corresponding kwargs dict.
         """
         candidates = (
             [("agent", self.agent_config)]
@@ -306,7 +306,7 @@ class RoomConfig:
             if not isinstance(cfg, config_rag.RAGConfigProtocol):
                 continue
 
-            if not isinstance(cfg, config_rag.SingleRAGDatabaseProtocol):
+            if not isinstance(cfg, config_rag.RAGDatabasesProtocol):
                 continue
 
             # Every database a config names travels in

--- a/src/soliplex/config/rooms.py
+++ b/src/soliplex/config/rooms.py
@@ -309,14 +309,19 @@ class RoomConfig:
             if not isinstance(cfg, config_rag.SingleRAGDatabaseProtocol):
                 continue
 
+            # Named databases travel in the config as 'lancedb.databases',
+            # which haiku.rag federates into one client.
+            db_path = None if cfg.rag_databases else cfg.rag_lancedb_path
+
             hrc_kw = {
-                "db_path": cfg.rag_lancedb_path,
+                "db_path": db_path,
                 "config": cfg.haiku_rag_config,
                 "read_only": True,
             }
 
             if include_source:
                 hrc_kw["source"] = source
+                hrc_kw["audit_db_path"] = cfg.rag_db_audit_path
 
             yield hrc_kw
 

--- a/src/soliplex/config/rooms.py
+++ b/src/soliplex/config/rooms.py
@@ -309,12 +309,9 @@ class RoomConfig:
             if not isinstance(cfg, config_rag.SingleRAGDatabaseProtocol):
                 continue
 
-            # Named databases travel in the config as 'lancedb.databases',
-            # which haiku.rag federates into one client.
-            db_path = None if cfg.rag_databases else cfg.rag_lancedb_path
-
+            # Every database a config names travels in
+            # 'config.lancedb.databases', so the client needs no path.
             hrc_kw = {
-                "db_path": db_path,
                 "config": cfg.haiku_rag_config,
                 "read_only": True,
             }

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -252,12 +252,7 @@ class _HaikuRAGCapabilityConfig(
 
     @property
     def capability(self) -> ai_capabilities.AbstractCapability:
-        # Named databases reach haiku.rag through the config, which
-        # resolves them into one capability covering the set.
-        db_path = None if self.rag_databases else self.rag_lancedb_path
-
         return type(self).capability_factory(
-            db_path=db_path,
             config=self.haiku_rag_config,
             defer_loading=self.defer_loading,
         )

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -230,6 +230,12 @@ class _HaikuRAGCapabilityConfig(
                     rldb_override_path
                 )
 
+            config_rag.adjust_yaml_rag_databases(
+                installation_config,
+                config_path,
+                config_dict,
+            )
+
             config_dict["_installation_config"] = installation_config
             config_dict["_config_path"] = config_path
             return cls(**config_dict)
@@ -246,8 +252,12 @@ class _HaikuRAGCapabilityConfig(
 
     @property
     def capability(self) -> ai_capabilities.AbstractCapability:
+        # Named databases reach haiku.rag through the config, which
+        # resolves them into one capability covering the set.
+        db_path = None if self.rag_databases else self.rag_lancedb_path
+
         return type(self).capability_factory(
-            db_path=self.rag_lancedb_path,
+            db_path=db_path,
             config=self.haiku_rag_config,
             defer_loading=self.defer_loading,
         )
@@ -262,7 +272,11 @@ class _HaikuRAGCapabilityConfig(
             "kind": self.kind,
             "defer_loading": self.defer_loading,
         }
-        if self.rag_lancedb_stem is not None:
+        if self.rag_databases:
+            result["rag_databases"] = [
+                entry.as_yaml for entry in self.rag_databases
+            ]
+        elif self.rag_lancedb_stem is not None:
             result["rag_lancedb_stem"] = self.rag_lancedb_stem
         else:
             result["rag_lancedb_override_path"] = str(
@@ -774,7 +788,7 @@ class RoomSkillsConfig:
                 capability = config.capability
                 # Paranoid defence against a "can't get here" condition
                 assert capability.id is not None
-                paths[capability.id] = str(config.rag_lancedb_path)
+                paths[capability.id] = config.rag_db_audit_path
         return paths
 
     @property

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -200,7 +200,7 @@ class FilesystemSkillConfig:
 @dataclasses.dataclass(kw_only=True)
 class _HaikuRAGCapabilityConfig(
     config_rag._RAGConfigBase,
-    config_rag._RAGDatabaseBase,
+    config_rag._RAGDatabasesBase,
 ):
     capability_factory: typing.ClassVar[typing.Callable]
     capability_name: typing.ClassVar[str]
@@ -220,15 +220,6 @@ class _HaikuRAGCapabilityConfig(
     ):
         try:
             config_dict.pop("kind", None)
-
-            rldb_override_path = config_dict.pop(
-                "rag_lancedb_override_path",
-                None,
-            )
-            if rldb_override_path is not None:
-                config_dict["rag_lancedb_override_path"] = pathlib.Path(
-                    rldb_override_path
-                )
 
             config_rag.adjust_yaml_rag_databases(
                 installation_config,
@@ -267,16 +258,11 @@ class _HaikuRAGCapabilityConfig(
             "kind": self.kind,
             "defer_loading": self.defer_loading,
         }
-        if self.rag_databases:
-            result["rag_databases"] = [
-                entry.as_yaml for entry in self.rag_databases
-            ]
-        elif self.rag_lancedb_stem is not None:
-            result["rag_lancedb_stem"] = self.rag_lancedb_stem
-        else:
-            result["rag_lancedb_override_path"] = str(
-                self.rag_lancedb_override_path
-            )
+        # Always the list: the singular options are input sugar,
+        # normalized into 'rag_databases' before this can be read.
+        result["rag_databases"] = [
+            entry.as_yaml for entry in self.rag_databases
+        ]
         return result
 
     @property

--- a/src/soliplex/config/tools.py
+++ b/src/soliplex/config/tools.py
@@ -352,6 +352,12 @@ class SearchDocumentsToolConfig(
             cls._adjust_yaml_agui_feature_names(config_dict)
             cls._adjust_yaml_ai_tool_params(config_dict, config_path)
 
+            config_rag.adjust_yaml_rag_databases(
+                installation_config,
+                config_path,
+                config_dict,
+            )
+
             instance = cls(**config_dict)
         except Exception as exc:
             raise config_exc.FromYamlException(
@@ -366,7 +372,11 @@ class SearchDocumentsToolConfig(
     def as_yaml(self) -> dict:
         result = super().as_yaml
 
-        if self.rag_lancedb_stem is not None:
+        if self.rag_databases:
+            result["rag_databases"] = [
+                entry.as_yaml for entry in self.rag_databases
+            ]
+        elif self.rag_lancedb_stem is not None:
             result["rag_lancedb_stem"] = self.rag_lancedb_stem
         else:
             result["rag_lancedb_override_path"] = (

--- a/src/soliplex/config/tools.py
+++ b/src/soliplex/config/tools.py
@@ -331,7 +331,7 @@ _, SDTC_TOOL_KIND = SDTC_TOOL_NAME.rsplit(".", 1)
 class SearchDocumentsToolConfig(
     ToolConfig,
     config_rag._RAGConfigBase,
-    config_rag._RAGDatabaseBase,
+    config_rag._RAGDatabasesBase,
 ):
     kind: str = SDTC_TOOL_KIND
     tool_name: str = SDTC_TOOL_NAME
@@ -372,16 +372,11 @@ class SearchDocumentsToolConfig(
     def as_yaml(self) -> dict:
         result = super().as_yaml
 
-        if self.rag_databases:
-            result["rag_databases"] = [
-                entry.as_yaml for entry in self.rag_databases
-            ]
-        elif self.rag_lancedb_stem is not None:
-            result["rag_lancedb_stem"] = self.rag_lancedb_stem
-        else:
-            result["rag_lancedb_override_path"] = (
-                self.rag_lancedb_override_path
-            )
+        # Always the list: the singular options are input sugar,
+        # normalized into 'rag_databases' before this can be read.
+        result["rag_databases"] = [
+            entry.as_yaml for entry in self.rag_databases
+        ]
 
         result["search_documents_limit"] = self.search_documents_limit
 
@@ -393,7 +388,7 @@ class SearchDocumentsToolConfig(
         }
         return (
             super().get_extra_parameters()
-            | config_rag._RAGDatabaseBase.get_extra_parameters(self)
+            | config_rag._RAGDatabasesBase.get_extra_parameters(self)
             | local
         )
 

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -604,8 +604,10 @@ class SearchHit(pydantic.BaseModel):
     score: float
     chunk_id: str
     document_id: str
-    document_uri: str
-    document_title: str
+    # A document need not carry either: haiku.rag leaves both unset for
+    # content added without a URI, or never given a title.
+    document_uri: str | None = None
+    document_title: str | None = None
     document_meta: dict[str, typing.Any] = {}
     headings: list[str]
     page_numbers: list[int]

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -599,6 +599,7 @@ class RAGSource(pydantic.BaseModel):
 
 class SearchHit(pydantic.BaseModel):
     source: RAGSource
+    database: str | None = None  # haiku.rag database name, if named
     content: str
     score: float
     chunk_id: str
@@ -619,6 +620,7 @@ class SearchResults(pydantic.BaseModel):
 
 class RAGDocument(pydantic.BaseModel):
     source: RAGSource
+    database: str | None = None  # haiku.rag database name, if named
     id: str
     uri: str | None
     title: str | None
@@ -940,6 +942,7 @@ class ChunkVisualization(pydantic.BaseModel):
     """Page images for a chunk, with chunk text highlighted"""
 
     source: RAGSource
+    database: str | None = None  # haiku.rag database name, if named
     chunk_id: str
     document_uri: str | None
     images_base_64: list[str]

--- a/src/soliplex/tools/rag.py
+++ b/src/soliplex/tools/rag.py
@@ -28,14 +28,21 @@ async def search_documents(
 
     hr_config = tool_config.haiku_rag_config
 
+    # Named databases reach haiku.rag through the config, which federates
+    # them into one client.
+    if tool_config.rag_databases:
+        db_path = None
+    else:
+        db_path = tool_config.rag_lancedb_path
+
     with rag_audit.audit_tool_access(
         ctx.deps,
         audit_method="search",
-        db_path=str(tool_config.rag_lancedb_path),
+        db_path=tool_config.rag_db_audit_path,
         selector=query,
     ) as access:
         async with hr_client.HaikuRAG(
-            db_path=tool_config.rag_lancedb_path,
+            db_path=db_path,
             config=hr_config,
             read_only=True,
         ) as rag:

--- a/src/soliplex/tools/rag.py
+++ b/src/soliplex/tools/rag.py
@@ -28,13 +28,6 @@ async def search_documents(
 
     hr_config = tool_config.haiku_rag_config
 
-    # Named databases reach haiku.rag through the config, which federates
-    # them into one client.
-    if tool_config.rag_databases:
-        db_path = None
-    else:
-        db_path = tool_config.rag_lancedb_path
-
     with rag_audit.audit_tool_access(
         ctx.deps,
         audit_method="search",
@@ -42,7 +35,6 @@ async def search_documents(
         selector=query,
     ) as access:
         async with hr_client.HaikuRAG(
-            db_path=db_path,
             config=hr_config,
             read_only=True,
         ) as rag:

--- a/src/soliplex/views/rooms.py
+++ b/src/soliplex/views/rooms.py
@@ -410,7 +410,8 @@ async def get_search(
                     document_uri=hit.document_uri,
                     document_title=hit.document_title,
                     document_meta=hit.document_meta,
-                    headings=hit.headings,
+                    # A chunk with no heading metadata has no headings.
+                    headings=hit.headings or [],
                     page_numbers=hit.page_numbers,
                     labels=hit.labels,
                 )

--- a/src/soliplex/views/rooms.py
+++ b/src/soliplex/views/rooms.py
@@ -198,7 +198,7 @@ async def get_room_documents(
     ):
         source_tag = hr_client_kw.pop("source")
         source = models.RAGSource.from_source_tag(source_tag)
-        db_path = str(hr_client_kw["db_path"])
+        db_path = hr_client_kw.pop("audit_db_path")
 
         async with hr_client.HaikuRAG(**hr_client_kw) as rag:
             results = await rag.list_documents()
@@ -208,6 +208,7 @@ async def get_room_documents(
         for document in results:
             document_set[document.id] = models.RAGDocument(
                 source=source,
+                database=document.source,
                 id=document.id,
                 uri=document.uri,
                 title=document.title,
@@ -220,6 +221,26 @@ async def get_room_documents(
         room_id=room_id,
         document_set=document_set,
     )
+
+
+async def _find_chunk(rag, chunk_id: str):
+    """Return a chunk and the name of the database holding it
+
+    Chunk IDs repeat between copies of a database, so a client covering
+    several is asked one at a time, and the first covered database holding
+    the ID wins.  A client covering one database reports the name that
+    database was configured under, None where the configuration named none.
+    """
+    if not rag.covers_multiple:
+        return await rag.get_chunk_by_id(chunk_id), rag.source
+
+    for database in rag.source_names:
+        chunk = await rag.get_chunk_by_id(chunk_id, source=database)
+
+        if chunk:
+            return chunk, database
+
+    return None, None
 
 
 @util.logfire_span("GET /v1/rooms/{room_id}/chunk/{chunk_id}")
@@ -276,13 +297,14 @@ async def get_chunk_visualization(
     ):
         source_tag = hr_client_kw.pop("source")
         source = models.RAGSource.from_source_tag(source_tag)
-        db_path = str(hr_client_kw["db_path"])
+        db_path = hr_client_kw.pop("audit_db_path")
 
         async with hr_client.HaikuRAG(**hr_client_kw) as rag:
-            chunk = await rag.chunk_repository.get_by_id(chunk_id)
+            chunk, database = await _find_chunk(rag, chunk_id)
 
             if chunk:
-                images = await rag.visualize_chunk(
+                owner = await rag.reader_for(database)
+                images = await owner.visualize_chunk(
                     chunk, refs=doc_item_refs, expand=expand
                 )
                 break  # first hit wins
@@ -321,6 +343,7 @@ async def get_chunk_visualization(
 
     return models.ChunkVisualization(
         source=source,
+        database=database,
         chunk_id=chunk_id,
         document_uri=chunk.document_uri,
         images_base_64=base64_images,
@@ -365,7 +388,7 @@ async def get_search(
     ):
         source_tag = hr_client_kw.pop("source")
         source = models.RAGSource.from_source_tag(source_tag)
-        db_path = str(hr_client_kw["db_path"])
+        db_path = hr_client_kw.pop("audit_db_path")
 
         async with hr_client.HaikuRAG(**hr_client_kw) as rag:
             hits = await rag.search(
@@ -379,6 +402,7 @@ async def get_search(
             aggregate_hits.append(
                 models.SearchHit(
                     source=source,
+                    database=hit.source,
                     content=hit.content,
                     score=hit.score,
                     chunk_id=hit.chunk_id,

--- a/tests/unit/cli/test_cli_audit.py
+++ b/tests/unit/cli/test_cli_audit.py
@@ -64,11 +64,13 @@ _FILE_DBURI = "sqlite+aiosqlite:///x.db"
 
 
 class _OkRagCfg:
+    haiku_rag_config = None
     rag_databases = ()
     rag_lancedb_path = None
 
 
 class _ErrRagCfg:
+    haiku_rag_config = None
     rag_databases = ()
 
     @property
@@ -78,6 +80,31 @@ class _ErrRagCfg:
 
 class _NoDbRagCfg:
     """Exposes a haiku-rag config but names no database at all"""
+
+    haiku_rag_config = None
+
+
+class _DeferringRagCfg(_ErrRagCfg):
+    """Leaves placement to its haiku.rag config, so has no path to probe"""
+
+    names_own_databases = False
+
+
+TESTING_RAG_UNBUILDABLE = (
+    "lancedb.uri is not a thing; write lancedb.databases: {NAME: <location>}"
+)
+
+
+class _UnbuildableRagCfg(_ErrRagCfg):
+    """A config whose haiku.rag configuration will not load
+
+    Its database also fails to resolve, and only one of the two is the
+    diagnosis an operator can act on.
+    """
+
+    @property
+    def haiku_rag_config(self):
+        raise ValueError(TESTING_RAG_UNBUILDABLE)
 
 
 class _MultiRagCfg:
@@ -89,6 +116,7 @@ class _MultiRagCfg:
     class _Wiki(_ErrRagCfg):
         name = "wiki"
 
+    haiku_rag_config = None
     rag_databases = (_Papers(), _Wiki())
 
 
@@ -766,6 +794,43 @@ def test__invalid_room_rag_dbs_wo_database(
     found = cli_audit._invalid_room_rag_dbs(the_installation)
 
     assert "rag_lancedb_path" in found["rag"]["r1"]["skill:rag"]
+
+
+@mock.patch("soliplex.cli.audit._iter_room_rag_candidates")
+def test__invalid_room_rag_dbs_w_deferred_database(
+    iter_candidates,
+    the_installation,
+):
+    """A config placing no database of its own has no path to probe"""
+    room_cfg = mock.Mock()
+    room_cfg.id = "r1"
+    the_installation._config.room_configs = {"r1": room_cfg}
+    iter_candidates.side_effect = [[("skill:rag", _DeferringRagCfg())]]
+
+    assert cli_audit._invalid_room_rag_dbs(the_installation) == {}
+
+
+@mock.patch("soliplex.cli.audit._iter_room_rag_candidates")
+def test__invalid_room_rag_dbs_w_unbuildable_config(
+    iter_candidates,
+    the_installation,
+):
+    """A config that will not build reports that, not its unresolved path
+
+    Its path fails to resolve as well, but naming the missing file sends
+    the operator to create it, which is not the fix.
+    """
+    room_cfg = mock.Mock()
+    room_cfg.id = "r1"
+    the_installation._config.room_configs = {"r1": room_cfg}
+    iter_candidates.side_effect = [[("skill:rag", _UnbuildableRagCfg())]]
+
+    found = cli_audit._invalid_room_rag_dbs(the_installation)
+
+    (reported,) = found["rag"]["r1"].values()
+    assert reported == TESTING_RAG_UNBUILDABLE
+    assert TESTING_RAG_ERROR not in reported
+    assert list(found["rag"]["r1"]) == ["skill:rag"]
 
 
 # _audit_rooms_section: ui only

--- a/tests/unit/cli/test_cli_audit.py
+++ b/tests/unit/cli/test_cli_audit.py
@@ -64,13 +64,32 @@ _FILE_DBURI = "sqlite+aiosqlite:///x.db"
 
 
 class _OkRagCfg:
+    rag_databases = ()
     rag_lancedb_path = None
 
 
 class _ErrRagCfg:
+    rag_databases = ()
+
     @property
     def rag_lancedb_path(self):
         raise RAGError()
+
+
+class _NoDbRagCfg:
+    """Exposes a haiku-rag config but names no database at all"""
+
+
+class _MultiRagCfg:
+    """Names two databases, the second of which cannot be resolved"""
+
+    class _Papers(_OkRagCfg):
+        name = "papers"
+
+    class _Wiki(_ErrRagCfg):
+        name = "wiki"
+
+    rag_databases = (_Papers(), _Wiki())
 
 
 @pytest.fixture
@@ -715,6 +734,38 @@ def test__invalid_room_rag_dbs(
     assert iter_candidates.call_args_list == [
         mock.call(rc) for rc in room_configs.values()
     ]
+
+
+@mock.patch("soliplex.cli.audit._iter_room_rag_candidates")
+def test__invalid_room_rag_dbs_w_rag_databases(
+    iter_candidates,
+    the_installation,
+):
+    """Each named database is probed and reported under its own name"""
+    room_cfg = mock.Mock()
+    room_cfg.id = "r1"
+    the_installation._config.room_configs = {"r1": room_cfg}
+    iter_candidates.side_effect = [[("skill:rag", _MultiRagCfg())]]
+
+    found = cli_audit._invalid_room_rag_dbs(the_installation)
+
+    assert found == {"rag": {"r1": {"skill:rag#wiki": TESTING_RAG_ERROR}}}
+
+
+@mock.patch("soliplex.cli.audit._iter_room_rag_candidates")
+def test__invalid_room_rag_dbs_wo_database(
+    iter_candidates,
+    the_installation,
+):
+    """A config naming no database is reported, not raised at the caller"""
+    room_cfg = mock.Mock()
+    room_cfg.id = "r1"
+    the_installation._config.room_configs = {"r1": room_cfg}
+    iter_candidates.side_effect = [[("skill:rag", _NoDbRagCfg())]]
+
+    found = cli_audit._invalid_room_rag_dbs(the_installation)
+
+    assert "rag_lancedb_path" in found["rag"]["r1"]["skill:rag"]
 
 
 # _audit_rooms_section: ui only

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -1,4 +1,5 @@
 import contextlib
+import dataclasses
 import pathlib
 
 import pytest
@@ -228,21 +229,217 @@ def test__rdb_override_path_expands_user(db_rag_path, monkeypatch):
     assert rdb_config.rag_lancedb_path == db_override_path.resolve()
 
 
-def test__mrdb_ctor_wo_db_configs():
-    mrdb_config = config_rag._MultiRAGDatabasesBase()
-
-    assert isinstance(mrdb_config, config_rag.MultipleRAGDatabasesProtocol)
-    assert mrdb_config.rag_lancedb_paths == []
+@dataclasses.dataclass(kw_only=True)
+class _MultiDBConfig(config_rag._RAGConfigBase, config_rag._RAGDatabaseBase):
+    """Mirror the bases a real RAG skill / tool config mixes in"""
 
 
-def test__mrdb_ctor_w_db_configs(db_rag_path):
-    db_override_path = db_rag_path / "test.lancedb"
-    db_override_path.mkdir()
+@pytest.fixture
+def stem_environ(installation_config, db_rag_path):
+    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
+    installation_config.get_environment = ic_environ.get
+    return installation_config
 
-    db_config = config_rag._RAGDatabaseBase(
-        rag_lancedb_override_path=db_override_path,
+
+@pytest.fixture
+def make_entry(stem_environ, db_rag_path):
+    def _make_entry(name, stem=None, mkdir=True):
+        stem = name if stem is None else stem
+
+        if mkdir:
+            (db_rag_path / f"{stem}.lancedb").mkdir()
+
+        return config_rag.RAGDatabaseEntry(
+            name=name,
+            rag_lancedb_stem=stem,
+            _installation_config=stem_environ,
+        )
+
+    return _make_entry
+
+
+def test__rde_ctor_w_stem(stem_environ, db_rag_path):
+    entry = config_rag.RAGDatabaseEntry(
+        name="papers",
+        rag_lancedb_stem="papers",
+        _installation_config=stem_environ,
     )
-    mrdb_config = config_rag._MultiRAGDatabasesBase(db_configs=[db_config])
+    expected = db_rag_path / "papers.lancedb"
+    expected.mkdir()
 
-    assert isinstance(mrdb_config, config_rag.MultipleRAGDatabasesProtocol)
-    assert mrdb_config.rag_lancedb_paths == [db_override_path]
+    assert isinstance(entry, config_rag.SingleRAGDatabaseProtocol)
+    assert entry.rag_lancedb_path == expected.resolve()
+
+
+@pytest.mark.parametrize("name", [None, "", "   "])
+def test__rde_ctor_wo_name(name):
+    with pytest.raises(config_rag.RagDbEntryRequiresName):
+        config_rag.RAGDatabaseEntry(name=name, rag_lancedb_stem="papers")
+
+
+def test__rde_ctor_w_nested_databases():
+    with pytest.raises(config_rag.RagDbNestedDatabases):
+        config_rag.RAGDatabaseEntry(
+            name="papers",
+            rag_lancedb_stem="papers",
+            rag_databases=[
+                config_rag.RAGDatabaseEntry(
+                    name="wiki",
+                    rag_lancedb_stem="wiki",
+                ),
+            ],
+        )
+
+
+def test__rde_ctor_wo_stem_or_override():
+    with rdb_exactly_one:
+        config_rag.RAGDatabaseEntry(name="papers")
+
+
+@pytest.mark.parametrize(
+    "stem, override",
+    [
+        ("papers", None),
+        (None, "../papers.lancedb"),
+    ],
+)
+def test__rde_yaml_roundtrip(installation_config, temp_dir, stem, override):
+    config_path = temp_dir / "rooms" / "test" / "room_config.yaml"
+    entry_yaml = {"name": "papers"}
+
+    if stem is not None:
+        entry_yaml["rag_lancedb_stem"] = stem
+    else:
+        entry_yaml["rag_lancedb_override_path"] = override
+
+    entry = config_rag.RAGDatabaseEntry.from_yaml(
+        installation_config,
+        config_path,
+        entry_yaml,
+    )
+
+    assert entry.name == "papers"
+    assert entry._config_path == config_path
+    assert entry._installation_config is installation_config
+
+    if override is not None:
+        assert entry.rag_lancedb_override_path == pathlib.Path(override)
+
+    assert entry.as_yaml == entry_yaml
+
+
+def test__rdb_ctor_w_databases_and_stem(make_entry):
+    with pytest.raises(config_rag.RagDbSingleAndMultiConflict):
+        config_rag._RAGDatabaseBase(
+            rag_lancedb_stem="papers",
+            rag_databases=[make_entry("papers")],
+        )
+
+
+def test__rdb_ctor_w_duplicate_database_names(make_entry):
+    with pytest.raises(config_rag.RagDbDuplicateDatabaseName):
+        config_rag._RAGDatabaseBase(
+            rag_databases=[
+                make_entry("papers"),
+                make_entry("papers", stem="wiki"),
+            ],
+        )
+
+
+def test__rdb_lancedb_path_w_databases(make_entry):
+    """The single-database path is not a thing when several are named"""
+    rdb_config = config_rag._RAGDatabaseBase(
+        rag_databases=[make_entry("papers")],
+    )
+
+    with pytest.raises(config_rag.RagDbNamesSeveralDatabases):
+        _ = rdb_config.rag_lancedb_path
+
+
+def test__rdb_audit_path_w_single_database(stem_environ, db_rag_path):
+    expected = db_rag_path / "papers.lancedb"
+    expected.mkdir()
+    rdb_config = config_rag._RAGDatabaseBase(
+        rag_lancedb_stem="papers",
+        _installation_config=stem_environ,
+    )
+
+    assert rdb_config.rag_db_audit_path == str(expected.resolve())
+
+
+def test__rdb_audit_path_w_databases(make_entry, db_rag_path):
+    papers = db_rag_path / "papers.lancedb"
+    wiki = db_rag_path / "wiki.lancedb"
+    rdb_config = config_rag._RAGDatabaseBase(
+        rag_databases=[make_entry("papers"), make_entry("wiki")],
+    )
+
+    assert rdb_config.rag_db_audit_path == (
+        f"papers={papers.resolve()}, wiki={wiki.resolve()}"
+    )
+
+
+def test__rdb_extra_parameters_w_databases(make_entry, db_rag_path):
+    papers = db_rag_path / "papers.lancedb"
+    rdb_config = config_rag._RAGDatabaseBase(
+        rag_databases=[
+            make_entry("papers"),
+            make_entry("wiki", mkdir=False),
+        ],
+    )
+
+    found = rdb_config.get_extra_parameters()["rag_lancedb_paths"]
+
+    assert found["papers"] == papers.resolve()
+    assert found["wiki"].startswith("MISSING:")
+
+
+def test__rcb_haiku_rag_config_w_databases(
+    stem_environ,
+    make_entry,
+    temp_dir,
+    db_rag_path,
+):
+    stem_environ.haiku_rag_config = hr_config_module.AppConfig(
+        lancedb=hr_config_module.LanceDBConfig(uri="/from/installation"),
+    )
+    room_config_dir = temp_dir / "rooms" / "test"
+    room_config_dir.mkdir(parents=True)
+    papers = db_rag_path / "papers.lancedb"
+    wiki = db_rag_path / "wiki.lancedb"
+
+    config = _MultiDBConfig(
+        rag_databases=[make_entry("papers"), make_entry("wiki")],
+        _installation_config=stem_environ,
+        _config_path=room_config_dir / "room_config.yaml",
+    )
+
+    found = config.haiku_rag_config
+
+    assert found.lancedb.databases == {
+        "papers": str(papers.resolve()),
+        "wiki": str(wiki.resolve()),
+    }
+    assert found.lancedb.uri == ""
+    # The installation's own config is never mutated in place.
+    assert stem_environ.haiku_rag_config.lancedb.uri == "/from/installation"
+    assert config.haiku_rag_config is found
+
+
+def test__rcb_haiku_rag_config_w_missing_database(
+    stem_environ,
+    make_entry,
+    temp_dir,
+):
+    stem_environ.haiku_rag_config = hr_config_module.AppConfig()
+    room_config_dir = temp_dir / "rooms" / "test"
+    room_config_dir.mkdir(parents=True)
+
+    config = _MultiDBConfig(
+        rag_databases=[make_entry("papers", mkdir=False)],
+        _installation_config=stem_environ,
+        _config_path=room_config_dir / "room_config.yaml",
+    )
+
+    with rdb_not_found:
+        _ = config.haiku_rag_config

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -9,7 +9,8 @@ from haiku.rag import config as hr_config_module
 from soliplex.config import exceptions as config_exc
 from soliplex.config import rag as config_rag
 
-rdb_exactly_one = pytest.raises(config_rag.RagDbExactlyOneOfStemOrOverride)
+rdb_stem_and_override = pytest.raises(config_rag.RagDbStemAndOverrideConflict)
+rde_requires_db = pytest.raises(config_rag.RagDbEntryRequiresDatabase)
 rdb_not_found = pytest.raises(config_rag.RagDbFileNotFound)
 no_config_path = pytest.raises(config_exc.NoConfigPath)
 ok_stem = contextlib.nullcontext("stem")
@@ -127,8 +128,7 @@ def db_rag_path(temp_dir):
 @pytest.mark.parametrize(
     "w_config_path, stem, override, ctor_expectation, rlp_expectation",
     [
-        (False, None, None, rdb_exactly_one, None),
-        (False, "testing", "/dev/null", rdb_exactly_one, None),
+        (False, "testing", "/dev/null", rdb_stem_and_override, None),
         (False, "bogus", None, ok_stem, rdb_not_found),
         (False, "testing", None, ok_stem, ok_stem),
         (False, None, "./override", ok_ovr, rdb_not_found),
@@ -292,7 +292,7 @@ def test__rde_ctor_w_nested_databases():
 
 
 def test__rde_ctor_wo_stem_or_override():
-    with rdb_exactly_one:
+    with rde_requires_db:
         config_rag.RAGDatabaseEntry(name="papers")
 
 
@@ -409,7 +409,7 @@ def test__rdb_audit_path_w_single_database(stem_environ, db_rag_path):
         _installation_config=stem_environ,
     )
 
-    assert rdb_config.rag_db_audit_path == str(expected.resolve())
+    assert rdb_config.rag_db_audit_path == f"papers={expected.resolve()}"
 
 
 def test__rdb_audit_path_w_databases(make_entry, db_rag_path):
@@ -470,9 +470,8 @@ def test__rcb_haiku_rag_config_w_databases(
     temp_dir,
     db_rag_path,
 ):
-    stem_environ.haiku_rag_config = hr_config_module.AppConfig(
-        lancedb=hr_config_module.LanceDBConfig(uri="/from/installation"),
-    )
+    installation_hr_config = hr_config_module.AppConfig()
+    stem_environ.haiku_rag_config = installation_hr_config
     room_config_dir = temp_dir / "rooms" / "test"
     room_config_dir.mkdir(parents=True)
     papers = db_rag_path / "papers.lancedb"
@@ -490,9 +489,8 @@ def test__rcb_haiku_rag_config_w_databases(
         "papers": str(papers.resolve()),
         "wiki": str(wiki.resolve()),
     }
-    assert found.lancedb.uri == ""
     # The installation's own config is never mutated in place.
-    assert stem_environ.haiku_rag_config.lancedb.uri == "/from/installation"
+    assert installation_hr_config.lancedb.databases == {}
     assert config.haiku_rag_config is found
 
 
@@ -513,3 +511,146 @@ def test__rcb_haiku_rag_config_w_missing_database(
 
     with rdb_not_found:
         _ = config.haiku_rag_config
+
+
+def _hr_config_naming(**databases):
+    return hr_config_module.AppConfig(
+        lancedb=hr_config_module.LanceDBConfig(databases=databases),
+    )
+
+
+def _deferring_config(stem_environ, temp_dir, hr_config, **kw):
+    stem_environ.haiku_rag_config = hr_config
+    room_config_dir = temp_dir / "rooms" / "test"
+    room_config_dir.mkdir(parents=True, exist_ok=True)
+
+    return _MultiDBConfig(
+        _installation_config=stem_environ,
+        _config_path=room_config_dir / "room_config.yaml",
+        **kw,
+    )
+
+
+def test__rdb_ctor_wo_stem_or_override():
+    """Naming no database defers placement to the haiku.rag config"""
+    rdb_config = config_rag._RAGDatabaseBase()
+
+    assert rdb_config.rag_databases == []
+
+    with pytest.raises(config_rag.RagDbNamesNoDatabase):
+        _ = rdb_config.rag_lancedb_path
+
+
+def test__rcb_deferred_databases(stem_environ, temp_dir):
+    """A config naming nothing reports what its haiku.rag config places"""
+    config = _deferring_config(
+        stem_environ,
+        temp_dir,
+        _hr_config_naming(medic="s3://bucket/medic.lancedb"),
+    )
+
+    assert config.rag_lancedb_databases == {
+        "medic": "s3://bucket/medic.lancedb",
+    }
+    assert config.rag_database_names == ["medic"]
+    assert config.rag_db_audit_path == "medic=s3://bucket/medic.lancedb"
+    assert config.get_extra_parameters() == {"database_names": ["medic"]}
+
+
+def test__rcb_deferred_databases_several(stem_environ, temp_dir):
+    config = _deferring_config(
+        stem_environ,
+        temp_dir,
+        _hr_config_naming(
+            medic="s3://bucket/medic.lancedb",
+            papers="/data/papers.lancedb",
+        ),
+    )
+
+    assert config.rag_database_names == ["medic", "papers"]
+    assert config.rag_db_audit_path == (
+        "medic=s3://bucket/medic.lancedb, papers=/data/papers.lancedb"
+    )
+
+
+def test__rcb_deferred_databases_leaves_config_alone(stem_environ, temp_dir):
+    """Placing nothing of its own, the config is passed through as it is"""
+    hr_config = _hr_config_naming(medic="s3://bucket/medic.lancedb")
+    config = _deferring_config(stem_environ, temp_dir, hr_config)
+
+    assert config.haiku_rag_config.lancedb.databases == {
+        "medic": "s3://bucket/medic.lancedb",
+    }
+
+
+def test__rcb_deferred_default_database(stem_environ, temp_dir):
+    """Placing nothing anywhere, haiku.rag's default database is the one"""
+    hr_config = hr_config_module.AppConfig()
+    config = _deferring_config(stem_environ, temp_dir, hr_config)
+
+    expected = hr_config.storage.data_dir / "haiku.rag.lancedb"
+
+    assert config.rag_lancedb_databases == {"haiku.rag": expected}
+    assert config.rag_database_names == ["haiku.rag"]
+
+
+def _placing_config(stem_environ, temp_dir, **kw):
+    stem_environ.haiku_rag_config = _hr_config_naming(
+        medic="s3://bucket/medic.lancedb"
+    )
+    room_config_dir = temp_dir / "rooms" / "test"
+    room_config_dir.mkdir(parents=True, exist_ok=True)
+
+    return _MultiDBConfig(
+        _installation_config=stem_environ,
+        _config_path=room_config_dir / "room_config.yaml",
+        **kw,
+    )
+
+
+@pytest.mark.parametrize("w_override", [False, True])
+def test__rcb_two_placements(stem_environ, db_rag_path, temp_dir, w_override):
+    """Naming a database beside a configured one is two placements
+
+    The two sets need not overlap, so both are named.
+    """
+    (db_rag_path / "blank.lancedb").mkdir()
+
+    if w_override:
+        kw = {"rag_lancedb_override_path": str(db_rag_path / "blank.lancedb")}
+    else:
+        kw = {"rag_lancedb_stem": "blank"}
+
+    config = _placing_config(stem_environ, temp_dir, **kw)
+
+    with pytest.raises(config_rag.RagDbTwoPlacements) as exc_info:
+        _ = config.haiku_rag_config
+
+    message = str(exc_info.value)
+    assert "blank" in message
+    assert "medic" in message
+    assert "lancedb.databases" in message
+
+
+def test__rcb_two_placements_wo_local_file(stem_environ, temp_dir):
+    """Two placements is the diagnosis even when the named path is absent
+
+    The database named beside a configured one is typically a placeholder
+    that was never created, so resolving it first answers the wrong
+    question.
+    """
+    config = _placing_config(stem_environ, temp_dir, rag_lancedb_stem="blank")
+
+    with pytest.raises(config_rag.RagDbTwoPlacements):
+        _ = config.haiku_rag_config
+
+
+def test__rcb_two_placements_w_entries(stem_environ, make_entry, temp_dir):
+    config = _placing_config(
+        stem_environ, temp_dir, rag_databases=[make_entry("papers")]
+    )
+
+    with pytest.raises(config_rag.RagDbTwoPlacements) as exc_info:
+        _ = config.haiku_rag_config
+
+    assert "papers" in str(exc_info.value)

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -328,6 +328,51 @@ def test__rde_yaml_roundtrip(installation_config, temp_dir, stem, override):
     assert entry.as_yaml == entry_yaml
 
 
+@pytest.mark.parametrize("rag_databases", [None, []])
+def test_adjust_yaml_rag_databases_wo_entries(
+    installation_config,
+    temp_dir,
+    rag_databases,
+):
+    """An empty or omitted 'rag_databases' leaves the field at its default"""
+    config_dict = {"rag_databases": rag_databases}
+
+    config_rag.adjust_yaml_rag_databases(
+        installation_config,
+        temp_dir / "room_config.yaml",
+        config_dict,
+    )
+
+    assert (
+        config_rag._RAGDatabaseBase(
+            rag_lancedb_stem="papers",
+            **config_dict,
+        ).rag_databases
+        == []
+    )
+
+
+def test_adjust_yaml_rag_databases_w_entries(
+    installation_config,
+    temp_dir,
+    db_rag_path,
+):
+    (db_rag_path / "papers.lancedb").mkdir()
+    config_dict = {
+        "rag_databases": [{"name": "papers", "rag_lancedb_stem": "papers"}],
+    }
+
+    config_rag.adjust_yaml_rag_databases(
+        installation_config,
+        temp_dir / "room_config.yaml",
+        config_dict,
+    )
+
+    (entry,) = config_dict["rag_databases"]
+    assert isinstance(entry, config_rag.RAGDatabaseEntry)
+    assert entry.name == "papers"
+
+
 def test__rdb_ctor_w_databases_and_stem(make_entry):
     with pytest.raises(config_rag.RagDbSingleAndMultiConflict):
         config_rag._RAGDatabaseBase(

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -44,6 +44,74 @@ def test__deep_merge(base, derived, expected):
     assert found == expected
 
 
+@pytest.fixture
+def db_rag_path(temp_dir):
+    result = temp_dir / "db" / "rag"
+    result.mkdir(parents=True)
+    return result
+
+
+@pytest.fixture
+def stem_environ(installation_config, db_rag_path):
+    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
+    installation_config.get_environment = ic_environ.get
+    return installation_config
+
+
+@pytest.fixture
+def make_entry(stem_environ, db_rag_path):
+    def _make_entry(name, stem=None, mkdir=True):
+        stem = name if stem is None else stem
+
+        if mkdir:
+            (db_rag_path / f"{stem}.lancedb").mkdir()
+
+        return config_rag.RAGDatabaseEntry(
+            name=name,
+            rag_lancedb_stem=stem,
+            _installation_config=stem_environ,
+        )
+
+    return _make_entry
+
+
+@dataclasses.dataclass(kw_only=True)
+class _MultiDBConfig(config_rag._RAGConfigBase, config_rag._RAGDatabasesBase):
+    """Mirror the bases a real RAG skill / tool config mixes in"""
+
+
+def _hr_config_naming(**databases):
+    return hr_config_module.AppConfig(
+        lancedb=hr_config_module.LanceDBConfig(databases=databases),
+    )
+
+
+def _deferring_config(stem_environ, temp_dir, hr_config, **kw):
+    stem_environ.haiku_rag_config = hr_config
+    room_config_dir = temp_dir / "rooms" / "test"
+    room_config_dir.mkdir(parents=True, exist_ok=True)
+
+    return _MultiDBConfig(
+        _installation_config=stem_environ,
+        _config_path=room_config_dir / "room_config.yaml",
+        **kw,
+    )
+
+
+def _placing_config(stem_environ, temp_dir, **kw):
+    stem_environ.haiku_rag_config = _hr_config_naming(
+        medic="s3://bucket/medic.lancedb"
+    )
+    room_config_dir = temp_dir / "rooms" / "test"
+    room_config_dir.mkdir(parents=True, exist_ok=True)
+
+    return _MultiDBConfig(
+        _installation_config=stem_environ,
+        _config_path=room_config_dir / "room_config.yaml",
+        **kw,
+    )
+
+
 @pytest.mark.parametrize(
     "w_already, w_config_path, w_hr_yaml",
     [
@@ -118,352 +186,6 @@ def test__rcb_haiku_rag_config(
                 _ = rcb_config.haiku_rag_config
 
 
-@pytest.fixture
-def db_rag_path(temp_dir):
-    result = temp_dir / "db" / "rag"
-    result.mkdir(parents=True)
-    return result
-
-
-@pytest.mark.parametrize(
-    "w_config_path, stem, override, ctor_expectation, rlp_expectation",
-    [
-        (False, "testing", "/dev/null", rdb_stem_and_override, None),
-        (False, "bogus", None, ok_stem, rdb_not_found),
-        (False, "testing", None, ok_stem, ok_stem),
-        (False, None, "./override", ok_ovr, rdb_not_found),
-        (True, None, "./override", ok_ovr, ok_ovr),
-    ],
-)
-def test__rdb_ctor(
-    installation_config,
-    temp_dir,
-    db_rag_path,
-    w_config_path,
-    stem,
-    override,
-    ctor_expectation,
-    rlp_expectation,
-):
-    if stem not in (None, "bogus"):
-        from_stem = db_rag_path / f"{stem}.lancedb"
-        from_stem.mkdir()
-    else:
-        from_stem = None
-
-    if override is not None:
-        from_override = temp_dir / "rooms" / "test" / override
-        if not from_override.exists():
-            from_override.mkdir(parents=True)
-    else:
-        from_override = None
-
-    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
-    installation_config.get_environment = ic_environ.get
-
-    kw = {"_installation_config": installation_config}
-
-    if w_config_path:
-        exp_config_path = kw["_config_path"] = (
-            temp_dir / "rooms" / "test" / "room_config.yaml"
-        )
-    else:
-        exp_config_path = None
-
-    if stem is not None:
-        kw["rag_lancedb_stem"] = stem
-
-    if override is not None:
-        kw["rag_lancedb_override_path"] = override
-
-    with ctor_expectation as ctor_which:
-        rdb_config = config_rag._RAGDatabaseBase(**kw)
-
-    if isinstance(ctor_which, str):
-        assert isinstance(rdb_config, config_rag.SingleRAGDatabaseProtocol)
-
-        if ctor_which == "stem":
-            expected = from_stem
-        else:
-            expected = from_override
-
-        assert rdb_config._config_path == exp_config_path
-
-        with rlp_expectation as rlp_which:
-            found = rdb_config.rag_lancedb_path
-
-        if isinstance(rlp_which, str):
-            assert found.resolve() == expected.resolve()
-
-            expected_ep = {
-                "database_names": [expected.resolve().stem],
-            }
-            assert rdb_config.get_extra_parameters() == expected_ep
-        else:
-            exc = rlp_which.value
-            w_missing = rdb_config.get_extra_parameters()
-            (err,) = w_missing["database_names"]
-            assert err == f"MISSING: {exc.rag_db_filename.stem}"
-
-
-def test__rdb_override_path_expands_user(db_rag_path, monkeypatch):
-    """A '~' in an override path names the user's home directory.
-
-    Without expansion it would be resolved against the room directory as
-    a literal '~', which is never a database.
-    """
-    # 'expanduser' reads a different variable per platform: 'HOME' on
-    # POSIX, 'USERPROFILE' (then 'HOMEDRIVE' + 'HOMEPATH') on Windows,
-    # where 'HOME' is ignored outright. Set both so '~' resolves to the
-    # fixture directory rather than the real home on either platform.
-    monkeypatch.setenv("HOME", str(db_rag_path))
-    monkeypatch.setenv("USERPROFILE", str(db_rag_path))
-    db_override_path = db_rag_path / "test.lancedb"
-    db_override_path.mkdir()
-
-    rdb_config = config_rag._RAGDatabaseBase(
-        rag_lancedb_override_path=pathlib.Path("~/test.lancedb"),
-        _config_path=db_rag_path / "rooms" / "test" / "room_config.yaml",
-    )
-
-    assert rdb_config.rag_lancedb_path == db_override_path.resolve()
-
-
-@dataclasses.dataclass(kw_only=True)
-class _MultiDBConfig(config_rag._RAGConfigBase, config_rag._RAGDatabaseBase):
-    """Mirror the bases a real RAG skill / tool config mixes in"""
-
-
-@pytest.fixture
-def stem_environ(installation_config, db_rag_path):
-    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
-    installation_config.get_environment = ic_environ.get
-    return installation_config
-
-
-@pytest.fixture
-def make_entry(stem_environ, db_rag_path):
-    def _make_entry(name, stem=None, mkdir=True):
-        stem = name if stem is None else stem
-
-        if mkdir:
-            (db_rag_path / f"{stem}.lancedb").mkdir()
-
-        return config_rag.RAGDatabaseEntry(
-            name=name,
-            rag_lancedb_stem=stem,
-            _installation_config=stem_environ,
-        )
-
-    return _make_entry
-
-
-def test__rde_ctor_w_stem(stem_environ, db_rag_path):
-    entry = config_rag.RAGDatabaseEntry(
-        name="papers",
-        rag_lancedb_stem="papers",
-        _installation_config=stem_environ,
-    )
-    expected = db_rag_path / "papers.lancedb"
-    expected.mkdir()
-
-    assert isinstance(entry, config_rag.SingleRAGDatabaseProtocol)
-    assert entry.rag_lancedb_path == expected.resolve()
-
-
-@pytest.mark.parametrize("name", [None, "", "   "])
-def test__rde_ctor_wo_name(name):
-    with pytest.raises(config_rag.RagDbEntryRequiresName):
-        config_rag.RAGDatabaseEntry(name=name, rag_lancedb_stem="papers")
-
-
-def test__rde_ctor_w_nested_databases():
-    with pytest.raises(config_rag.RagDbNestedDatabases):
-        config_rag.RAGDatabaseEntry(
-            name="papers",
-            rag_lancedb_stem="papers",
-            rag_databases=[
-                config_rag.RAGDatabaseEntry(
-                    name="wiki",
-                    rag_lancedb_stem="wiki",
-                ),
-            ],
-        )
-
-
-def test__rde_ctor_wo_stem_or_override():
-    with rde_requires_db:
-        config_rag.RAGDatabaseEntry(name="papers")
-
-
-@pytest.mark.parametrize(
-    "stem, override",
-    [
-        ("papers", None),
-        (None, "../papers.lancedb"),
-    ],
-)
-def test__rde_yaml_roundtrip(installation_config, temp_dir, stem, override):
-    config_path = temp_dir / "rooms" / "test" / "room_config.yaml"
-    entry_yaml = {"name": "papers"}
-
-    if stem is not None:
-        entry_yaml["rag_lancedb_stem"] = stem
-    else:
-        entry_yaml["rag_lancedb_override_path"] = override
-
-    entry = config_rag.RAGDatabaseEntry.from_yaml(
-        installation_config,
-        config_path,
-        entry_yaml,
-    )
-
-    assert entry.name == "papers"
-    assert entry._config_path == config_path
-    assert entry._installation_config is installation_config
-
-    if override is not None:
-        assert entry.rag_lancedb_override_path == pathlib.Path(override)
-
-    assert entry.as_yaml == entry_yaml
-
-
-@pytest.mark.parametrize("rag_databases", [None, []])
-def test_adjust_yaml_rag_databases_wo_entries(
-    installation_config,
-    temp_dir,
-    rag_databases,
-):
-    """An empty or omitted 'rag_databases' leaves the field at its default"""
-    config_dict = {"rag_databases": rag_databases}
-
-    config_rag.adjust_yaml_rag_databases(
-        installation_config,
-        temp_dir / "room_config.yaml",
-        config_dict,
-    )
-
-    assert (
-        config_rag._RAGDatabaseBase(
-            rag_lancedb_stem="papers",
-            **config_dict,
-        ).rag_databases
-        == []
-    )
-
-
-def test_adjust_yaml_rag_databases_w_entries(
-    installation_config,
-    temp_dir,
-    db_rag_path,
-):
-    (db_rag_path / "papers.lancedb").mkdir()
-    config_dict = {
-        "rag_databases": [{"name": "papers", "rag_lancedb_stem": "papers"}],
-    }
-
-    config_rag.adjust_yaml_rag_databases(
-        installation_config,
-        temp_dir / "room_config.yaml",
-        config_dict,
-    )
-
-    (entry,) = config_dict["rag_databases"]
-    assert isinstance(entry, config_rag.RAGDatabaseEntry)
-    assert entry.name == "papers"
-
-
-def test__rdb_ctor_w_databases_and_stem(make_entry):
-    with pytest.raises(config_rag.RagDbSingleAndMultiConflict):
-        config_rag._RAGDatabaseBase(
-            rag_lancedb_stem="papers",
-            rag_databases=[make_entry("papers")],
-        )
-
-
-def test__rdb_ctor_w_duplicate_database_names(make_entry):
-    with pytest.raises(config_rag.RagDbDuplicateDatabaseName):
-        config_rag._RAGDatabaseBase(
-            rag_databases=[
-                make_entry("papers"),
-                make_entry("papers", stem="wiki"),
-            ],
-        )
-
-
-def test__rdb_lancedb_path_w_databases(make_entry):
-    """The single-database path is not a thing when several are named"""
-    rdb_config = config_rag._RAGDatabaseBase(
-        rag_databases=[make_entry("papers")],
-    )
-
-    with pytest.raises(config_rag.RagDbNamesSeveralDatabases):
-        _ = rdb_config.rag_lancedb_path
-
-
-def test__rdb_audit_path_w_single_database(stem_environ, db_rag_path):
-    expected = db_rag_path / "papers.lancedb"
-    expected.mkdir()
-    rdb_config = config_rag._RAGDatabaseBase(
-        rag_lancedb_stem="papers",
-        _installation_config=stem_environ,
-    )
-
-    assert rdb_config.rag_db_audit_path == f"papers={expected.resolve()}"
-
-
-def test__rdb_audit_path_w_databases(make_entry, db_rag_path):
-    papers = db_rag_path / "papers.lancedb"
-    wiki = db_rag_path / "wiki.lancedb"
-    rdb_config = config_rag._RAGDatabaseBase(
-        rag_databases=[make_entry("papers"), make_entry("wiki")],
-    )
-
-    assert rdb_config.rag_db_audit_path == (
-        f"papers={papers.resolve()}, wiki={wiki.resolve()}"
-    )
-
-
-def test__rdb_extra_parameters_w_databases(make_entry):
-    """Every database is named, and a missing one says so"""
-    rdb_config = config_rag._RAGDatabaseBase(
-        rag_databases=[
-            make_entry("papers"),
-            make_entry("wiki", mkdir=False),
-        ],
-    )
-
-    assert rdb_config.get_extra_parameters() == {
-        "database_names": ["papers", "MISSING: wiki"],
-    }
-
-
-def test__rdb_lancedb_databases_w_stem(stem_environ, db_rag_path):
-    """A config with no 'rag_databases' names its database for the stem"""
-    expected = db_rag_path / "papers.lancedb"
-    expected.mkdir()
-    rdb_config = config_rag._RAGDatabaseBase(
-        rag_lancedb_stem="papers",
-        _installation_config=stem_environ,
-    )
-
-    assert rdb_config.rag_lancedb_databases == {"papers": expected.resolve()}
-    assert rdb_config.get_extra_parameters() == {
-        "database_names": ["papers"],
-    }
-
-
-def test__rdb_lancedb_databases_w_databases(make_entry, db_rag_path):
-    rdb_config = config_rag._RAGDatabaseBase(
-        rag_databases=[make_entry("papers"), make_entry("wiki")],
-    )
-
-    assert rdb_config.rag_lancedb_databases == {
-        "papers": (db_rag_path / "papers.lancedb").resolve(),
-        "wiki": (db_rag_path / "wiki.lancedb").resolve(),
-    }
-
-
 def test__rcb_haiku_rag_config_w_databases(
     stem_environ,
     make_entry,
@@ -511,34 +233,6 @@ def test__rcb_haiku_rag_config_w_missing_database(
 
     with rdb_not_found:
         _ = config.haiku_rag_config
-
-
-def _hr_config_naming(**databases):
-    return hr_config_module.AppConfig(
-        lancedb=hr_config_module.LanceDBConfig(databases=databases),
-    )
-
-
-def _deferring_config(stem_environ, temp_dir, hr_config, **kw):
-    stem_environ.haiku_rag_config = hr_config
-    room_config_dir = temp_dir / "rooms" / "test"
-    room_config_dir.mkdir(parents=True, exist_ok=True)
-
-    return _MultiDBConfig(
-        _installation_config=stem_environ,
-        _config_path=room_config_dir / "room_config.yaml",
-        **kw,
-    )
-
-
-def test__rdb_ctor_wo_stem_or_override():
-    """Naming no database defers placement to the haiku.rag config"""
-    rdb_config = config_rag._RAGDatabaseBase()
-
-    assert rdb_config.rag_databases == []
-
-    with pytest.raises(config_rag.RagDbNamesNoDatabase):
-        _ = rdb_config.rag_lancedb_path
 
 
 def test__rcb_deferred_databases(stem_environ, temp_dir):
@@ -594,20 +288,6 @@ def test__rcb_deferred_default_database(stem_environ, temp_dir):
     assert config.rag_database_names == ["haiku.rag"]
 
 
-def _placing_config(stem_environ, temp_dir, **kw):
-    stem_environ.haiku_rag_config = _hr_config_naming(
-        medic="s3://bucket/medic.lancedb"
-    )
-    room_config_dir = temp_dir / "rooms" / "test"
-    room_config_dir.mkdir(parents=True, exist_ok=True)
-
-    return _MultiDBConfig(
-        _installation_config=stem_environ,
-        _config_path=room_config_dir / "room_config.yaml",
-        **kw,
-    )
-
-
 @pytest.mark.parametrize("w_override", [False, True])
 def test__rcb_two_placements(stem_environ, db_rag_path, temp_dir, w_override):
     """Naming a database beside a configured one is two placements
@@ -654,3 +334,348 @@ def test__rcb_two_placements_w_entries(stem_environ, make_entry, temp_dir):
         _ = config.haiku_rag_config
 
     assert "papers" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "stem, override, expected_name",
+    [
+        ("testing", None, "testing"),
+        (None, "./override", "override"),
+        (None, "/data/papers.lancedb", "papers"),
+    ],
+)
+def test__rdb_ctor_normalizes_sugar(
+    installation_config,
+    temp_dir,
+    stem,
+    override,
+    expected_name,
+):
+    """The singular options are sugar for a one-entry 'rag_databases'"""
+    config_path = temp_dir / "rooms" / "test" / "room_config.yaml"
+    kw = {
+        "_installation_config": installation_config,
+        "_config_path": config_path,
+    }
+
+    if stem is not None:
+        kw["rag_lancedb_stem"] = stem
+
+    if override is not None:
+        kw["rag_lancedb_override_path"] = override
+
+    rdb_config = config_rag._RAGDatabasesBase(**kw)
+
+    (entry,) = rdb_config.rag_databases
+    assert entry.name == expected_name
+    assert entry.rag_lancedb_stem == stem
+
+    if override is None:
+        assert entry.rag_lancedb_override_path is None
+    else:
+        # The entry normalizes whatever spelling reached it.
+        assert entry.rag_lancedb_override_path == pathlib.Path(override)
+    assert entry._config_path == config_path
+    assert entry._installation_config is installation_config
+    assert rdb_config.names_own_databases
+
+
+def test__rdb_ctor_w_stem_and_override(installation_config):
+    """The sugar carries the entry's own 'exactly one' check"""
+    with rdb_stem_and_override:
+        config_rag._RAGDatabasesBase(
+            rag_lancedb_stem="testing",
+            rag_lancedb_override_path="/dev/null",
+            _installation_config=installation_config,
+        )
+
+
+def test__rdb_ctor_wo_stem_or_override():
+    """Naming no database defers placement to the haiku.rag config"""
+    rdb_config = config_rag._RAGDatabasesBase()
+
+    assert rdb_config.rag_databases == []
+    assert not rdb_config.names_own_databases
+
+
+def test__rdb_ctor_w_databases_and_stem(make_entry):
+    with pytest.raises(config_rag.RagDbSingleAndMultiConflict):
+        config_rag._RAGDatabasesBase(
+            rag_lancedb_stem="papers",
+            rag_databases=[make_entry("papers")],
+        )
+
+
+def test__rdb_ctor_w_duplicate_database_names(make_entry):
+    with pytest.raises(config_rag.RagDbDuplicateDatabaseName):
+        config_rag._RAGDatabasesBase(
+            rag_databases=[
+                make_entry("papers"),
+                make_entry("papers", stem="wiki"),
+            ],
+        )
+
+
+def test__rdb_lancedb_databases_w_stem(stem_environ, db_rag_path):
+    """A config with no 'rag_databases' names its database for the stem"""
+    expected = db_rag_path / "papers.lancedb"
+    expected.mkdir()
+    rdb_config = config_rag._RAGDatabasesBase(
+        rag_lancedb_stem="papers",
+        _installation_config=stem_environ,
+    )
+
+    assert rdb_config.rag_lancedb_databases == {"papers": expected.resolve()}
+    assert rdb_config.get_extra_parameters() == {
+        "database_names": ["papers"],
+    }
+
+
+def test__rdb_lancedb_databases_w_databases(make_entry, db_rag_path):
+    rdb_config = config_rag._RAGDatabasesBase(
+        rag_databases=[make_entry("papers"), make_entry("wiki")],
+    )
+
+    assert rdb_config.rag_lancedb_databases == {
+        "papers": (db_rag_path / "papers.lancedb").resolve(),
+        "wiki": (db_rag_path / "wiki.lancedb").resolve(),
+    }
+
+
+def test__rdb_audit_path_w_single_database(stem_environ, db_rag_path):
+    expected = db_rag_path / "papers.lancedb"
+    expected.mkdir()
+    rdb_config = config_rag._RAGDatabasesBase(
+        rag_lancedb_stem="papers",
+        _installation_config=stem_environ,
+    )
+
+    assert rdb_config.rag_db_audit_path == f"papers={expected.resolve()}"
+
+
+def test__rdb_audit_path_w_databases(make_entry, db_rag_path):
+    papers = db_rag_path / "papers.lancedb"
+    wiki = db_rag_path / "wiki.lancedb"
+    rdb_config = config_rag._RAGDatabasesBase(
+        rag_databases=[make_entry("papers"), make_entry("wiki")],
+    )
+
+    assert rdb_config.rag_db_audit_path == (
+        f"papers={papers.resolve()}, wiki={wiki.resolve()}"
+    )
+
+
+def test__rdb_extra_parameters_w_databases(make_entry):
+    """Every database is named, and a missing one says so"""
+    rdb_config = config_rag._RAGDatabasesBase(
+        rag_databases=[
+            make_entry("papers"),
+            make_entry("wiki", mkdir=False),
+        ],
+    )
+
+    assert rdb_config.get_extra_parameters() == {
+        "database_names": ["papers", "MISSING: wiki"],
+    }
+
+
+@pytest.mark.parametrize("rag_databases", [None, []])
+def test_adjust_yaml_rag_databases_wo_entries(
+    installation_config,
+    temp_dir,
+    rag_databases,
+):
+    """An empty or omitted 'rag_databases' leaves the field at its default"""
+    config_dict = {"rag_databases": rag_databases}
+
+    config_rag.adjust_yaml_rag_databases(
+        installation_config,
+        temp_dir / "room_config.yaml",
+        config_dict,
+    )
+
+    assert config_rag._RAGDatabasesBase(**config_dict).rag_databases == []
+
+
+def test_adjust_yaml_rag_databases_w_entries(
+    installation_config,
+    temp_dir,
+    db_rag_path,
+):
+    (db_rag_path / "papers.lancedb").mkdir()
+    config_dict = {
+        "rag_databases": [{"name": "papers", "rag_lancedb_stem": "papers"}],
+    }
+
+    config_rag.adjust_yaml_rag_databases(
+        installation_config,
+        temp_dir / "room_config.yaml",
+        config_dict,
+    )
+
+    (entry,) = config_dict["rag_databases"]
+    assert isinstance(entry, config_rag.RAGDatabaseEntry)
+    assert entry.name == "papers"
+
+
+def test__rde_ctor_w_stem(stem_environ, db_rag_path):
+    entry = config_rag.RAGDatabaseEntry(
+        name="papers",
+        rag_lancedb_stem="papers",
+        _installation_config=stem_environ,
+    )
+    expected = db_rag_path / "papers.lancedb"
+    expected.mkdir()
+
+    assert isinstance(entry, config_rag.SingleRAGDatabaseProtocol)
+    assert entry.rag_lancedb_path == expected.resolve()
+
+
+@pytest.mark.parametrize("name", ["", "   "])
+def test__rde_ctor_w_blank_name(name):
+    """Spelled out but empty is a typo, not a request to derive one"""
+    with pytest.raises(config_rag.RagDbEntryRequiresName):
+        config_rag.RAGDatabaseEntry(name=name, rag_lancedb_stem="papers")
+
+
+@pytest.mark.parametrize(
+    "kw, expected",
+    [
+        ({"rag_lancedb_stem": "papers"}, "papers"),
+        ({"rag_lancedb_override_path": "../wiki.lancedb"}, "wiki"),
+        ({"rag_lancedb_override_path": pathlib.Path("/db/medic")}, "medic"),
+    ],
+)
+def test__rde_ctor_wo_name(kw, expected):
+    """An entry naming none takes the name from whichever option placed it"""
+    entry = config_rag.RAGDatabaseEntry(**kw)
+
+    assert entry.name == expected
+
+
+def test__rde_ctor_wo_stem_or_override():
+    with rde_requires_db:
+        config_rag.RAGDatabaseEntry(name="papers")
+
+
+@pytest.mark.parametrize(
+    "w_config_path, stem, override, expectation",
+    [
+        (False, "bogus", None, rdb_not_found),
+        (False, "testing", None, ok_stem),
+        (False, None, "./override", rdb_not_found),
+        (True, None, "./override", ok_ovr),
+    ],
+)
+def test__rde_lancedb_path(
+    installation_config,
+    temp_dir,
+    db_rag_path,
+    w_config_path,
+    stem,
+    override,
+    expectation,
+):
+    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
+    installation_config.get_environment = ic_environ.get
+
+    room_dir = temp_dir / "rooms" / "test"
+    kw = {"_installation_config": installation_config}
+
+    if w_config_path:
+        kw["_config_path"] = room_dir / "room_config.yaml"
+
+    if stem is not None:
+        kw["rag_lancedb_stem"] = stem
+        expected = db_rag_path / f"{stem}.lancedb"
+
+        if stem != "bogus":
+            expected.mkdir()
+    else:
+        kw["rag_lancedb_override_path"] = override
+        # With no config path the override resolves against the cwd.
+        parent = room_dir if w_config_path else pathlib.Path.cwd()
+        expected = parent / override
+
+        if w_config_path:
+            expected.mkdir(parents=True)
+
+    entry = config_rag.RAGDatabaseEntry(**kw)
+
+    with expectation as which:
+        found = entry.rag_lancedb_path
+
+    if isinstance(which, str):
+        assert found == expected.resolve()
+        assert entry.database_name == entry.name
+    else:
+        assert which.value.rag_db_filename == expected.resolve()
+        assert entry.database_name == f"MISSING: {entry.name}"
+
+
+def test__rde_override_path_expands_user(db_rag_path, monkeypatch):
+    """A '~' in an override path names the user's home directory.
+
+    Without expansion it would be resolved against the room directory as
+    a literal '~', which is never a database.
+    """
+    # 'expanduser' reads a different variable per platform: 'HOME' on
+    # POSIX, 'USERPROFILE' (then 'HOMEDRIVE' + 'HOMEPATH') on Windows,
+    # where 'HOME' is ignored outright. Set both so '~' resolves to the
+    # fixture directory rather than the real home on either platform.
+    monkeypatch.setenv("HOME", str(db_rag_path))
+    monkeypatch.setenv("USERPROFILE", str(db_rag_path))
+    db_override_path = db_rag_path / "test.lancedb"
+    db_override_path.mkdir()
+
+    entry = config_rag.RAGDatabaseEntry(
+        rag_lancedb_override_path=pathlib.Path("~/test.lancedb"),
+        _config_path=db_rag_path / "rooms" / "test" / "room_config.yaml",
+    )
+
+    assert entry.rag_lancedb_path == db_override_path.resolve()
+
+
+def test__rde_from_yaml_w_nested_databases(installation_config, temp_dir):
+    with pytest.raises(config_rag.RagDbNestedDatabases):
+        config_rag.RAGDatabaseEntry.from_yaml(
+            installation_config,
+            temp_dir / "room_config.yaml",
+            {
+                "name": "papers",
+                "rag_lancedb_stem": "papers",
+                "rag_databases": [{"name": "wiki", "rag_lancedb_stem": "w"}],
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "stem, override",
+    [
+        ("papers", None),
+        (None, "../papers.lancedb"),
+    ],
+)
+def test__rde_yaml_roundtrip(installation_config, temp_dir, stem, override):
+    config_path = temp_dir / "rooms" / "test" / "room_config.yaml"
+    entry_yaml = {"name": "papers"}
+
+    if stem is not None:
+        entry_yaml["rag_lancedb_stem"] = stem
+    else:
+        entry_yaml["rag_lancedb_override_path"] = override
+
+    entry = config_rag.RAGDatabaseEntry.from_yaml(
+        installation_config,
+        config_path,
+        entry_yaml,
+    )
+
+    assert entry.name == "papers"
+    assert entry._config_path == config_path
+    assert entry._installation_config is installation_config
+
+    if override is not None:
+        assert entry.rag_lancedb_override_path == pathlib.Path(override)
+
+    assert entry.as_yaml == entry_yaml

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -424,8 +424,8 @@ def test__rdb_audit_path_w_databases(make_entry, db_rag_path):
     )
 
 
-def test__rdb_extra_parameters_w_databases(make_entry, db_rag_path):
-    papers = db_rag_path / "papers.lancedb"
+def test__rdb_extra_parameters_w_databases(make_entry):
+    """Every database is named, and a missing one says so"""
     rdb_config = config_rag._RAGDatabaseBase(
         rag_databases=[
             make_entry("papers"),
@@ -433,10 +433,35 @@ def test__rdb_extra_parameters_w_databases(make_entry, db_rag_path):
         ],
     )
 
-    found = rdb_config.get_extra_parameters()["rag_lancedb_paths"]
+    assert rdb_config.get_extra_parameters() == {
+        "database_names": ["papers", "MISSING: wiki"],
+    }
 
-    assert found["papers"] == papers.resolve()
-    assert found["wiki"].startswith("MISSING:")
+
+def test__rdb_lancedb_databases_w_stem(stem_environ, db_rag_path):
+    """A config with no 'rag_databases' names its database for the stem"""
+    expected = db_rag_path / "papers.lancedb"
+    expected.mkdir()
+    rdb_config = config_rag._RAGDatabaseBase(
+        rag_lancedb_stem="papers",
+        _installation_config=stem_environ,
+    )
+
+    assert rdb_config.rag_lancedb_databases == {"papers": expected.resolve()}
+    assert rdb_config.get_extra_parameters() == {
+        "database_names": ["papers"],
+    }
+
+
+def test__rdb_lancedb_databases_w_databases(make_entry, db_rag_path):
+    rdb_config = config_rag._RAGDatabaseBase(
+        rag_databases=[make_entry("papers"), make_entry("wiki")],
+    )
+
+    assert rdb_config.rag_lancedb_databases == {
+        "papers": (db_rag_path / "papers.lancedb").resolve(),
+        "wiki": (db_rag_path / "wiki.lancedb").resolve(),
+    }
 
 
 def test__rcb_haiku_rag_config_w_databases(

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -952,7 +952,8 @@ async def test_roomconfig_list_haiku_rag_client_kws(
     db_path.mkdir()
 
     expected = [
-        exp_kw | {"db_path": db_path, "audit_db_path": str(db_path)}
+        {key: value for key, value in exp_kw.items() if key != "db_path"}
+        | {"audit_db_path": str(db_path)}
         if "db_path" in exp_kw
         else exp_kw
         for exp_kw in expected
@@ -1039,7 +1040,7 @@ def test_roomconfig_list_haiku_rag_client_kws_w_rag_databases(
 
     (found,) = room_config.list_haiku_rag_client_kw(include_source=True)
 
-    assert found["db_path"] is None
+    assert "db_path" not in found
     assert found["read_only"] is True
     assert found["source"] == "skill:rag"
     assert found["audit_db_path"] == f"papers={papers}, wiki={wiki}"

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -123,7 +123,7 @@ W_HR_TOOLS_ROOM_CONFIG_KW = BARE_ROOM_CONFIG_KW | {
             config_tools.ToolConfig,
             rag_lancedb_path=LANCE_DB_OVERRIDE_PATH,
             rag_databases=[],
-            rag_db_audit_path=str(LANCE_DB_OVERRIDE_PATH),
+            rag_db_audit_path=f"rag={LANCE_DB_OVERRIDE_PATH}",
             haiku_rag_config=HR_CONFIG,
         ),
     },
@@ -609,7 +609,7 @@ def test_roomconfig_rag_db_paths_w_hit(temp_dir, installation_config):
 
     found = room_config.rag_db_paths
 
-    assert found == {"haiku-rag": str(OVERRIDE_PATH)}
+    assert found == {"haiku-rag": f"rag={OVERRIDE_PATH}"}
 
 
 def test_roomconfig_has_sandbox_bare(installation_config):
@@ -953,7 +953,7 @@ async def test_roomconfig_list_haiku_rag_client_kws(
 
     expected = [
         {key: value for key, value in exp_kw.items() if key != "db_path"}
-        | {"audit_db_path": str(db_path)}
+        | {"audit_db_path": f"rag={db_path}"}
         if "db_path" in exp_kw
         else exp_kw
         for exp_kw in expected
@@ -992,7 +992,7 @@ async def test_roomconfig_list_haiku_rag_client_kws(
             rldbp = getattr(value, "rag_lancedb_path", None)
             if rldbp is not None:
                 value.rag_lancedb_path = db_path
-                value.rag_db_audit_path = str(db_path)
+                value.rag_db_audit_path = f"rag={db_path}"
 
     room_config = config_rooms.RoomConfig(
         _installation_config=installation_config_w_skill,

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -74,6 +74,20 @@ skills:
         - "{test_skills.SKILL_NAME}"
 """
 
+
+def _replace_w_entries(config, **changes):
+    """Replace a DB-bearing config, carrying changes into 'rag_databases'
+
+    An entry holds its own '_config_path' / '_installation_config', which
+    'dataclasses.replace' on the owning config leaves alone.
+    """
+    changes["rag_databases"] = [
+        dataclasses.replace(entry, **changes) for entry in config.rag_databases
+    ]
+
+    return dataclasses.replace(config, **changes)
+
+
 LANCE_DB_OVERRIDE_PATH = pathlib.Path("/tmp/rag.lancedb")
 # 'str(WindowsPath("/tmp/rag.lancedb"))' is '\tmp\rag.lancedb', and a
 # double-quoted YAML scalar expands '\t' / '\r' as escapes -- so the path
@@ -121,7 +135,7 @@ W_HR_TOOLS_ROOM_CONFIG_KW = BARE_ROOM_CONFIG_KW | {
     "tool_configs": {
         "hr_tool": mock.create_autospec(
             config_tools.ToolConfig,
-            rag_lancedb_path=LANCE_DB_OVERRIDE_PATH,
+            rag_lancedb_databases={"rag": LANCE_DB_OVERRIDE_PATH},
             rag_databases=[],
             rag_db_audit_path=f"rag={LANCE_DB_OVERRIDE_PATH}",
             haiku_rag_config=HR_CONFIG,
@@ -348,7 +362,7 @@ def test_roomconfig_from_yaml(
         if "skills" in config_yaml:
             replaced_skill_configs = {}
             for key, skill_config in expected.skills._skill_configs.items():
-                replaced_skill_configs[key] = dataclasses.replace(
+                replaced_skill_configs[key] = _replace_w_entries(
                     skill_config,
                     _installation_config=installation_config_w_skill,
                     _config_path=yaml_file,
@@ -976,7 +990,14 @@ async def test_roomconfig_list_haiku_rag_client_kws(
             replaced_skill_configs[key] = dataclasses.replace(
                 skill_config,
                 _installation_config=installation_config_w_skill,
-                rag_lancedb_override_path=db_path,
+                rag_databases=[
+                    dataclasses.replace(
+                        entry,
+                        rag_lancedb_override_path=db_path,
+                        _installation_config=installation_config_w_skill,
+                    )
+                    for entry in skill_config.rag_databases
+                ],
                 _haiku_rag_config=HR_CONFIG,
             )
 
@@ -989,9 +1010,9 @@ async def test_roomconfig_list_haiku_rag_client_kws(
     tool_configs = room_config_kwargs.get("tool_configs")
     if tool_configs is not None:
         for value in tool_configs.values():
-            rldbp = getattr(value, "rag_lancedb_path", None)
-            if rldbp is not None:
-                value.rag_lancedb_path = db_path
+            databases = getattr(value, "rag_lancedb_databases", None)
+            if databases is not None:
+                value.rag_lancedb_databases = {"rag": db_path}
                 value.rag_db_audit_path = f"rag={db_path}"
 
     room_config = config_rooms.RoomConfig(

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -122,6 +122,8 @@ W_HR_TOOLS_ROOM_CONFIG_KW = BARE_ROOM_CONFIG_KW | {
         "hr_tool": mock.create_autospec(
             config_tools.ToolConfig,
             rag_lancedb_path=LANCE_DB_OVERRIDE_PATH,
+            rag_databases=[],
+            rag_db_audit_path=str(LANCE_DB_OVERRIDE_PATH),
             haiku_rag_config=HR_CONFIG,
         ),
     },
@@ -950,13 +952,19 @@ async def test_roomconfig_list_haiku_rag_client_kws(
     db_path.mkdir()
 
     expected = [
-        exp_kw | {"db_path": db_path} if "db_path" in exp_kw else exp_kw
+        exp_kw | {"db_path": db_path, "audit_db_path": str(db_path)}
+        if "db_path" in exp_kw
+        else exp_kw
         for exp_kw in expected
     ]
 
     if not incl_source_kwargs.get("include_source"):
         expected = [
-            {key: value for key, value in exp_kw.items() if key != "source"}
+            {
+                key: value
+                for key, value in exp_kw.items()
+                if key not in ("source", "audit_db_path")
+            }
             for exp_kw in expected
         ]
 
@@ -983,6 +991,7 @@ async def test_roomconfig_list_haiku_rag_client_kws(
             rldbp = getattr(value, "rag_lancedb_path", None)
             if rldbp is not None:
                 value.rag_lancedb_path = db_path
+                value.rag_db_audit_path = str(db_path)
 
     room_config = config_rooms.RoomConfig(
         _installation_config=installation_config_w_skill,
@@ -992,6 +1001,52 @@ async def test_roomconfig_list_haiku_rag_client_kws(
     found = list(room_config.list_haiku_rag_client_kw(**incl_source_kwargs))
 
     assert found == expected
+
+
+def test_roomconfig_list_haiku_rag_client_kws_w_rag_databases(
+    installation_config,
+    temp_dir,
+):
+    """Named databases yield one federated client, not one client each"""
+    papers = temp_dir / "papers.lancedb"
+    papers.mkdir()
+    wiki = temp_dir / "wiki.lancedb"
+    wiki.mkdir()
+    installation_config.haiku_rag_config = hr_config.AppConfig()
+
+    skill_config = config_skills.HR_RAG_SkillConfig(
+        rag_databases=[
+            config_rag.RAGDatabaseEntry(
+                name="papers",
+                rag_lancedb_override_path=papers,
+            ),
+            config_rag.RAGDatabaseEntry(
+                name="wiki",
+                rag_lancedb_override_path=wiki,
+            ),
+        ],
+        _installation_config=installation_config,
+        _config_path=temp_dir / "room_config.yaml",
+    )
+    room_config = config_rooms.RoomConfig(
+        _installation_config=installation_config,
+        skills=config_skills.RoomSkillsConfig(
+            _skill_configs={"rag": skill_config},
+            _installation_config=installation_config,
+        ),
+        **BARE_ROOM_CONFIG_KW,
+    )
+
+    (found,) = room_config.list_haiku_rag_client_kw(include_source=True)
+
+    assert found["db_path"] is None
+    assert found["read_only"] is True
+    assert found["source"] == "skill:rag"
+    assert found["audit_db_path"] == f"papers={papers}, wiki={wiki}"
+    assert found["config"].lancedb.databases == {
+        "papers": str(papers),
+        "wiki": str(wiki),
+    }
 
 
 def test_roomconfig_list_haiku_rag_client_kws_wo_database(

--- a/tests/unit/config/test_config_rooms.py
+++ b/tests/unit/config/test_config_rooms.py
@@ -12,6 +12,7 @@ from haiku.rag.capabilities import rag as hr_rag
 from soliplex.config import agents as config_agents
 from soliplex.config import exceptions as config_exc
 from soliplex.config import quizzes as config_quizzes
+from soliplex.config import rag as config_rag
 from soliplex.config import rooms as config_rooms
 from soliplex.config import skills as config_skills
 from soliplex.config import tools as config_tools
@@ -991,3 +992,16 @@ async def test_roomconfig_list_haiku_rag_client_kws(
     found = list(room_config.list_haiku_rag_client_kw(**incl_source_kwargs))
 
     assert found == expected
+
+
+def test_roomconfig_list_haiku_rag_client_kws_wo_database(
+    installation_config,
+):
+    """A config exposing a haiku-rag config but no database yields nothing"""
+    room_config = config_rooms.RoomConfig(
+        _installation_config=installation_config,
+        tool_configs={"db_less": config_rag._RAGConfigBase()},
+        **BARE_ROOM_CONFIG_KW,
+    )
+
+    assert list(room_config.list_haiku_rag_client_kw()) == []

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -216,7 +216,7 @@ def test_haiku_rag_capability_config_w_rag_databases(
     ]
 
     assert config.extra_parameters == {
-        "rag_lancedb_paths": {"papers": papers, "wiki": wiki},
+        "database_names": ["papers", "wiki"],
     }
 
 

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -13,6 +13,7 @@ from haiku.rag.capabilities import rag as hr_rag
 from soliplex.capabilities import filesystem as cap_fs
 from soliplex.config import agui as config_agui
 from soliplex.config import exceptions as config_exc
+from soliplex.config import rag as config_rag
 from soliplex.config import skills as config_skills
 from soliplex.skills import bwrap_sandbox
 
@@ -167,6 +168,132 @@ def test_haiku_rag_capability_config_with_stem(
         "rag_lancedb_stem": "example",
         "defer_loading": False,
     }
+
+
+def _rag_databases_yaml(config_class, wiki_path):
+    return {
+        "kind": config_class.kind,
+        "rag_databases": [
+            {"name": "papers", "rag_lancedb_stem": "papers"},
+            {"name": "wiki", "rag_lancedb_override_path": str(wiki_path)},
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "config_class",
+    [
+        config_skills.HR_RAG_SkillConfig,
+        config_skills.HR_Analysis_SkillConfig,
+    ],
+)
+def test_haiku_rag_capability_config_w_rag_databases(
+    temp_dir,
+    installation_config,
+    config_class,
+):
+    """Named databases become one capability covering them all"""
+    papers = temp_dir / "papers.lancedb"
+    papers.mkdir()
+    wiki = temp_dir / "wiki.lancedb"
+    wiki.mkdir()
+
+    config = config_class.from_yaml(
+        installation_config,
+        temp_dir / "room.yaml",
+        _rag_databases_yaml(config_class, wiki),
+    )
+
+    assert [entry.name for entry in config.rag_databases] == [
+        "papers",
+        "wiki",
+    ]
+
+    capability = config.capability
+    assert [(ref.name, ref.db_path) for ref in capability.scope.databases] == [
+        ("papers", papers),
+        ("wiki", wiki),
+    ]
+
+    assert config.extra_parameters == {
+        "rag_lancedb_paths": {"papers": papers, "wiki": wiki},
+    }
+
+
+@pytest.mark.parametrize(
+    "config_class",
+    [
+        config_skills.HR_RAG_SkillConfig,
+        config_skills.HR_Analysis_SkillConfig,
+    ],
+)
+def test_haiku_rag_capability_config_w_rag_databases_round_trips(
+    temp_dir,
+    installation_config,
+    config_class,
+):
+    wiki = temp_dir / "wiki.lancedb"
+    wiki.mkdir()
+    (temp_dir / "papers.lancedb").mkdir()
+
+    original, reloaded = _round_trip_hr_skill(
+        config_class,
+        installation_config,
+        temp_dir / "room.yaml",
+        _rag_databases_yaml(config_class, wiki),
+    )
+
+    assert reloaded == original
+    assert reloaded.rag_db_audit_path == original.rag_db_audit_path
+
+
+def test_room_skills_config_rag_db_paths_w_rag_databases(
+    temp_dir,
+    installation_config,
+):
+    """The audit map names every database a capability reads"""
+    papers = temp_dir / "papers.lancedb"
+    papers.mkdir()
+    wiki = temp_dir / "wiki.lancedb"
+    wiki.mkdir()
+
+    config = config_skills.RoomSkillsConfig.from_yaml(
+        installation_config,
+        temp_dir / "room.yaml",
+        {
+            "skill_configs": [
+                _rag_databases_yaml(config_skills.HR_RAG_SkillConfig, wiki),
+            ],
+        },
+    )
+
+    assert config.rag_db_paths == {
+        "haiku-rag": f"papers={papers}, wiki={wiki}",
+    }
+
+
+def test_haiku_rag_capability_config_rejects_databases_and_stem(
+    temp_dir,
+    installation_config,
+):
+    """The two ways of naming a database are mutually exclusive"""
+    with pytest.raises(config_exc.FromYamlException) as exc:
+        config_skills.HR_RAG_SkillConfig.from_yaml(
+            installation_config,
+            temp_dir / "room.yaml",
+            {
+                "kind": config_skills.HR_RAG_SkillConfig.kind,
+                "rag_lancedb_stem": "papers",
+                "rag_databases": [
+                    {"name": "papers", "rag_lancedb_stem": "papers"},
+                ],
+            },
+        )
+
+    assert isinstance(
+        exc.value.__cause__,
+        config_rag.RagDbSingleAndMultiConflict,
+    )
 
 
 def _round_trip_hr_skill(

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -134,7 +134,7 @@ def test_haiku_rag_capability_config(
 
     capability = config.capability
     assert isinstance(capability, capability_class)
-    assert [ref.db_path for ref in capability.scope.databases] == [db_path]
+    assert [ref.location for ref in capability.scope.databases] == [db_path]
     assert capability.defer_loading is False
 
     assert config.state_namespace == state_namespace
@@ -210,7 +210,9 @@ def test_haiku_rag_capability_config_w_rag_databases(
     ]
 
     capability = config.capability
-    assert [(ref.name, ref.db_path) for ref in capability.scope.databases] == [
+    assert [
+        (ref.name, ref.location) for ref in capability.scope.databases
+    ] == [
         ("papers", papers),
         ("wiki", wiki),
     ]
@@ -361,7 +363,11 @@ def test_haiku_rag_capability_config_wraps_yaml_errors(
         config_skills.HR_RAG_SkillConfig.from_yaml(
             installation_config,
             temp_dir / "room.yaml",
-            {"kind": config_skills.HR_RAG_SkillConfig.kind},
+            {
+                "kind": config_skills.HR_RAG_SkillConfig.kind,
+                "rag_lancedb_stem": "papers",
+                "rag_lancedb_override_path": "/dev/null",
+            },
         )
 
 
@@ -641,7 +647,7 @@ def test_room_skills_config_combines_capabilities(
         bwrap_sandbox.SKILL_PROPERTIES.name,
     }
     assert len(config.capabilities) == 3
-    assert config.rag_db_paths == {"haiku-rag": str(db_path)}
+    assert config.rag_db_paths == {"haiku-rag": f"rag={db_path}"}
     assert config.has_sandbox is True
     assert config.as_yaml["installation_skill_names"] == [
         {"name": SKILL_NAME, "defer_loading": True},

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -143,10 +143,17 @@ def test_haiku_rag_capability_config(
 
     assert config.source is config_skills.SkillKind.NATIVE
     assert config.extra_parameters == {"database_names": ["rag"]}
-    assert config.rag_lancedb_override_path == db_path
+
+    # The singular option is sugar: it lands in 'rag_databases', named
+    # for the path it placed, and 'as_yaml' emits only the list.
+    (entry,) = config.rag_databases
+    assert entry.name == "rag"
+    assert entry.rag_lancedb_override_path == db_path
     assert config.as_yaml == {
         "kind": config.kind,
-        "rag_lancedb_override_path": str(db_path),
+        "rag_databases": [
+            {"name": "rag", "rag_lancedb_override_path": str(db_path)},
+        ],
         "defer_loading": False,
     }
 
@@ -162,10 +169,10 @@ def test_haiku_rag_capability_config_with_stem(
         _installation_config=installation_config,
     )
 
-    assert config.rag_lancedb_path == db_path
+    assert config.rag_lancedb_databases == {"example": db_path}
     assert config.as_yaml == {
         "kind": config.kind,
-        "rag_lancedb_stem": "example",
+        "rag_databases": [{"name": "example", "rag_lancedb_stem": "example"}],
         "defer_loading": False,
     }
 
@@ -352,7 +359,7 @@ def test_haiku_rag_capability_config_as_yaml_round_trips(
     )
 
     assert reloaded == original
-    assert reloaded.rag_lancedb_path == original.rag_lancedb_path
+    assert reloaded.rag_databases == original.rag_databases
 
 
 def test_haiku_rag_capability_config_wraps_yaml_errors(
@@ -655,7 +662,9 @@ def test_room_skills_config_combines_capabilities(
     hrsc_yaml, bws_yaml = config.as_yaml["skill_configs"]
     assert hrsc_yaml == {
         "kind": config_skills.HR_RAG_SkillConfig.kind,
-        "rag_lancedb_override_path": str(db_path),
+        "rag_databases": [
+            {"name": "rag", "rag_lancedb_override_path": str(db_path)},
+        ],
         "defer_loading": False,
     }
     assert bws_yaml == {

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -133,7 +133,7 @@ def test_haiku_rag_capability_config(
 
     capability = config.capability
     assert isinstance(capability, capability_class)
-    assert capability.db_path == db_path
+    assert [ref.db_path for ref in capability.scope.databases] == [db_path]
     assert capability.defer_loading is False
 
     assert config.state_namespace == state_namespace

--- a/tests/unit/config/test_config_tools.py
+++ b/tests/unit/config/test_config_tools.py
@@ -2,6 +2,7 @@ import copy
 import dataclasses
 import functools
 import inspect
+import pathlib
 from unittest import mock
 from urllib import parse as url_parse
 
@@ -910,8 +911,9 @@ def test_sdtc_ctor(installation_config, temp_dir):
     assert sdt_config._installation_config is installation_config
     assert sdt_config._config_path == config_path
 
-    found = sdt_config.rag_lancedb_path
-    assert found.resolve() == from_stem.resolve()
+    assert sdt_config.rag_lancedb_databases == {
+        "stem": from_stem.resolve(),
+    }
 
     expected_ep = {
         "database_names": ["stem"],
@@ -1007,12 +1009,21 @@ def test_sdtc_as_yaml(temp_dir, installation_config, w_kw):
 
     expected = {"tool_name": config_tools.SDTC_TOOL_NAME}
 
+    # Either singular option is sugar for a one-entry 'rag_databases',
+    # named for whatever placed it, and only the list is emitted.
     if "rag_lancedb_override_path" in w_kw:
-        expected["rag_lancedb_override_path"] = w_kw[
-            "rag_lancedb_override_path"
+        override = w_kw["rag_lancedb_override_path"]
+        expected["rag_databases"] = [
+            {
+                "name": pathlib.Path(override).stem,
+                "rag_lancedb_override_path": override,
+            },
         ]
     else:
-        expected["rag_lancedb_stem"] = w_kw["rag_lancedb_stem"]
+        stem = w_kw["rag_lancedb_stem"]
+        expected["rag_databases"] = [
+            {"name": stem, "rag_lancedb_stem": stem},
+        ]
 
     if "search_documents_limit" in w_kw:
         expected["search_documents_limit"] = w_kw["search_documents_limit"]

--- a/tests/unit/config/test_config_tools.py
+++ b/tests/unit/config/test_config_tools.py
@@ -839,6 +839,7 @@ def test_toolconfig_extra_parameters():
 
     assert tool_config.extra_parameters == {}
 
+
 def test_sdtc_w_rag_databases(installation_config, temp_dir):
     """Named databases round-trip and report a path each"""
     db_rag_path = temp_dir / "db" / "rag"
@@ -875,7 +876,7 @@ def test_sdtc_w_rag_databases(installation_config, temp_dir):
     ]
     assert sdt_config.rag_db_audit_path == f"papers={papers}, wiki={wiki}"
     assert sdt_config.get_extra_parameters() == {
-        "rag_lancedb_paths": {"papers": papers, "wiki": wiki},
+        "database_names": ["papers", "wiki"],
         "search_documents_limit": 5,
     }
 

--- a/tests/unit/config/test_config_tools.py
+++ b/tests/unit/config/test_config_tools.py
@@ -839,6 +839,54 @@ def test_toolconfig_extra_parameters():
 
     assert tool_config.extra_parameters == {}
 
+def test_sdtc_w_rag_databases(installation_config, temp_dir):
+    """Named databases round-trip and report a path each"""
+    db_rag_path = temp_dir / "db" / "rag"
+    db_rag_path.mkdir(parents=True)
+    papers = db_rag_path / "papers.lancedb"
+    papers.mkdir()
+    wiki = db_rag_path / "wiki.lancedb"
+    wiki.mkdir()
+
+    ic_environ = {"RAG_LANCE_DB_PATH": str(db_rag_path)}
+    installation_config.get_environment = ic_environ.get
+
+    config_dir = temp_dir / "rooms" / "test_room"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "room_config.yaml"
+
+    config_yaml = {
+        "tool_name": config_tools.SDTC_TOOL_NAME,
+        "rag_databases": [
+            {"name": "papers", "rag_lancedb_stem": "papers"},
+            {"name": "wiki", "rag_lancedb_override_path": str(wiki)},
+        ],
+    }
+
+    sdt_config = config_tools.SearchDocumentsToolConfig.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(config_yaml),
+    )
+
+    assert [entry.name for entry in sdt_config.rag_databases] == [
+        "papers",
+        "wiki",
+    ]
+    assert sdt_config.rag_db_audit_path == f"papers={papers}, wiki={wiki}"
+    assert sdt_config.get_extra_parameters() == {
+        "rag_lancedb_paths": {"papers": papers, "wiki": wiki},
+        "search_documents_limit": 5,
+    }
+
+    reloaded = config_tools.SearchDocumentsToolConfig.from_yaml(
+        installation_config,
+        config_path,
+        copy.deepcopy(sdt_config.as_yaml),
+    )
+
+    assert reloaded.rag_databases == sdt_config.rag_databases
+
 
 def test_sdtc_ctor(installation_config, temp_dir):
     db_rag_path = temp_dir / "db" / "rag"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -492,7 +492,7 @@ def test_skill_from_config_w_hrrsc(hr_rag_skill_config):
     assert found.state_type_schema == hr_rag.RAGState.model_json_schema()
     assert found.state_namespace == hr_rag.STATE_NAMESPACE
     assert found.extra_parameters == {
-        "database_names": [hr_rag_skill_config.rag_lancedb_path.stem],
+        "database_names": hr_rag_skill_config.rag_database_names,
     }
 
 

--- a/tests/unit/tools/test_rag_tools.py
+++ b/tests/unit/tools/test_rag_tools.py
@@ -75,7 +75,6 @@ async def test_search_documents(
     search.assert_awaited_once_with(QUESTION, limit=exp_limit)
 
     hr_class.assert_called_once_with(
-        db_path=sd_tool_config.rag_lancedb_path,
         config=sd_tool_config.haiku_rag_config,
         read_only=True,
     )
@@ -114,7 +113,6 @@ async def test_search_documents_w_rag_databases(
     await rag_tools.search_documents(ctx_w_deps, query=QUESTION)
 
     hr_class.assert_called_once_with(
-        db_path=None,
         config=sd_tool_config.haiku_rag_config,
         read_only=True,
     )

--- a/tests/unit/tools/test_rag_tools.py
+++ b/tests/unit/tools/test_rag_tools.py
@@ -52,6 +52,8 @@ async def test_search_documents(
     search.return_value = search_results
 
     sd_tool_config.rag_lancedb_path = "/db/tool"
+    sd_tool_config.rag_databases = []
+    sd_tool_config.rag_db_audit_path = "/db/tool"
     ctx_w_deps.deps.user = None
     ctx_w_deps.deps.room_id = "room-1"
     ctx_w_deps.deps.thread_id = "thread-1"
@@ -92,6 +94,35 @@ async def test_search_documents(
 
 @pytest.mark.anyio
 @mock.patch("soliplex.tools.rag.hr_client")
+async def test_search_documents_w_rag_databases(
+    hr_client, ctx_w_deps, sd_tool_config, audit_records
+):
+    """Named databases open one federated client, audited by name"""
+    AUDIT_PATH = "papers=/db/papers, wiki=/db/wiki"
+    hr_class = hr_client.HaikuRAG = mock.MagicMock()
+    client = hr_class.return_value.__aenter__.return_value
+    client.search.return_value = []
+
+    sd_tool_config.rag_databases = [mock.Mock(), mock.Mock()]
+    sd_tool_config.rag_db_audit_path = AUDIT_PATH
+    sd_tool_config.search_documents_limit = 5
+    ctx_w_deps.deps.user = None
+    ctx_w_deps.deps.room_id = "room-1"
+    ctx_w_deps.deps.thread_id = "thread-1"
+    ctx_w_deps.deps.run_id = "run-1"
+
+    await rag_tools.search_documents(ctx_w_deps, query=QUESTION)
+
+    hr_class.assert_called_once_with(
+        db_path=None,
+        config=sd_tool_config.haiku_rag_config,
+        read_only=True,
+    )
+    assert audit_records[-1].db_path == AUDIT_PATH
+
+
+@pytest.mark.anyio
+@mock.patch("soliplex.tools.rag.hr_client")
 async def test_search_documents_records_failure(
     hr_client, ctx_w_deps, sd_tool_config, audit_records
 ):
@@ -100,6 +131,8 @@ async def test_search_documents_records_failure(
     client.search.side_effect = RuntimeError("boom")
 
     sd_tool_config.rag_lancedb_path = "/db/tool"
+    sd_tool_config.rag_databases = []
+    sd_tool_config.rag_db_audit_path = "/db/tool"
     sd_tool_config.search_documents_limit = 5
     ctx_w_deps.deps.user = None
     ctx_w_deps.deps.room_id = "room-1"

--- a/tests/unit/views/test_rooms_views.py
+++ b/tests/unit/views/test_rooms_views.py
@@ -322,7 +322,9 @@ async def test_get_room_documents(
 ):
     ROOM_ID = "foo"
 
-    w_hrc_kws = [kws.copy() for kws in w_hrc_kws]
+    w_hrc_kws = [
+        kws | {"audit_db_path": str(kws["db_path"])} for kws in w_hrc_kws
+    ]
     sources = [kws["source"] for kws in w_hrc_kws]
     hr_insts = {source: mock.AsyncMock() for source in sources}
     hr_entereds = {
@@ -355,9 +357,21 @@ async def test_get_room_documents(
         }
         for source in sources
     }
-    doc_fields = ["id", "uri", "title", "metadata", "created_at", "updated_at"]
+    doc_fields = [
+        "id",
+        "uri",
+        "title",
+        "metadata",
+        "created_at",
+        "updated_at",
+        "source",  # the haiku.rag database name
+    ]
     documents = {
-        source: mock.Mock(spec_set=doc_fields, **document_infos[source])
+        source: mock.Mock(
+            spec_set=doc_fields,
+            source=f"db-{source}",
+            **document_infos[source],
+        )
         for source in sources
     }
 
@@ -400,7 +414,9 @@ async def test_get_room_documents(
 
         exp_rag_docs = {
             document_info["id"]: models.RAGDocument(
-                source=rag_sources[source], **document_info
+                source=rag_sources[source],
+                database=f"db-{source}",
+                **document_info,
             )
             for source, document_info in document_infos.items()
         }
@@ -505,7 +521,9 @@ async def test_get_chunk_visualization(
     ]
     b64enc.return_value.decode.side_effect = PAGES_B64
 
-    w_hrc_kws = [kws.copy() for kws in w_hrc_kws]
+    w_hrc_kws = [
+        kws | {"audit_db_path": str(kws["db_path"])} for kws in w_hrc_kws
+    ]
     sources = [kws["source"] for kws in w_hrc_kws]
     hr_insts = {source: mock.AsyncMock() for source in sources}
     hr_entereds = {
@@ -541,7 +559,10 @@ async def test_get_chunk_visualization(
     if ROOM_ID in room_configs:
         if w_hrc_kws:
             for rag in rags:
-                rag.chunk_repository.get_by_id.return_value = None
+                rag.covers_multiple = False
+                rag.source = None  # an unnamed single database
+                rag.reader_for.return_value = rag
+                rag.get_chunk_by_id.return_value = None
                 rag.visualize_chunk.return_value = None
 
             if w_chunk_index is not None:
@@ -551,7 +572,7 @@ async def test_get_chunk_visualization(
                     content="waaa",
                 )
                 rag_w_chunk = rags[w_chunk_index]
-                rag_w_chunk.chunk_repository.get_by_id.return_value = chunk
+                rag_w_chunk.get_chunk_by_id.return_value = chunk
 
                 if w_image:
                     rag_w_chunk.visualize_chunk.return_value = PAGES_PNG
@@ -752,13 +773,22 @@ async def test_get_chunk_visualization_refs_and_expand(
         document_uri=DOCUMENT_URI,
         content="waaa",
     )
-    rag.chunk_repository.get_by_id.return_value = chunk
+    rag.covers_multiple = False
+    rag.source = None  # an unnamed single database
+    rag.reader_for.return_value = rag
+    rag.get_chunk_by_id.return_value = chunk
     rag.visualize_chunk.return_value = PAGES_PNG
 
     room_config = mock.create_autospec(config_rooms.RoomConfig)
     room_config.list_haiku_rag_client_kw = mock.Mock(
         spec_set=(),
-        return_value=[{"source": "agent", "db_path": "/db/agent"}],
+        return_value=[
+            {
+                "source": "agent",
+                "db_path": "/db/agent",
+                "audit_db_path": "/db/agent",
+            },
+        ],
     )
     the_installation = mock.create_autospec(installation.Installation)
     the_installation.get_room_config.return_value = room_config
@@ -777,11 +807,207 @@ async def test_get_chunk_visualization_refs_and_expand(
     )
 
     assert found.chunk_id == CHUNK_ID
+    assert found.database is None
     rag.visualize_chunk.assert_awaited_once_with(
         chunk,
         refs=expected_refs,
         expand=expand,
     )
+
+
+def _federated_room_config(covered_names, chunks_by_name):
+    """A room whose sole RAG config covers several named databases"""
+    rag = mock.AsyncMock()
+    rag.covers_multiple = True
+    rag.source_names = covered_names
+    rag.get_chunk_by_id.side_effect = lambda chunk_id, source=None: (
+        chunks_by_name.get(source)
+    )
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    room_config.list_haiku_rag_client_kw = mock.Mock(
+        spec_set=(),
+        return_value=[
+            {
+                "source": "skill:rag",
+                "db_path": None,
+                "audit_db_path": "papers=/db/papers, wiki=/db/wiki",
+            },
+        ],
+    )
+    return rag, room_config
+
+
+@pytest.mark.anyio
+@mock.patch("haiku.rag.client.HaikuRAG")
+@mock.patch("base64.b64encode")
+async def test_get_chunk_visualization_federated(
+    b64enc,
+    hr_klass,
+    audit_records,
+):
+    """The database holding the chunk owns the visualization"""
+    ROOM_ID = "foo"
+    CHUNK_ID = "test-chunk-123"
+    DOCUMENT_URI = f"https://example.com/chunks/{CHUNK_ID}"
+    PAGES_PNG = [mock.Mock(spec_set=["blob", "save"], blob="facedace8765")]
+    b64enc.return_value.decode.return_value = "facedace8765"
+
+    chunk = hr_chunk.Chunk(
+        chunk_id=CHUNK_ID,
+        document_uri=DOCUMENT_URI,
+        content="waaa",
+    )
+    rag, room_config = _federated_room_config(
+        ("papers", "wiki"),
+        {"wiki": chunk},
+    )
+    owner = mock.AsyncMock()
+    owner.visualize_chunk.return_value = PAGES_PNG
+    rag.reader_for.return_value = owner
+
+    hr_inst = mock.AsyncMock()
+    hr_inst.__aenter__.return_value = rag
+    hr_klass.side_effect = [hr_inst]
+
+    the_installation = mock.create_autospec(installation.Installation)
+    the_installation.get_room_config.return_value = room_config
+    the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    found = await rooms_views.get_chunk_visualization(
+        room_id=ROOM_ID,
+        chunk_id=CHUNK_ID,
+        the_installation=the_installation,
+        the_room_authz=the_room_authz,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found.chunk_id == CHUNK_ID
+    assert found.database == "wiki"
+    assert found.document_uri == DOCUMENT_URI
+
+    # Asked the databases in turn, stopping at the one holding the chunk.
+    assert rag.get_chunk_by_id.await_args_list == [
+        mock.call(CHUNK_ID, source="papers"),
+        mock.call(CHUNK_ID, source="wiki"),
+    ]
+    rag.reader_for.assert_awaited_once_with("wiki")
+    owner.visualize_chunk.assert_awaited_once_with(
+        chunk,
+        refs=None,
+        expand=False,
+    )
+    rag.visualize_chunk.assert_not_called()
+
+    record = _sole_rag_record(audit_records)
+    assert record.db_path == "papers=/db/papers, wiki=/db/wiki"
+
+
+@pytest.mark.anyio
+@mock.patch("haiku.rag.client.HaikuRAG")
+@mock.patch("base64.b64encode")
+async def test_get_chunk_visualization_one_named_database(
+    b64enc,
+    hr_klass,
+    audit_records,
+):
+    """One named database reports its name, as search and documents do"""
+    ROOM_ID = "foo"
+    CHUNK_ID = "test-chunk-123"
+    DOCUMENT_URI = f"https://example.com/chunks/{CHUNK_ID}"
+    PAGES_PNG = [mock.Mock(spec_set=["blob", "save"], blob="facedace8765")]
+    b64enc.return_value.decode.return_value = "facedace8765"
+
+    chunk = hr_chunk.Chunk(
+        chunk_id=CHUNK_ID,
+        document_uri=DOCUMENT_URI,
+        content="waaa",
+    )
+    # A one-entry 'rag_databases' opens as a single-database client that
+    # keeps the configured name.
+    rag = mock.AsyncMock()
+    rag.covers_multiple = False
+    rag.source = "papers"
+    rag.reader_for.return_value = rag
+    rag.get_chunk_by_id.return_value = chunk
+    rag.visualize_chunk.return_value = PAGES_PNG
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    room_config.list_haiku_rag_client_kw = mock.Mock(
+        spec_set=(),
+        return_value=[
+            {
+                "source": "skill:rag",
+                "db_path": None,
+                "audit_db_path": "papers=/db/papers",
+            },
+        ],
+    )
+
+    hr_inst = mock.AsyncMock()
+    hr_inst.__aenter__.return_value = rag
+    hr_klass.side_effect = [hr_inst]
+
+    the_installation = mock.create_autospec(installation.Installation)
+    the_installation.get_room_config.return_value = room_config
+    the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    found = await rooms_views.get_chunk_visualization(
+        room_id=ROOM_ID,
+        chunk_id=CHUNK_ID,
+        the_installation=the_installation,
+        the_room_authz=the_room_authz,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    assert found.database == "papers"
+    rag.get_chunk_by_id.assert_awaited_once_with(CHUNK_ID)
+    rag.reader_for.assert_awaited_once_with("papers")
+
+
+@pytest.mark.anyio
+@mock.patch("haiku.rag.client.HaikuRAG")
+async def test_get_chunk_visualization_federated_wo_chunk(
+    hr_klass,
+    audit_records,
+):
+    """A chunk in none of the covered databases is a 404"""
+    ROOM_ID = "foo"
+    CHUNK_ID = "test-chunk-123"
+
+    rag, room_config = _federated_room_config(("papers", "wiki"), {})
+
+    hr_inst = mock.AsyncMock()
+    hr_inst.__aenter__.return_value = rag
+    hr_klass.side_effect = [hr_inst]
+
+    the_installation = mock.create_autospec(installation.Installation)
+    the_installation.get_room_config.return_value = room_config
+    the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    with pytest.raises(fastapi.HTTPException) as exc:
+        await rooms_views.get_chunk_visualization(
+            room_id=ROOM_ID,
+            chunk_id=CHUNK_ID,
+            the_installation=the_installation,
+            the_room_authz=the_room_authz,
+            the_user_claims=THE_USER_CLAIMS,
+            the_logger=the_logger,
+        )
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == f"{loggers.ROOM_UNKNOWN_CHUNK_ID}: {CHUNK_ID}"
+    rag.reader_for.assert_not_called()
+
+    record = _sole_rag_record(audit_records)
+    assert record.outcome == loggers.AUDIT_OUTCOME_ERROR
+    assert record.db_path is None
+    assert record.reason == loggers.ROOM_UNKNOWN_CHUNK_ID
 
 
 @pytest.mark.anyio
@@ -818,7 +1044,9 @@ async def test_get_search(
     else:
         exp_search_type = "hybrid"
 
-    w_hrc_kws = [kws.copy() for kws in w_hrc_kws]
+    w_hrc_kws = [
+        kws | {"audit_db_path": str(kws["db_path"])} for kws in w_hrc_kws
+    ]
     sources = [kws["source"] for kws in w_hrc_kws]
     hr_insts = {source: mock.AsyncMock() for source in sources}
     hr_entereds = {
@@ -842,6 +1070,7 @@ async def test_get_search(
             headings=[f"Test Heading #{i_source}"],
             labels=[f"test-label-{i_source}"],
             image_data={f"img-{i_source:03}": "abcdef0123456789"},
+            source=f"db-{i_source}",
         )
         for i_source, source in enumerate(sources)
     ]
@@ -916,6 +1145,7 @@ async def test_get_search(
                 assert f_hit.source.source_type == source_type
                 assert f_hit.source.name == name
 
+            assert f_hit.database == exp_result.source
             assert f_hit.content == exp_result.content
             assert f_hit.score == exp_result.score
             assert f_hit.chunk_id == exp_result.chunk_id

--- a/tests/unit/views/test_rooms_views.py
+++ b/tests/unit/views/test_rooms_views.py
@@ -1011,6 +1011,60 @@ async def test_get_chunk_visualization_federated_wo_chunk(
 
 
 @pytest.mark.anyio
+@mock.patch("haiku.rag.client.HaikuRAG")
+async def test_get_search_wo_title_uri_or_headings(hr_klass, audit_records):
+    """A document with no title, URI or headings is a hit like any other"""
+    ROOM_ID = "foo"
+    QUERY = "waaa"
+
+    hit = hr_chunk.SearchResult(
+        content="Test content",
+        score=1.0,
+        chunk_id="test-chunk",
+        document_id="test-document",
+        document_uri=None,
+        document_title=None,
+        headings=None,
+    )
+
+    rag = mock.AsyncMock()
+    rag.search.return_value = [hit]
+    hr_inst = mock.AsyncMock()
+    hr_inst.__aenter__.return_value = rag
+    hr_klass.side_effect = [hr_inst]
+
+    room_config = mock.create_autospec(config_rooms.RoomConfig)
+    room_config.list_haiku_rag_client_kw = mock.Mock(
+        spec_set=(),
+        return_value=[
+            {
+                "source": "skill:rag",
+                "db_path": "/db/rag",
+                "audit_db_path": "/db/rag",
+            },
+        ],
+    )
+    the_installation = mock.create_autospec(installation.Installation)
+    the_installation.get_room_config.return_value = room_config
+    the_room_authz = mock.create_autospec(authz.RoomAuthorizationPolicy)
+    the_logger = mock.create_autospec(loggers.LogWrapper)
+
+    found = await rooms_views.get_search(
+        query=QUERY,
+        room_id=ROOM_ID,
+        the_installation=the_installation,
+        the_room_authz=the_room_authz,
+        the_user_claims=THE_USER_CLAIMS,
+        the_logger=the_logger,
+    )
+
+    (f_hit,) = found.hits
+    assert f_hit.document_title is None
+    assert f_hit.document_uri is None
+    assert f_hit.headings == []
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("w_search_type", [False, True])
 @pytest.mark.parametrize(
     "w_hrc_kws",

--- a/uv.lock
+++ b/uv.lock
@@ -1009,7 +1009,7 @@ wheels = [
 
 [[package]]
 name = "haiku-rag-slim"
-version = "0.78.0"
+version = "0.82.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docling-core" },
@@ -1030,9 +1030,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/a7/a78d0f11e7246603ce73205be27fdcd0b415890edaace87f5dff32e854cb/haiku_rag_slim-0.78.0.tar.gz", hash = "sha256:d381779c87fc5c6c8d23522bf2572c5f8960781bba81f16d1d8b7f9ee2cd0ef7", size = 262440, upload-time = "2026-08-24T13:07:02.087Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/de/37ceddd1f34139207fe1d107a96a86f7679cc11c6630fedf08e62e3daef2/haiku_rag_slim-0.82.1.tar.gz", hash = "sha256:5f49a15a8a2142a81b7564edbd4919c321bd689f5729a56be4e2b4c0786ab40c", size = 289492, upload-time = "2026-09-03T15:02:07.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/4d/7a4aeffa352fc762e5efed149129360602fbba09bf86b37ff6924a815a83/haiku_rag_slim-0.78.0-py3-none-any.whl", hash = "sha256:92f250436efe6f79716baf5e64b4190228f8c8683ef49111218c19ac257328be", size = 345873, upload-time = "2026-08-24T13:07:00.45Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2e/e62cbdea84544b4fd3536bb88cd1a1a00e19b0aad06e437b9928437d5af7/haiku_rag_slim-0.82.1-py3-none-any.whl", hash = "sha256:79e4016daafd20503d52c97e69fbf48ade668cc432a54ea61a3838cd49c23088", size = 375748, upload-time = "2026-09-03T15:02:06.314Z" },
 ]
 
 [[package]]
@@ -1411,7 +1411,7 @@ wheels = [
 
 [[package]]
 name = "lancedb"
-version = "0.34.0"
+version = "0.37.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
@@ -1423,10 +1423,10 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/f7/5262b9aa593f790757163c0165ab0da1dda054758901bea7e4f02c9cb633/lancedb-0.34.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c462f2e6f933cad659fd0179394eaab578acbc9151fe2ef41bc29b36ecca5058", size = 52654213, upload-time = "2026-07-02T17:13:31.102Z" },
-    { url = "https://files.pythonhosted.org/packages/69/99/05ea0d32229ebea695193ff20c15d6ecae25785ad82a9d4723d98832a284/lancedb-0.34.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48829e88e708947d0520454ab9e4f8efa35f3e3626469eadd3a6e061b89cb223", size = 55434501, upload-time = "2026-07-02T17:13:34.81Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/4e/4325c13d5afa93c466428a5a0f168ad4d96f5eb4a77bbe7c5100d39c9897/lancedb-0.34.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:05ba8a5b58e064edfbe5be71b1abf2e411b4eaf295d1a173dcb1a55c5bfb5285", size = 58659359, upload-time = "2026-07-02T17:13:38.424Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/5d/8ca165f1386caf6c4d1c515afd52f345b66432264eecfdfb7fd33eefd9af/lancedb-0.34.0-cp39-abi3-win_amd64.whl", hash = "sha256:51cbc11808f9e3332819b9367c975b3a888541447a8e7bea09c57c852a279153", size = 63530726, upload-time = "2026-07-02T17:13:41.612Z" },
+    { url = "https://files.pythonhosted.org/packages/23/2f/4ddcab82bb618c6c8de00725f3cf59585dcb9040964dde13cb0cae6ed3cd/lancedb-0.37.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c15c46f23cf6959c79fb93cdba2c76536cf784d3134386662da03dc6ccac3c26", size = 58474767, upload-time = "2026-08-10T10:41:45.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5e/dac0fd9478a21685444f23e6ec937babf4ff48b1616b68e8137778d6ecb9/lancedb-0.37.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:35d872d920cbfdc3771fbcd33f2c63bff6ff7203d6d2ba8fe4330e98eb859d12", size = 61666580, upload-time = "2026-08-10T10:41:49.535Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/fa/ee1cdb1e904872d75fa0ff44ad35cd23494e810299c33e68de0687de7a71/lancedb-0.37.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:86597f4dbc51a33a07341550dc77d21a1ddd1f7539266eda5bb64c4f3bd11cca", size = 64802395, upload-time = "2026-08-10T10:41:52.969Z" },
+    { url = "https://files.pythonhosted.org/packages/42/55/65c69307373b7f05dea38465b7d3836c86390f0ebc79b5c56d2c0919f229/lancedb-0.37.1-cp310-abi3-win_amd64.whl", hash = "sha256:488eca15361dfc34439500c9e2607c4fb2b8bf190fa1003bd54b1d6eb40e0316", size = 70994296, upload-time = "2026-08-10T10:41:56.609Z" },
 ]
 
 [[package]]
@@ -3159,7 +3159,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.3.0,<3.4" },
     { name = "greenlet" },
-    { name = "haiku-rag-slim", specifier = ">=0.78.0,<0.79" },
+    { name = "haiku-rag-slim", specifier = ">=0.82.0,<0.83" },
     { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous" },
     { name = "joserfc", specifier = ">=1.6.7,<1.7" },


### PR DESCRIPTION
A room's RAG skill or tool can name several LanceDB databases and search
them as one, or name none and read the databases its `haiku.rag`
configuration places. Results, documents and audit records report which
database they came from.

Requires `haiku.rag-slim >= 0.82.0, < 0.83` (bumped in the first commit).

## Configuration

`rag_databases` replaces the single `rag_lancedb_stem` /
`rag_lancedb_override_path` pair; the two forms are mutually exclusive.
A configuration may also use neither, and read what its `haiku.rag`
configuration places.

```yaml
skills:
  skill_configs:
    - kind: "haiku.rag.skills.rag"
      rag_databases:
        - name: "papers"
          rag_lancedb_stem: "papers"
        - name: "wiki"
          rag_lancedb_override_path: "../wiki.lancedb"
```

Entries resolve their paths as the single-database fields do. Names must
be unique.

## Placement

A configuration naming no database of its own reads the ones its
`haiku.rag.yaml` places in `lancedb.databases`:

```yaml
lancedb:
  databases:
    archive: "s3://bucket/lancedb/archive.lancedb"
```

This is the only way for a room to read a database that is not a local
directory. Previously such a room had to name a local database it never
used, as a placeholder, and set `lancedb.uri` beside it.

**Breaking.** That placeholder arrangement no longer works, and now says
so. `haiku.rag` 0.82 places every database in `lancedb.databases`, and a
configuration carrying `lancedb.uri` fails to load with the replacement
spelled out and its own location echoed back:

```
lancedb
  Value error, lancedb.uri was removed; write lancedb.databases:
  {NAME: 's3://bucket/lancedb/example.lancedb'} instead
```

A room reaches this whether the `uri` is its own or the installation's,
since it reads the two merged, so an installation-wide `lancedb.uri`
fails every room. `soliplex-cli audit` reports it before a room is used,
in place of the unresolved path it would otherwise blame.

Naming a database in soliplex while that configuration already places
one in `lancedb.databases` is two placements for one room, and raises
`RagDbTwoPlacements` when the room is used. soliplex writes the
databases a room names into the client configuration, so without this it
would silently replace what the room configured and open the
placeholder.

This replaces silent breakage rather than introducing it: from
`haiku.rag` 0.79 a location soliplex passes wins over a configured
`lancedb.uri`, so these rooms already read the placeholder database and
returned nothing.

## Behaviour

Every database a config names is resolved into
`config.lancedb.databases`, including the one a stem or override path
names, which takes the file's stem for its name. A config naming none
leaves that configuration untouched, and reads the names out of it
through `DatabaseScope.resolve`. The client, the
capability and the audit CLI read the location from the config rather
than a `db_path` argument. A config naming one database is read as one
database, not as a set of one, so instructions and result formatting are
unchanged for existing rooms.

The name reaches the agent as the collection a result came from, the room
endpoints as `database`, and audit records as `name=location` pairs.
Single-database rooms gain the `name=` prefix in their audit records.
Locations stay in the configuration. Following #1324,
`extra_parameters` reports `database_names`, now for several databases as
well as one.

Candidates are combined by the configured reranker. Without one they are
ordered by cosine similarity to the query, which compares across
databases because a set shares an embedding model. Full-text searches
order by retrieval score.

The chunk endpoint asks each covered database in turn, since chunk IDs
repeat between copies of a database.

`MultipleRAGDatabasesProtocol` and `_MultiRAGDatabasesBase` are removed:
no implementer, and as structural protocols the `isinstance` dispatch
could never reach them. That dispatch also held an unreachable
`NameError`.

## Unrelated fix (severable)

`GET /rooms/{id}/search` returned 500 for any document without a title,
because `SearchHit` required strings where `haiku.rag` returns
`str | None`. Any corpus ingested without `auto_title` hits it.
`document_title` and `document_uri` are now nullable in the
`SearchResults` schema. Not breaking, since those responses were 500s,
but the Flutter repo should regenerate if it generates from OpenAPI.

## Testing

Unit tests throughout, 100% coverage maintained. Verified end to end
against two real databases: `soliplex-cli audit` reports the federated
document count, `/documents` and `/search` attribute each result,
`/chunk/{id}` renders page images for a chunk held only by the second
database, and the agent answered questions from each corpus in turn. A
single-database room written in the old form was checked to keep its
document count; its audit records gain the `name=` prefix.

Placement is covered by unit tests rather than end to end: a config
naming nothing reports the names, audit string and `database_names` its
`haiku.rag` configuration implies, including the default database; and
the conflict raises for both the stem and the `rag_databases` forms.

## Not included

- Selecting among a room's databases at query time. A room searches
  every database its configuration places. `haiku.rag` narrows a client
  with `sources=[...]` and raises for a name outside the room's set, so
  the follow-up is carrying a selection from the client through to the
  query. The room model reports the names today
  (`extra_parameters.database_names`), which is what a picker needs to
  offer.
- No example room: one corpus under two names returns every chunk twice
  and raises `AmbiguousCitationError`, and a real example needs two
  corpora the repo does not ship. The shape is documented instead.
- Duplicate skill names remain silently accepted
  (`extract_skill_configs` keys on name, so two differently configured
  sandboxes collapse to one). Pre-existing, orthogonal.
- `docs/config/rooms.md` still lists `ask` / `research` /
  `list_documents` / `get_document` as RAG skill tools; the capability
  exposes `rag_search` and `rag_cite`. Pre-existing drift.



