### PR TITLE
fix: remove filesystem paths from view models

### DIFF
--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -177,10 +177,13 @@ class _RAGDatabaseBase:
         try:
             rag_lancedb_path = self.rag_lancedb_path
         except RagDbFileNotFound as exc:
-            rag_lancedb_path = f"MISSING: {exc.rag_db_filename}"
+            missing = exc.rag_db_filename
+            db_name = f"MISSING: {missing.stem}"
+        else:
+            db_name = rag_lancedb_path.stem
 
         return {
-            "rag_lancedb_path": rag_lancedb_path,
+            "database_names": [db_name],
         }
 
 

--- a/src/soliplex/config/skills.py
+++ b/src/soliplex/config/skills.py
@@ -177,7 +177,7 @@ class FilesystemSkillConfig:
 
     @property
     def extra_parameters(self) -> dict[str, pathlib.Path]:
-        return {"path": self.path}
+        return {}
 
     def with_defer_loading(self, defer_loading: bool) -> FilesystemSkillConfig:
         """A copy whose capability loads as a room asked.

--- a/src/soliplex/config/tools.py
+++ b/src/soliplex/config/tools.py
@@ -315,6 +315,10 @@ class ToolConfig:
     def get_extra_parameters(self) -> dict:
         return {}
 
+    @property
+    def extra_parameters(self) -> dict:
+        return self.get_extra_parameters()
+
 
 SDTC_TOOL_NAME = "soliplex.tools.rag.search_documents"
 _, SDTC_TOOL_KIND = SDTC_TOOL_NAME.rsplit(".", 1)

--- a/src/soliplex/models.py
+++ b/src/soliplex/models.py
@@ -111,7 +111,7 @@ class Tool(pydantic.BaseModel):
             tool_requires=tool_config.tool_requires,
             allow_mcp=tool_config.allow_mcp,
             agui_feature_names=list(tool_config.agui_feature_names),
-            extra_parameters=tool_config.get_extra_parameters(),
+            extra_parameters=tool_config.extra_parameters,
         )
 
 

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -195,12 +195,14 @@ def test__rdb_ctor(
             assert found.resolve() == expected.resolve()
 
             expected_ep = {
-                "rag_lancedb_path": expected.resolve(),
+                "database_names": [expected.resolve().stem],
             }
             assert rdb_config.get_extra_parameters() == expected_ep
         else:
+            exc = rlp_which.value
             w_missing = rdb_config.get_extra_parameters()
-            assert w_missing["rag_lancedb_path"].startswith("MISSING:")
+            (err,) = w_missing["database_names"]
+            assert err == f"MISSING: {exc.rag_db_filename.stem}"
 
 
 def test__rdb_override_path_expands_user(db_rag_path, monkeypatch):

--- a/tests/unit/config/test_config_skills.py
+++ b/tests/unit/config/test_config_skills.py
@@ -69,7 +69,7 @@ def test_filesystem_skill_config_properties(temp_dir):
     assert config.state_type is None
     assert config.state_namespace is None
     assert config.agui_feature_names == ()
-    assert config.extra_parameters == {"path": path}
+    assert config.extra_parameters == {}
 
 
 def test_filesystem_skill_config_from_path(temp_dir):
@@ -141,7 +141,7 @@ def test_haiku_rag_capability_config(
     assert state_namespace in config_agui.AGUI_FEATURES_BY_NAME
 
     assert config.source is config_skills.SkillKind.NATIVE
-    assert config.extra_parameters == {"rag_lancedb_path": db_path}
+    assert config.extra_parameters == {"database_names": ["rag"]}
     assert config.rag_lancedb_override_path == db_path
     assert config.as_yaml == {
         "kind": config.kind,

--- a/tests/unit/config/test_config_tools.py
+++ b/tests/unit/config/test_config_tools.py
@@ -832,6 +832,14 @@ def test_toolconfig_get_extra_parameters():
     assert tool_config.get_extra_parameters() == {}
 
 
+def test_toolconfig_extra_parameters():
+    tool_config = config_tools.ToolConfig(
+        tool_name="soliplex.tools.test_tool",
+    )
+
+    assert tool_config.extra_parameters == {}
+
+
 def test_sdtc_ctor(installation_config, temp_dir):
     db_rag_path = temp_dir / "db" / "rag"
     db_rag_path.mkdir(parents=True)
@@ -857,7 +865,7 @@ def test_sdtc_ctor(installation_config, temp_dir):
     assert found.resolve() == from_stem.resolve()
 
     expected_ep = {
-        "rag_lancedb_path": from_stem.resolve(),
+        "database_names": ["stem"],
         "search_documents_limit": 5,
     }
 
@@ -1041,7 +1049,7 @@ def test_sdtc_get_extra_parameters_w_missing_file(
 
     ep = sdt_config.get_extra_parameters()
 
-    assert ep["rag_lancedb_path"] == f"MISSING: {exp_filename.resolve()}"
+    assert ep["database_names"] == [f"MISSING: {exp_filename.stem}"]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -26,6 +26,7 @@ from soliplex.config import tools as config_tools
 
 NOW = datetime.datetime.now(datetime.UTC)
 
+
 QUIZ_ID = "test_quiz"
 QUIZ_TITLE = "Test Quiz"
 QUIZ_MAX_QUESTIONS = 14
@@ -70,6 +71,8 @@ OTHER_AGENT_KIND = "other-agent-kind"
 FACTORY_NAME = "some.package.function"
 
 INSTALLATION_ID = "test-installation"
+SERVER_NAME = "test-server"
+SERVER_DESC = "Test Installation"
 INSTALLATION_SECRET = "Seeeeeekrit!"
 INSTALLATION_ENVVAR_NAME = "TEST_ENVVAR"
 INSTALLATION_ENVVAR_STR_VALUE = "Test Envvar"
@@ -351,11 +354,24 @@ def test_quiz_from_config(
         assert quiz_model.questions == exp_questions
 
 
-def test_tool_from_config_w_toolconfig():
+class TCWithParms(config_tools.ToolConfig):
+    @property
+    def extra_parameters(self):
+        return {"test": "extra"}
+
+
+@pytest.mark.parametrize(
+    "w_tc_klass, exp_ep",
+    [
+        (config_tools.ToolConfig, {}),
+        (TCWithParms, {"test": "extra"}),
+    ],
+)
+def test_tool_from_config_w_toolconfig(w_tc_klass, exp_ep):
     def test_tool():
         """This is a test tool"""
 
-    tool_config = config_tools.ToolConfig(
+    tool_config = w_tc_klass(
         tool_name="soliplex.tools.test_tool",
     )
 
@@ -368,7 +384,7 @@ def test_tool_from_config_w_toolconfig():
     assert tool_model.tool_requires == config_tools.ToolRequires.BARE
     assert tool_model.allow_mcp is False
     assert tool_model.agui_feature_names == []
-    assert tool_model.extra_parameters == {}
+    assert tool_model.extra_parameters == exp_ep
 
 
 def test_mcp_client_toolset_from_config_w_stdio():
@@ -454,7 +470,7 @@ def test_skill_from_config_w_fssc(filesystem_skill_config):
     assert found.description == filesystem_skill_config.description
     assert found.state_type_schema is None
     assert found.state_namespace is None
-    assert found.extra_parameters == {"path": filesystem_skill_config.path}
+    assert found.extra_parameters == {}
 
 
 @pytest.fixture
@@ -476,7 +492,7 @@ def test_skill_from_config_w_hrrsc(hr_rag_skill_config):
     assert found.state_type_schema == hr_rag.RAGState.model_json_schema()
     assert found.state_namespace == hr_rag.STATE_NAMESPACE
     assert found.extra_parameters == {
-        "rag_lancedb_path": hr_rag_skill_config.rag_lancedb_path,
+        "database_names": [hr_rag_skill_config.rag_lancedb_path.stem],
     }
 
 
@@ -520,7 +536,12 @@ def agent_retries(request):
 @pytest.fixture
 def installation_config():
     environ = {"OLLAMA_BASE_URL": OLLAMA_BASE_URL}
-    installation = mock.create_autospec(config_installation.InstallationConfig)
+    installation = mock.create_autospec(
+        config_installation.InstallationConfig,
+        id=INSTALLATION_ID,
+        server_name=SERVER_NAME,
+        server_description=SERVER_DESC,
+    )
     installation.get_environment = environ.get
     installation.interpolate_environment = lambda to_interp: to_interp
     return installation
@@ -1204,6 +1225,15 @@ def test_installation_from_config_w_agui_feature(
         assert m_feature.name == c_feature.name
         assert m_feature.description == c_feature.description
         assert m_feature.source == c_feature.source
+
+
+def test_serverinfo_from_config(installation_config):
+
+    found = models.ServerInfo.from_config(installation_config)
+
+    assert found.installation_id == INSTALLATION_ID
+    assert found.name == SERVER_NAME
+    assert found.description == SERVER_DESC
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- refactor: 'models.Tool' uses 'ToolConfig.extra_parameters'

  ... which property is newly-added to 'config.tools.ToolConfig',
  wrapping its 'get_extra_parameters' method, to permit subclasses
  to override while preserving the property in the base.

- fix: drop 'path' from 'FilessystemSkillConfig.extra_parameters'

- fix: 'config.rag.get_extra_parameters' returns list of DB stems

  ... not a path.

- tests: explicit coverage for 'models.ServerInfo'

  Previously covered only incidentally via tests of
  'views.installation.get_installation_identity'

Closes #1323.