### PR TITLE
fix: avoid listing/serving non-regular files from sandbox workdirs

### DIFF
--- a/scripts/lint_textio.py
+++ b/scripts/lint_textio.py
@@ -38,8 +38,17 @@ from typing import NamedTuple
 REPO_DIR = pathlib.Path(__file__).resolve().parent.parent
 DEFAULT_TARGET = REPO_DIR / "src" / "soliplex"
 
-# 'pathlib.Path' text helpers, plus builtin 'open' / 'Path.open'.
-TEXT_IO_NAMES = frozenset({"read_text", "write_text", "open"})
+# 'pathlib.Path' text helpers, plus builtin 'open' / 'Path.open', and
+# 'os.fdopen', which wraps a descriptor in a text stream by default.
+TEXT_IO_NAMES = frozenset(
+    {"read_text", "write_text", "open", "fdopen"},
+)
+
+# Qualified calls whose trailing name collides with one above, but which
+# do no text IO at all. 'os.open' is the POSIX 'open(2)' wrapper: it
+# returns an integer file descriptor, takes flags rather than a mode
+# string, and raises 'TypeError' if handed an 'encoding='.
+NOT_TEXT_IO_QUALNAMES = frozenset({"os.open"})
 
 
 class Finding(NamedTuple):
@@ -55,9 +64,20 @@ class Finding(NamedTuple):
 
 
 def _call_name(node: ast.Call) -> str | None:
-    """Return the called attribute / bare name, or 'None' if neither."""
+    """Return the called attribute / bare name, or 'None' if neither.
+
+    A qualified call listed in 'NOT_TEXT_IO_QUALNAMES' returns 'None':
+    matching on the trailing attribute alone cannot tell 'os.open' from
+    the builtin 'open', and the former admits no 'encoding='.
+    """
     func = node.func
     if isinstance(func, ast.Attribute):
+        base = getattr(func.value, "id", None)
+
+        if base is not None:
+            if f"{base}.{func.attr}" in NOT_TEXT_IO_QUALNAMES:
+                return None
+
         return func.attr
 
     return getattr(func, "id", None)
@@ -194,11 +214,13 @@ def report(scanned: Scan, verbose: bool) -> None:
 # Every form the check must catch, and every form it must let through.
 # Line numbers are asserted on below, so keep the layout stable.
 SELF_TEST_SOURCE = """\
+import os
 import pathlib
 
 path = pathlib.Path("f")
 data = "x"
 mode = "rb"
+fd = 0
 
 path.read_text()
 path.read_text(encoding="utf-8")
@@ -208,6 +230,9 @@ path.open()
 path.open("rb")
 path.open(mode)
 open("f")
+os.open("f", os.O_RDONLY)
+os.fdopen(fd)
+os.fdopen(fd, "rb")
 len("not file io")
 path.write_text(
     data,
@@ -216,15 +241,18 @@ path.write_text(
 """
 
 SELF_TEST_EXPECTED = [
-    Finding("self-test", 7, 7, "read_text"),
-    Finding("self-test", 9, 9, "write_text"),
-    Finding("self-test", 11, 11, "open"),
-    # Non-literal mode: reported rather than assumed binary.
+    Finding("self-test", 9, 9, "read_text"),
+    Finding("self-test", 11, 11, "write_text"),
     Finding("self-test", 13, 13, "open"),
+    # Non-literal mode: reported rather than assumed binary.
+    Finding("self-test", 15, 15, "open"),
     # Builtin, not a method.
-    Finding("self-test", 14, 14, "open"),
-    # Multi-line call: spans lines 16-19.
-    Finding("self-test", 16, 19, "write_text"),
+    Finding("self-test", 16, 16, "open"),
+    # 'os.open' on line 17 is absent: a POSIX descriptor call, which
+    # takes no 'encoding='. 'os.fdopen' below it is text IO by default.
+    Finding("self-test", 18, 18, "fdopen"),
+    # Multi-line call: spans lines 21-24.
+    Finding("self-test", 21, 24, "write_text"),
 ]
 
 

--- a/src/soliplex/views/room_file_uploads.py
+++ b/src/soliplex/views/room_file_uploads.py
@@ -110,7 +110,13 @@ async def get_uploads_room_filename(
     the_user_claims: authn_package.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
 ) -> str:  # file path, converted to file response by FastAPI
-    """Download a file from the room uploads directory"""
+    """Download a file from the room uploads directory
+
+    Unlike sandbox workdir files, which are created by a possibly-
+    hallucinating or mischievous agent, files in the room-uploads tree
+    are under purview of the admin / operator:  symlinks to share e.g.
+    large datasets between rooms may be intentional and appropriate.
+    """
     the_logger.debug(loggers.UPLOADS_GET_ROOM_FILE)
 
     _room_config = await soliplex_views_agui._check_user_in_room(

--- a/src/soliplex/views/sandbox_workdirs.py
+++ b/src/soliplex/views/sandbox_workdirs.py
@@ -1,4 +1,7 @@
+import os
 import pathlib
+import stat
+import urllib.parse as url_parse
 
 import fastapi
 import pydantic
@@ -21,6 +24,14 @@ depend_the_threads = agui.depend_the_threads
 depend_the_room_authz = views.depend_the_room_authz_policy
 depend_the_user_claims = views.depend_the_user_claims
 depend_the_logger = views.depend_the_logger
+
+
+CHUNKSIZE = 2**16  # 64k
+
+# DO NOT SIMPLIFY HERE:
+# This is the RFC 5987 extended-parameter syntax for a
+# 'Content-Disposition' header value using 'attachment'.
+ATTACHMENT_PREFIX = "attachment; filename*=UTF-8''"
 
 
 @soliplex_views_util.logfire_span(
@@ -68,7 +79,7 @@ async def get_workdirs_room_thread_run(
 
     if run_dir.is_dir():
         for file_or_sub in run_dir.glob("*"):
-            if file_or_sub.is_file():
+            if not file_or_sub.is_symlink() and file_or_sub.is_file():
                 filename = file_or_sub.name
                 filename_urls[filename] = request.url_for(
                     # View function name, not the route path.
@@ -93,13 +104,48 @@ async def get_workdirs_room_thread_run(
     )
 
 
+def _open_no_symlinks(file_path: pathlib.Path):
+    """Return a streaming generator for 'file_path'
+
+    First ensure that it is a regular file (no symlinks, etc.)
+    """
+    not_found = f"No workdir file: {file_path.name}"
+
+    try:
+        fd = os.open(
+            file_path,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | os.O_CLOEXEC,
+        )
+    except OSError:  # ELOOP for a symlink, ENOENT, EACCES
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail=not_found,
+        ) from None
+
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):  # directory, FIFO, device, socket
+        os.close(fd)
+        raise fastapi.HTTPException(status_code=404, detail=not_found)
+
+    def _stream():  # now owns the fd
+        with os.fdopen(fd, "rb") as fh:
+            while chunk := fh.read(CHUNKSIZE):
+                yield chunk
+
+    return _stream, st.st_size
+
+
+def _disposition(file_path: pathlib.Path) -> str:
+    attachment_name = url_parse.quote(file_path.name, safe="")
+    return f"{ATTACHMENT_PREFIX}{attachment_name}"
+
+
 @soliplex_views_util.logfire_span(
     "GET "
     "/v1/workdirs/{room_id}/thread/{thread_id}/run/{run_id}/file/{filename}"
 )
 @router.get(
     "/v1/workdirs/{room_id}/thread/{thread_id}/run/{run_id}/file/{filename}",
-    response_class=responses.FileResponse,
 )
 async def get_workdirs_room_thread_run_filename(
     room_id: str,
@@ -111,8 +157,13 @@ async def get_workdirs_room_thread_run_filename(
     the_room_authz: authz.RoomAuthorizationPolicy = depend_the_room_authz,
     the_user_claims: authn.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
-) -> str:  # file path, converted to file response by FastAPI
-    """Return a list of files uploaded to the thread"""
+) -> responses.StreamingResponse:
+    """Return a file uploaded to the thread.
+
+    In order to prevent an agent-created symlink from exposing a file
+    not in the workdir, this view returns a streaming response, rather
+    than using `fastapi`s 'FileResponse-from-filename' affordance.
+    """
     thread_id = str(thread_id)
     run_id = str(run_id)
 
@@ -140,10 +191,16 @@ async def get_workdirs_room_thread_run_filename(
     run_dir = pathlib.Path(workdirs_path) / room_id / thread_id / run_id
 
     file_path = run_dir / filename
-    if not file_path.is_file():
-        raise fastapi.HTTPException(
-            status_code=404,
-            detail=f"No workdir file: {filename}",
-        )
 
-    return str(file_path)
+    streamer, size = _open_no_symlinks(file_path)
+
+    stream = streamer()
+
+    return responses.StreamingResponse(
+        stream,
+        headers={
+            "content-length": str(size),
+            "content-disposition": _disposition(file_path),
+            "x-content-type-options": "nosniff",
+        },
+    )

--- a/src/soliplex/views/sandbox_workdirs.py
+++ b/src/soliplex/views/sandbox_workdirs.py
@@ -196,8 +196,15 @@ async def get_workdirs_room_thread_run_filename(
 
     stream = streamer()
 
+    # Declare one fixed, inert type rather than guessing from the
+    # filename as 'FileResponse' did: the name is chosen by
+    # model-authored code, so a guess would hand the browser a
+    # content type derived from untrusted input. Together with the
+    # 'attachment' disposition and 'nosniff', this makes the browser
+    # download the file and never interpret it.
     return responses.StreamingResponse(
         stream,
+        media_type="application/octet-stream",
         headers={
             "content-length": str(size),
             "content-disposition": _disposition(file_path),

--- a/src/soliplex/views/thread_file_uploads.py
+++ b/src/soliplex/views/thread_file_uploads.py
@@ -96,14 +96,6 @@ async def get_uploads_room_id_thread_thread_id(
     response_class=responses.FileResponse,
 )
 async def get_uploads_room_id_thread_thread_id_filename(
-    """Download a file from the thread uploads directory
-
-    Unlike sandbox workdir files, which are created by a possibly-
-    hallucinating or mischievous agent, files in the thread-uploads tree
-    are durable.  The operator may choose to add a symlink into a particular
-    thread's directory to share a large dataset, without requiring that
-    the user download it from somewhere and then re-upload it here.
-    """
     room_id: str,
     thread_id: pydantic.UUID4,
     filename: str,
@@ -113,7 +105,14 @@ async def get_uploads_room_id_thread_thread_id_filename(
     the_user_claims: authn.UserClaims = depend_the_user_claims,
     the_logger: loggers.LogWrapper = depend_the_logger,
 ) -> str:  # file path, converted to file response by FastAPI
-    """Download a file from the room uploads directory"""
+    """Download a file from the thread uploads directory
+
+    Unlike sandbox workdir files, which are created by a possibly-
+    hallucinating or mischievous agent, files in the thread-uploads tree
+    are durable.  The operator may choose to add a symlink into a particular
+    thread's directory to share a large dataset, without requiring that
+    the user download it from somewhere and then re-upload it here.
+    """
     thread_id = str(thread_id)
 
     the_logger.debug(loggers.UPLOADS_GET_ROOM_THREAD_FILE)

--- a/src/soliplex/views/thread_file_uploads.py
+++ b/src/soliplex/views/thread_file_uploads.py
@@ -96,6 +96,14 @@ async def get_uploads_room_id_thread_thread_id(
     response_class=responses.FileResponse,
 )
 async def get_uploads_room_id_thread_thread_id_filename(
+    """Download a file from the thread uploads directory
+
+    Unlike sandbox workdir files, which are created by a possibly-
+    hallucinating or mischievous agent, files in the thread-uploads tree
+    are durable.  The operator may choose to add a symlink into a particular
+    thread's directory to share a large dataset, without requiring that
+    the user download it from somewhere and then re-upload it here.
+    """
     room_id: str,
     thread_id: pydantic.UUID4,
     filename: str,

--- a/tests/functional/test_sandbox_workdirs.py
+++ b/tests/functional/test_sandbox_workdirs.py
@@ -55,7 +55,11 @@ def test_get_workdir_file_returns_file_bytes(client_no_llm, run_workdir):
 
     assert response.status_code == 200
     assert response.content == file_bytes
-    assert response.headers["content-type"].startswith("text/plain")
+    assert response.headers["content-type"] == "application/octet-stream"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["content-disposition"] == (
+        "attachment; filename*=UTF-8''result.txt"
+    )
 
 
 def test_get_workdir_file_404_when_file_missing(client_no_llm, run_workdir):

--- a/tests/unit/views/test_sandbox_workdirs.py
+++ b/tests/unit/views/test_sandbox_workdirs.py
@@ -1,4 +1,6 @@
 import contextlib
+import os
+import pathlib
 import uuid
 from unittest import mock
 
@@ -45,11 +47,13 @@ def sandbox_path(temp_dir):
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "w_filenames",
+    "w_filenames, w_link",
     [
-        [],
-        ["foo.txt"],
-        [f"file_{i_file:03}.txt" for i_file in range(10)],
+        ([], None),
+        (["foo.txt"], None),
+        ([f"file_{i_file:03}.txt" for i_file in range(10)], None),
+        (["sneaky.txt"], "symlink"),
+        (["hard.txt"], "hardlink"),
     ],
 )
 @pytest.mark.parametrize(
@@ -73,6 +77,7 @@ async def test_get_workdirs_room_thread_run_only(
     w_workdir_path,
     expectation,
     w_filenames,
+    w_link,
 ):
     sandbox_workdirs_path = sandbox_path / "workdirs"
     run_path = (
@@ -97,17 +102,31 @@ async def test_get_workdirs_room_thread_run_only(
 
     if w_workdir_path:
         run_path.mkdir(parents=True)
+        link_target = sandbox_path / "link-target"
+        link_target.write_text("sneaky link points here")
         (run_path / "ignore_me").mkdir()
         for filename in w_filenames:
             file_path = run_path / filename
-            file_path.write_text(f"filename: {filename}")
-            exp_filename_urls[filename] = download_url(
-                ROUTE_NAME,
-                TEST_ROOM_ID,
-                TEST_THREAD_ID_STR,
-                TEST_RUN_ID_STR,
-                filename,
-            )
+            if w_link == "symlink":
+                file_path.symlink_to(link_target)
+            elif w_link == "hardlink":
+                file_path.hardlink_to(link_target)
+                exp_filename_urls[filename] = download_url(
+                    ROUTE_NAME,
+                    TEST_ROOM_ID,
+                    TEST_THREAD_ID_STR,
+                    TEST_RUN_ID_STR,
+                    filename,
+                )
+            else:
+                file_path.write_text(f"filename: {filename}")
+                exp_filename_urls[filename] = download_url(
+                    ROUTE_NAME,
+                    TEST_ROOM_ID,
+                    TEST_THREAD_ID_STR,
+                    TEST_RUN_ID_STR,
+                    filename,
+                )
 
     request = mock.create_autospec(fastapi.Request)
     request.url_for.side_effect = download_url
@@ -148,11 +167,14 @@ async def test_get_workdirs_room_thread_run_only(
 
         if w_workdir_path:
             found_files = {f_up.filename: f_up.url for f_up in found.files}
-            assert set(found_files) == set(w_filenames)
 
-            for filename in w_filenames:
-                exp_url = exp_filename_urls[filename]
-                assert str(found_files[filename]) == exp_url
+            if w_link == "symlink":
+                assert not found_files
+            else:
+                assert set(found_files) == set(w_filenames)
+                for filename in w_filenames:
+                    exp_url = exp_filename_urls[filename]
+                    assert str(found_files[filename]) == exp_url
         else:
             assert found.files == []
 
@@ -171,41 +193,112 @@ async def test_get_workdirs_room_thread_run_only(
     )
 
 
+not_a_workdir_file = raises_httpexc(
+    code=404,
+    match=f"No workdir file: {TEST_FILENAME}",
+)
+
+
+@pytest.mark.parametrize(
+    "w_workdir_path, w_filename, w_link, expectation",
+    [
+        # The open itself fails: 'O_NOFOLLOW' rejects the final component.
+        (True, True, "symlink", not_a_workdir_file),
+        # The open succeeds, but 'fstat' reports a non-regular file.
+        (True, True, "dir", not_a_workdir_file),
+        # 'O_NONBLOCK' keeps this from hanging until a writer appears.
+        (True, True, "fifo", not_a_workdir_file),
+        (True, False, None, not_a_workdir_file),
+        (False, None, None, not_a_workdir_file),
+        # A hard link is a regular file, and cannot escape the workdir:
+        # each bwrap bind is its own mount, so 'link' fails 'EXDEV' across
+        # them. It is therefore served like any other file.
+        (True, True, "hardlink", no_error(None)),
+        (True, True, None, no_error(None)),
+    ],
+)
+def test__open_no_symlinks(
+    sandbox_path,
+    w_workdir_path,
+    w_filename,
+    w_link,
+    expectation,
+):
+    workdir_path = sandbox_path / "workdir"
+    file_path = workdir_path / TEST_FILENAME
+
+    if w_workdir_path:
+        workdir_path.mkdir()
+        link_target = sandbox_path / "link-target"
+        link_target.write_text("sneaky link points here")
+
+        if w_filename:
+            if w_link == "symlink":
+                file_path.symlink_to(link_target)
+            elif w_link == "hardlink":
+                file_path.hardlink_to(link_target)
+            elif w_link == "dir":
+                file_path.mkdir()
+            elif w_link == "fifo":
+                os.mkfifo(file_path)
+            else:
+                file_path.write_text(f"filename: {TEST_FILENAME}")
+
+    with expectation as expected:
+        found = workdir_views._open_no_symlinks(file_path)
+
+    if expected is None:
+        streamer, size = found
+
+        assert size == file_path.stat().st_size
+        assert b"".join(streamer()) == file_path.read_bytes()
+
+
+@pytest.mark.parametrize(
+    "w_name, expected",
+    [
+        ("report.txt", "report.txt"),
+        ('a"b.txt', "a%22b.txt"),
+        ("a\r\nX-Injected: yes", "a%0D%0AX-Injected%3A%20yes"),
+        ("r\u00e9sum\u00e9.pdf", "r%C3%A9sum%C3%A9.pdf"),
+        ("/var/soliplex/workdirs/chat/uuid/uuid/report.txt", "report.txt"),
+    ],
+)
+def test__disposition(w_name, expected):
+    found = workdir_views._disposition(pathlib.Path(w_name))
+
+    assert found == workdir_views.ATTACHMENT_PREFIX + expected
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "w_sandbox_path, w_workdir_path, w_filename, expectation",
+    "w_sandbox_path, expectation",
     [
-        (True, True, True, no_error(None)),
-        (
-            True,
-            True,
-            False,
-            raises_httpexc(code=404, match=".*"),
-        ),
-        (
-            True,
-            False,
-            None,
-            raises_httpexc(code=404, match=".*"),
-        ),
+        (True, no_error(None)),
         (
             False,
-            None,
-            None,
             raises_httpexc(code=404, match="Sandbox workdirs not configured"),
         ),
     ],
 )
+@mock.patch("soliplex.views.sandbox_workdirs._disposition")
+@mock.patch("soliplex.views.sandbox_workdirs._open_no_symlinks")
 @mock.patch("soliplex.views.agui._check_thread_ownership")
+@mock.patch("fastapi.responses.StreamingResponse")
 async def test_get_workdirs_room_thread_run_filename(
+    frsr,
     cto,
+    open_no_symlinks,
+    disposition,
     the_threads,
     sandbox_path,
     w_sandbox_path,
-    w_workdir_path,
-    w_filename,
     expectation,
 ):
+    file_size = 2**17
+    streamer = mock.MagicMock(name="streamer")
+    open_no_symlinks.return_value = (streamer, file_size)
+
     sandbox_workdirs_path = sandbox_path / "workdirs"
     workdir_path = (
         sandbox_workdirs_path
@@ -214,12 +307,9 @@ async def test_get_workdirs_room_thread_run_filename(
         / TEST_RUN_ID_STR
     )
 
-    if w_workdir_path:
-        workdir_path.mkdir(parents=True)
-
-        if w_filename:
-            file_path = workdir_path / TEST_FILENAME
-            file_path.write_text(f"filename: {TEST_FILENAME}")
+    workdir_path.mkdir(parents=True)
+    file_path = workdir_path / TEST_FILENAME
+    file_path.write_text(f"filename: {TEST_FILENAME}")
 
     room_config = mock.create_autospec(config_rooms.RoomConfig)
     cto.return_value = room_config
@@ -250,7 +340,18 @@ async def test_get_workdirs_room_thread_run_filename(
         )
 
     if expected is None:
-        assert found == str(file_path)
+        assert found is frsr.return_value
+
+        frsr.assert_called_once_with(
+            streamer.return_value,
+            headers={
+                "content-length": str(file_size),
+                "content-disposition": disposition.return_value,
+                "x-content-type-options": "nosniff",
+            },
+        )
+        disposition.assert_called_once_with(file_path)
+        open_no_symlinks.assert_called_once_with(file_path)
 
     cto.assert_awaited_once_with(
         room_id=TEST_ROOM_ID,

--- a/tests/unit/views/test_sandbox_workdirs.py
+++ b/tests/unit/views/test_sandbox_workdirs.py
@@ -344,6 +344,7 @@ async def test_get_workdirs_room_thread_run_filename(
 
         frsr.assert_called_once_with(
             streamer.return_value,
+            media_type="application/octet-stream",
             headers={
                 "content-length": str(file_size),
                 "content-disposition": disposition.return_value,


### PR DESCRIPTION
Exclude symlinks, directories, FIFOs, sockets, etc.

Hard-links are OK, because the agent can only make them within its own read-write volume mount.

Closes #1331.