### PR TITLE
feat: '._RAGConfigBase.local_hr_config'

### DIFF
--- a/src/soliplex/config/rag.py
+++ b/src/soliplex/config/rag.py
@@ -31,6 +31,16 @@ class RagDbExactlyOneOfStemOrOverride(TypeError):
         )
 
 
+class RagDbS3_URI_RequiresStemNotOverride(TypeError):
+    def __init__(self, _config_path):
+        self._config_path = _config_path
+        super().__init__(
+            f"Use of 'rag_lancedb_s3_bucket' requires 'rag_lancedb_stem' "
+            f" but cannot be used with 'rag_lancedb_override_path' "
+            f"(configured in {_config_path})"
+        )
+
+
 class RagDbFileNotFound(ValueError):
     def __init__(self, rag_db_filename, _config_path):
         self.rag_db_filename = rag_db_filename
@@ -85,6 +95,31 @@ class _RAGConfigBase:
         _utils._no_repr_no_compare_none()
     )
     _config_path: pathlib.Path = None
+    _local_haiku_rag_config: hr_config.AppConfig | None = None
+
+    @classmethod
+    def _extract_local_hr_config(
+        cls,
+        config_dict,
+    ) -> hr_config.AppConfig | None:
+        """Helper for derived class 'from_yaml'"""
+        lrhc = config_dict.pop("local_haiku_rag_config", None)
+
+        if lrhc is not None:
+            config_dict["_local_haiku_rag_config"] = (
+                hr_config.AppConfig.model_validate(lrhc)
+            )
+
+        return config_dict
+
+    # Allow for overrides in the skill / tool config itself
+    @property
+    def local_haiku_rag_config(self) -> hr_config.AppConfig:
+        return (
+            self._local_haiku_rag_config
+            if self._local_haiku_rag_config
+            else {}
+        )
 
     @property
     def haiku_rag_config(self) -> hr_config.AppConfig:
@@ -99,22 +134,31 @@ class _RAGConfigBase:
                 raise exceptions.NoConfigPath()
 
             base_config = self._installation_config.haiku_rag_config
+            base_config_yaml = base_config.model_dump(exclude_unset=True)
+            merged_config_yaml = base_config_yaml
 
             hr_config_file = self._config_path.parent / "haiku.rag.yaml"
 
             if hr_config_file.is_file():
-                base_config_yaml = base_config.model_dump(exclude_unset=True)
                 room_config_yaml = hr_config.load_yaml_config(hr_config_file)
                 merged_config_yaml = _deep_merge(
-                    base_config_yaml,
+                    merged_config_yaml,
                     room_config_yaml,
                 )
 
-                self._haiku_rag_config = hr_config.AppConfig.model_validate(
-                    merged_config_yaml
+            local_config = self._local_haiku_rag_config
+            if local_config is not None:
+                my_config_yaml = local_config.model_dump(exclude_unset=True)
+                merged_config_yaml = _deep_merge(
+                    merged_config_yaml,
+                    my_config_yaml,
                 )
-            else:
-                self._haiku_rag_config = base_config
+
+            merged_hr_config = hr_config.AppConfig.model_validate(
+                merged_config_yaml
+            )
+
+            self._haiku_rag_config = merged_hr_config
 
         return self._haiku_rag_config
 
@@ -126,6 +170,9 @@ class _RAGDatabaseBase:
     # One of these two options must be specified
     rag_lancedb_stem: str = None
     rag_lancedb_override_path: str = None
+
+    # Uses the stem, but cannot be used with 'rag_lancedb_override_path`
+    rag_lancedb_s3_bucket: str = None
 
     # Normally set via subclass 'from_yaml'
     _installation_config: InstallationConfig = (  # noqa F821 cycle
@@ -142,6 +189,12 @@ class _RAGDatabaseBase:
 
         if len(list(passed)) != 1:
             raise RagDbExactlyOneOfStemOrOverride(self._config_path)
+
+        if self.rag_lancedb_s3_bucket is not None and (
+            self.rag_lancedb_stem is None
+            or self.rag_lancedb_override_path is not None
+        ):
+            raise RagDbS3_URI_RequiresStemNotOverride(self._config_path)
 
     @property
     def rag_lancedb_path(self) -> pathlib.Path:

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -1,4 +1,5 @@
 import contextlib
+from unittest import mock
 
 import pytest
 import yaml
@@ -7,7 +8,10 @@ from haiku.rag import config as hr_config_module
 from soliplex.config import exceptions as config_exc
 from soliplex.config import rag as config_rag
 
+S3_URI = "s3://my-test-bucket/my-folder"
+
 rdb_exactly_one = pytest.raises(config_rag.RagDbExactlyOneOfStemOrOverride)
+rdb_s3_rq_stem = pytest.raises(config_rag.RagDbS3_URI_RequiresStemNotOverride)
 rdb_not_found = pytest.raises(config_rag.RagDbFileNotFound)
 no_config_path = pytest.raises(config_exc.NoConfigPath)
 ok_stem = contextlib.nullcontext("stem")
@@ -42,15 +46,59 @@ def test__deep_merge(base, derived, expected):
 
 
 @pytest.mark.parametrize(
-    "w_already, w_config_path, w_hr_yaml",
+    "w_config_dict",
     [
-        (False, False, {}),
-        (False, True, {}),
-        (False, True, {"environment": "from_room"}),
-        (False, True, {"prompts": {"domain_preamble": "from_room"}}),
-        (True, False, {}),
-        (True, True, {}),
-        (True, True, {"environment": "from_room"}),
+        {},
+        {"local_haiku_rag_config": {"environment": "from_local"}},
+    ],
+)
+@mock.patch("haiku.rag.config.AppConfig")
+def test__rcb__extract_local_hr_config(ac_klass, w_config_dict):
+    config_dict = w_config_dict.copy()
+    found = config_rag._RAGConfigBase._extract_local_hr_config(config_dict)
+
+    if config_dict:
+        assert found == {
+            "_local_haiku_rag_config": ac_klass.model_validate.return_value,
+        }
+        ac_klass.model_validate.assert_called_once_with(
+            w_config_dict["local_haiku_rag_config"]
+        )
+    else:
+        assert found == w_config_dict
+        ac_klass.model_validate.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "w_already, w_config_path, w_hr_yaml, w_local",
+    [
+        (False, False, {}, {}),
+        (False, True, {}, {}),
+        (False, True, {"environment": "from_room"}, {}),
+        (False, True, {"prompts": {"domain_preamble": "from_room"}}, {}),
+        (False, True, {}, {"prompts": {"domain_preamble": "from_local"}}),
+        (
+            False,
+            True,
+            {"prompts": {"domain_preamble": "from_room"}},
+            {"prompts": {"domain_preamble": "from_local"}},
+        ),
+        (True, False, {}, {}),
+        (True, True, {}, {}),
+        (True, True, {"environment": "from_room"}, {}),
+        (True, True, {}, {"environment": "from_local"}),
+        (
+            True,
+            True,
+            {"environment": "from_room"},
+            {"environment": "from_local"},
+        ),
+        (
+            False,
+            True,
+            {"prompts": {"domain_preamble": "from_room"}},
+            {"environment": "from_local"},
+        ),
     ],
 )
 def test__rcb_haiku_rag_config(
@@ -59,6 +107,7 @@ def test__rcb_haiku_rag_config(
     w_already,
     w_config_path,
     w_hr_yaml,
+    w_local,
 ):
     already = object()
 
@@ -88,6 +137,11 @@ def test__rcb_haiku_rag_config(
     else:
         exp_room_config_path = None
 
+    if w_local:
+        kw["_local_haiku_rag_config"] = (
+            hr_config_module.AppConfig.model_validate(w_local)
+        )
+
     rcb_config = config_rag._RAGConfigBase(**kw)
     assert isinstance(rcb_config, config_rag.RAGConfigProtocol)
 
@@ -98,12 +152,16 @@ def test__rcb_haiku_rag_config(
         if w_config_path:
             hr_config = rcb_config.haiku_rag_config
 
-            if "environment" in w_hr_yaml:
+            if "environment" in w_local:
+                assert hr_config.environment == "from_local"
+            elif "environment" in w_hr_yaml:
                 assert hr_config.environment == "from_room"
             else:
                 assert hr_config.environment == "from_installation"
 
-            if "prompts" in w_hr_yaml:
+            if "prompts" in w_local:
+                assert hr_config.prompts.domain_preamble == "from_local"
+            elif "prompts" in w_hr_yaml:
                 assert hr_config.prompts.domain_preamble == "from_room"
             else:
                 assert hr_config.prompts.domain_preamble == "from_installation"
@@ -123,14 +181,17 @@ def db_rag_path(temp_dir):
 
 
 @pytest.mark.parametrize(
-    "w_config_path, stem, override, ctor_expectation, rlp_expectation",
+    "w_config_path, stem, override, s3, ctor_expectation, rlp_expectation",
     [
-        (False, None, None, rdb_exactly_one, None),
-        (False, "testing", "/dev/null", rdb_exactly_one, None),
-        (False, "bogus", None, ok_stem, rdb_not_found),
-        (False, "testing", None, ok_stem, ok_stem),
-        (False, None, "./override", ok_ovr, rdb_not_found),
-        (True, None, "./override", ok_ovr, ok_ovr),
+        (False, None, None, None, rdb_exactly_one, None),
+        (False, "testing", "/dev/null", None, rdb_exactly_one, None),
+        (False, None, None, S3_URI, rdb_exactly_one, None),
+        (False, "bogus", None, None, ok_stem, rdb_not_found),
+        (False, "testing", None, None, ok_stem, ok_stem),
+        (False, "testing", None, S3_URI, ok_stem, ok_stem),
+        (False, None, "./override", None, ok_ovr, rdb_not_found),
+        (True, None, "./override", None, ok_ovr, ok_ovr),
+        (True, None, "./override", S3_URI, rdb_s3_rq_stem, None),
     ],
 )
 def test__rdb_ctor(
@@ -140,6 +201,7 @@ def test__rdb_ctor(
     w_config_path,
     stem,
     override,
+    s3,
     ctor_expectation,
     rlp_expectation,
 ):
@@ -173,6 +235,9 @@ def test__rdb_ctor(
 
     if override is not None:
         kw["rag_lancedb_override_path"] = override
+
+    if s3 is not None:
+        kw["rag_lancedb_s3_bucket"] = s3
 
     with ctor_expectation as ctor_which:
         rdb_config = config_rag._RAGDatabaseBase(**kw)


### PR DESCRIPTION
  Inline 'haiku_rag' config overrides in tool / skill config.

feat: '._RAGDatabaseBase.rag_lancedb_s3_bucket'

  Prefix defining S3 bucket / root directory for db storage.

Toward #1246.