### PR TITLE
docs: lead the RAG ingestion setup with a docling container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,3 +63,33 @@ services:
       - ./db:/app/db
       - ./sandbox/workdirs:/app/sandbox/workdirs
       - ./uploads:/app/uploads
+
+  # Document conversion for RAG ingestion.
+  #
+  #   docker compose up -d docling_serve
+  #
+  # Only needed to BUILD a RAG database, never to serve one. The server
+  # depends on 'haiku.rag-slim', which queries an existing LanceDB but
+  # cannot ingest documents; ingestion needs docling, which drags in
+  # torch, transformers and the whole CUDA stack -- some 88 packages.
+  # Running it as a container keeps all of that out of the venv the
+  # server actually ships.
+  #
+  # Port 5001 is what 'example/haiku.rag.yaml' already points its
+  # 'providers.docling_serve.base_url' at, so no config change is needed.
+  # Once it is up:
+  #
+  #   haiku-rag --config example/haiku.rag.yaml \
+  #     add-src --db db/rag/rag.lancedb docs/
+  #
+  # The CPU image is deliberate: the example corpus is Markdown, so there
+  # is no OCR to accelerate, and it avoids requiring the NVIDIA container
+  # toolkit. Swap to 'docling-serve' (no '-cpu') plus a 'gpus: all'
+  # deploy block if you start ingesting scanned PDFs at volume.
+  docling_serve:
+    image: ghcr.io/docling-project/docling-serve-cpu:latest
+    ports:
+      - "5001:5001"
+    environment:
+      DOCLING_SERVE_ENABLE_UI: "true"
+    restart: unless-stopped

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -18,13 +18,27 @@ against an existing LanceDB database.
 However, this dependency is not sufficient to perform the ingestion /
 indexing of documents.  For that purpose, either:
 
-- Install the main `haiku-rag` project
-  (<https://pypi.org/project/haiku.rag/>)
-  which will pull in all the dependencies required to ingest and index
-  documents.
+- Run `docling-serve` as a container, which this repository's
+  `docker-compose.yaml` provides. **Recommended:** it keeps the ingestion
+  dependencies out of the environment the server runs in.
 
-- Pull the `docling-serve` Docker image, and run its server, with
-  your `haiku.rag.yaml` file configured to use it.
+  ```bash
+  docker compose up -d docling_serve
+  ```
+
+  It listens on port 5001, which is where `example/haiku.rag.yaml`
+  already points `providers.docling_serve.base_url`, so no configuration
+  change is needed.
+
+- Or install the main `haiku-rag` project
+  (<https://pypi.org/project/haiku.rag/>), which pulls in every
+  dependency needed to ingest and index documents.
+
+  Be aware of what that costs: it resolves to roughly 88 additional
+  packages, including `torch`, `transformers`, `opencv` and the full
+  NVIDIA CUDA stack, and it upgrades `click` out from under the CLI.
+  It also leaves both `haiku.rag` and `haiku.rag-slim` installed, each
+  providing the same import package.
 
 See the `haiku.rag` documentation to determine:
 


### PR DESCRIPTION
Ingestion needs docling, which the server's `haiku.rag-slim` dependency
deliberately leaves out. Installing the full `haiku.rag` to get it costs
more than it looks: roughly 88 additional packages including `torch`,
`transformers`, `opencv` and the full NVIDIA CUDA stack, an upgrade to
`click` out from under the CLI, and two distributions left providing the
same import package.

Running docling as a container avoids all of that, and the compose
service listens on the port `example/haiku.rag.yaml` already points at,
so it needs no configuration change. This makes it the leading option
and documents what the pip route actually costs.

The CPU image is deliberate: the example corpus is Markdown, so there is
no OCR to accelerate and it avoids requiring the NVIDIA container
toolkit.

Split out of the context-metering work so it can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGgKMJXcvXn53C8zjKxzfR
