### PR TITLE
portability fixes

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -24,12 +24,26 @@ on:
 jobs:
   test-soliplex:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    # A Windows runner is the slower machine, and pays a heavier
+    # per-worker start-up cost under xdist, so give it more headroom
+    # than the Linux runners need.
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 30 || 15 }}
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.13", "3.14"]
+        # Linux is the supported platform and carries the full version
+        # matrix. Windows is checked for portability, on one version:
+        # a break there is a break in the tests, not in the Python.
+        exclude:
+          - os: windows-latest
+            python-version: "3.14"
+    defaults:
+      run:
+        # The steps below are bash ('set -o pipefail', 'tee', the
+        # summary heredoc); a Windows runner would otherwise use 'pwsh'.
+        shell: bash
     steps:
       - uses: actions/checkout@v6
 
@@ -58,7 +72,14 @@ jobs:
       # Functional tests run serially: they share on-disk state (e.g. the
       # 'sandbox/workdirs' tree, keyed by a constant room id) and
       # module-scoped app fixtures, so xdist workers race each other.
+      #
+      # Linux only: Windows is in the matrix to check the portability of
+      # the unit suite, and one of these modules
+      # ('test_sandbox_workdirs.py') builds the POSIX-only bubblewrap
+      # workdir tree that the matching unit tests skip off POSIX (see
+      # 'tests/_platform.py').
       - name: Run functional tests
+        if: runner.os != 'Windows'
         run: |
           set -o pipefail
           uv run py.test -s --no-cov -m "not needs_llm" tests/functional/ 2>&1 \
@@ -70,7 +91,7 @@ jobs:
         if: failure()
         run: |
           {
-            echo "## Python ${{ matrix.python-version }} failed"
+            echo "## ${{ matrix.os }}, Python ${{ matrix.python-version }} failed"
             echo
             for log in unit-tests.log functional-tests.log; do
               [ -f "$log" ] || continue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,10 +140,15 @@ tree). The configured hooks (see `.pre-commit-config.yaml`) enforce:
   *report* (`tests/_platform.py: POSIX_ONLY_COVERAGE_OMIT`), warning
   that it has -- so everything the host can measure is still held to
   100%, and only the sandbox needs re-checking on Linux
-- Prefer either of those to loosening an assertion. An assertion on a
+- CI checks that: `.github/workflows/python-test.yaml` runs the unit
+  suite on `windows-latest` as well, on Python 3.13 only, with the
+  functional step skipped there. The 100% gate applies to that job like
+  any other
+- Never loosen an assertion to make a platform pass. An assertion on a
   rendered path should build its expectation with `pathlib` so it holds
   on either separator; a test that needs a POSIX-only primitive and is
-  *not* about the sandbox needs a new gate rather than a weaker check
+  *not* about the sandbox needs a gate of its own rather than a weaker
+  check
 
 ## Repository Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,19 +128,22 @@ tree). The configured hooks (see `.pre-commit-config.yaml`) enforce:
   `-n`-less step
 - Coverage and xdist compose (pytest-cov merges the workers' data), so
   `-n` does not weaken the 100% gate
-- **The suite runs on Windows and macOS too**, with a few tests skipped.
-  A test needing something only a POSIX host offers (an `O_NOFOLLOW`
-  open, a FIFO, a symlink, `PosixPath.resolve` rejecting an embedded
-  NUL) calls the matching `requires_*` helper from `tests/_platform.py`,
-  which warns and skips where the host cannot oblige. The probes ask the
-  host, not `os.name`, where they can -- Windows with Developer Mode on
-  makes symlinks, and runs those tests. Add a probe there rather than
-  loosening an assertion; an assertion on a rendered path should build
-  its expectation with `pathlib` so it holds on either separator
-- Those skips leave the code they cover unmeasured, so the 100% gate is
-  unmeetable off POSIX. `tests/conftest.py` drops `--cov-fail-under` to
-  0 there (warning that it has), and leaves POSIX hosts and CI on the
-  full gate -- coverage from a non-Linux run proves nothing
+- **The suite runs on Windows and macOS too.** The one exception is
+  the bubblewrap sandbox, which is Linux-only, and so are the symlinks,
+  FIFOs and `O_NOFOLLOW` opens its tests set up. The two modules
+  covering it (`test_bwrap_sandbox.py` under `tests/unit/skills/`, and
+  `test_sandbox_workdirs.py` under `tests/unit/views/`) therefore carry
+  `pytestmark = _platform.requires_posix_sandbox` and skip whole off
+  POSIX
+- The 100% gate still applies off POSIX. `tests/conftest.py` drops the
+  two skipped modules, and the two they cover, from the coverage
+  *report* (`tests/_platform.py: POSIX_ONLY_COVERAGE_OMIT`), warning
+  that it has -- so everything the host can measure is still held to
+  100%, and only the sandbox needs re-checking on Linux
+- Prefer either of those to loosening an assertion. An assertion on a
+  rendered path should build its expectation with `pathlib` so it holds
+  on either separator; a test that needs a POSIX-only primitive and is
+  *not* about the sandbox needs a new gate rather than a weaker check
 
 ## Repository Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,19 @@ tree). The configured hooks (see `.pre-commit-config.yaml`) enforce:
   `-n`-less step
 - Coverage and xdist compose (pytest-cov merges the workers' data), so
   `-n` does not weaken the 100% gate
+- **The suite runs on Windows and macOS too**, with a few tests skipped.
+  A test needing something only a POSIX host offers (an `O_NOFOLLOW`
+  open, a FIFO, a symlink, `PosixPath.resolve` rejecting an embedded
+  NUL) calls the matching `requires_*` helper from `tests/_platform.py`,
+  which warns and skips where the host cannot oblige. The probes ask the
+  host, not `os.name`, where they can -- Windows with Developer Mode on
+  makes symlinks, and runs those tests. Add a probe there rather than
+  loosening an assertion; an assertion on a rendered path should build
+  its expectation with `pathlib` so it holds on either separator
+- Those skips leave the code they cover unmeasured, so the 100% gate is
+  unmeetable off POSIX. `tests/conftest.py` drops `--cov-fail-under` to
+  0 there (warning that it has), and leaves POSIX hosts and CI on the
+  full gate -- coverage from a non-Linux run proves nothing
 
 ## Repository Structure
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -270,6 +270,14 @@ later `coverage report` can still be pointed at it. And it reaches the
 with a second, `combining_cov` instance -- neither is reachable through
 `config.option`.
 
+CI checks this rather than taking it on trust:
+`.github/workflows/python-test.yaml` runs the unit suite on
+`windows-latest` alongside the Linux matrix. Windows runs Python 3.13
+only -- a break there is a break in the tests, not in the interpreter --
+and skips the functional step, which stays Linux-only. The coverage gate
+applies to the Windows job in full, narrowed as above, so it does fail
+on a real coverage regression.
+
 Anything genuinely platform-specific belongs behind a gate, not behind a
 loosened assertion: assertions on rendered paths should build their
 expectation with `pathlib` (`str(pathlib.Path(...))`) so they hold on

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -235,6 +235,32 @@ Coverage is unaffected by `-n`: pytest-cov collects each worker's data and
 merges it, so a parallel run enforces the same 100% threshold as a serial
 one.
 
+### Running the unit tests off Linux
+
+Linux is the supported platform, and the whole unit suite runs there. It
+also runs green on Windows and macOS, with a handful of tests skipped: a
+few exercise behaviour the standard library only offers on a POSIX host
+-- an `O_NOFOLLOW` open, a FIFO, a symlink, `PosixPath.resolve` rejecting
+an embedded NUL.
+
+`tests/_platform.py` holds the probes. A test that needs one of those
+calls the matching `requires_*` helper, which warns (an
+`UnsupportedPlatformWarning`, listed in pytest's warnings summary) and
+skips when the host cannot oblige. The probes answer for the host rather
+than for `os.name` where they can: a Windows box with Developer Mode
+turned on creates symlinks, and runs the symlink tests.
+
+Because those skips leave the code they cover unmeasured, the 100% gate
+cannot be met off POSIX. `tests/conftest.py` relaxes `--cov-fail-under`
+to 0 there -- warning that it has done so -- and leaves POSIX hosts, CI
+included, on the full gate. Coverage numbers from a Windows or macOS run
+therefore prove nothing; re-check them on Linux.
+
+Anything genuinely platform-specific belongs behind a probe, not behind
+a loosened assertion: assertions on rendered paths should build their
+expectation with `pathlib` (`str(pathlib.Path(...))`) so they hold on
+either separator, rather than being weakened to match both.
+
 ## Configuration system
 
 - Configuration is YAML-based and hierarchical, parsed under

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -238,26 +238,40 @@ one.
 ### Running the unit tests off Linux
 
 Linux is the supported platform, and the whole unit suite runs there. It
-also runs green on Windows and macOS, with a handful of tests skipped: a
-few exercise behaviour the standard library only offers on a POSIX host
--- an `O_NOFOLLOW` open, a FIFO, a symlink, `PosixPath.resolve` rejecting
-an embedded NUL.
+also runs green on Windows and macOS, with two modules skipped: the ones
+covering the bubblewrap sandbox. `bwrap` is Linux-only, and so is
+everything its tests build to exercise it -- an `O_NOFOLLOW` open, a
+FIFO, a symlink, `PosixPath.resolve` rejecting an embedded NUL -- so
+there is nothing left for them to assert on a host without it.
 
-`tests/_platform.py` holds the probes. A test that needs one of those
-calls the matching `requires_*` helper, which warns (an
-`UnsupportedPlatformWarning`, listed in pytest's warnings summary) and
-skips when the host cannot oblige. The probes answer for the host rather
-than for `os.name` where they can: a Windows box with Developer Mode
-turned on creates symlinks, and runs the symlink tests.
+`tests/_platform.py` holds the gate. The two modules covering the
+sandbox -- `test_bwrap_sandbox.py` under `tests/unit/skills/`, and
+`test_sandbox_workdirs.py` under `tests/unit/views/` -- each set
+`pytestmark = _platform.requires_posix_sandbox`, which skips the module
+where `os.name` is not `"posix"`.
 
-Because those skips leave the code they cover unmeasured, the 100% gate
-cannot be met off POSIX. `tests/conftest.py` relaxes `--cov-fail-under`
-to 0 there -- warning that it has done so -- and leaves POSIX hosts, CI
-included, on the full gate. Coverage numbers from a Windows or macOS run
-therefore prove nothing; re-check them on Linux.
+Those skips leave the code they cover unmeasured, which would make the
+100% gate unmeetable. Rather than relax the gate, `tests/conftest.py`
+narrows what it is measured against: a `pytest_configure` hook adds
+`POSIX_ONLY_COVERAGE_OMIT` -- the two skipped test modules, and
+`soliplex.skills.bwrap_sandbox` and `soliplex.views.sandbox_workdirs`
+with them -- to the coverage report's `omit`, and warns (an
+`UnsupportedPlatformWarning`, listed in pytest's warnings summary) that
+it has. Everything else is still held to 100%, so a Windows or macOS run
+does catch a coverage regression; only the sandbox needs re-checking on
+Linux.
 
-Anything genuinely platform-specific belongs behind a probe, not behind
-a loosened assertion: assertions on rendered paths should build their
+Two notes on the hook, for anyone changing it. It omits at *report*
+time, not run time: measurement has already started by the time
+`pytest_configure` runs, and leaving the data file complete means a
+later `coverage report` can still be pointed at it. And it reaches the
+`Coverage` objects through pytest-cov's registered plugin, via
+`config.pluginmanager.get_plugin("_cov")`, because pytest-cov reports
+with a second, `combining_cov` instance -- neither is reachable through
+`config.option`.
+
+Anything genuinely platform-specific belongs behind a gate, not behind a
+loosened assertion: assertions on rendered paths should build their
 expectation with `pathlib` (`str(pathlib.Path(...))`) so they hold on
 either separator, rather than being weakened to match both.
 

--- a/tests/_platform.py
+++ b/tests/_platform.py
@@ -1,95 +1,53 @@
-"""Platform capability probes for tests needing a POSIX backend.
+"""Platform gating for the tests of the POSIX-only sandbox.
 
-Soliplex sandboxes run on Linux, so a handful of unit tests exercise
-behaviour the standard library offers only on POSIX hosts: 'O_NOFOLLOW'
-opens, FIFOs, and symlinks. Nothing here changes what those tests
-assert -- on Linux they run exactly as they did. On a host which cannot
-express the precondition (Windows, most obviously) the test warns and
-skips, rather than failing on an 'AttributeError' or a 'WinError 1314'.
+Soliplex sandboxes a room's tool calls with bubblewrap, which exists
+only on Linux: 'src/soliplex/skills/bwrap_sandbox/' drives 'bwrap'
+itself, and 'src/soliplex/views/sandbox_workdirs.py' serves the workdir
+tree it leaves behind, guarding the walk with an 'O_NOFOLLOW' open.
 
-Each 'requires_*' helper is called from inside the test that needs it,
-so the warning names the skipped test instead of firing once at import
-time. 'HAVE_*' is the same answer as a plain boolean, for a test which
-must decide per parameter rather than skip outright.
+Their tests build the same preconditions the machinery does -- a
+symlink, a FIFO, a name with an embedded NUL that 'PosixPath.resolve'
+rejects -- so on a host offering none of them there is nothing left to
+assert. Rather than skip test by test, each module skips whole: mark it
+with 'requires_posix_sandbox' and name it (with the module it covers)
+in 'POSIX_ONLY_COVERAGE_OMIT', which 'tests/conftest.py' drops from the
+coverage report so the 100% gate keeps its meaning off POSIX.
 
 This module lives in 'tests/', not 'tests/unit/', on purpose: the
-coverage targets in 'pyproject.toml' include 'tests/unit', and a probe
-whose branches are by definition unreachable on whichever platform is
-running could never satisfy the 100% gate.
+coverage targets in 'pyproject.toml' include 'tests/unit', and a
+platform gate whose other branch is by definition unreachable on
+whichever host is running could never satisfy the 100% gate.
+'tests/_dburi.py' is the existing precedent.
 """
 
 import os
-import pathlib
-import tempfile
-import warnings
 
 import pytest
 
 
 class UnsupportedPlatformWarning(UserWarning):
-    """A test was skipped: the host cannot express its precondition."""
+    """Something was skipped: the host cannot express its precondition."""
 
 
-def _probe_symlinks() -> bool:
-    """Report whether this host lets the test user create a symlink
+HAVE_POSIX_SANDBOX = os.name == "posix"
 
-    Windows does, but only for an administrator or with Developer Mode
-    turned on, so 'os.name' alone does not answer it -- make one and
-    see.
-    """
-    with tempfile.TemporaryDirectory() as td:
-        temp_path = pathlib.Path(td)
-        target = temp_path / "probe-target"
-        target.write_text("probe", encoding="utf-8")
+POSIX_ONLY_REASON = (
+    "needs a POSIX host: the bubblewrap sandbox, and the workdir tree "
+    "it leaves behind, are Linux-only, and so are the symlinks, FIFOs "
+    "and NUL-rejecting path resolution these tests set up"
+)
 
-        try:
-            (temp_path / "probe-link").symlink_to(target)
-        except (OSError, NotImplementedError):
-            return False
-        else:
-            return True
+requires_posix_sandbox = pytest.mark.skipif(
+    not HAVE_POSIX_SANDBOX,
+    reason=POSIX_ONLY_REASON,
+)
 
-
-HAVE_SYMLINKS = _probe_symlinks()
-HAVE_MKFIFO = hasattr(os, "mkfifo")
-HAVE_O_NOFOLLOW = hasattr(os, "O_NOFOLLOW")
-
-
-def _warn_and_skip(reason: str) -> None:
-    warnings.warn(reason, UnsupportedPlatformWarning, stacklevel=3)
-    pytest.skip(reason)
-
-
-def requires_symlinks() -> None:
-    """Skip unless this host can create a symlink"""
-    if not HAVE_SYMLINKS:
-        _warn_and_skip(
-            "needs symlinks: this host refuses to create one (on Windows, "
-            "run as an administrator or enable Developer Mode)"
-        )
-
-
-def requires_mkfifo() -> None:
-    """Skip unless this host has 'os.mkfifo'"""
-    if not HAVE_MKFIFO:
-        _warn_and_skip("needs FIFOs: 'os.mkfifo' is POSIX-only")
-
-
-def requires_o_nofollow() -> None:
-    """Skip unless 'os.open' accepts the POSIX-only 'O_NOFOLLOW'"""
-    if not HAVE_O_NOFOLLOW:
-        _warn_and_skip("needs a no-follow open: 'os.O_NOFOLLOW' is POSIX-only")
-
-
-def requires_posix_paths() -> None:
-    """Skip unless 'pathlib' resolves paths the POSIX way
-
-    'PosixPath.resolve' rejects an embedded NUL with 'ValueError';
-    'WindowsPath.resolve' returns a path nothing can open. Code relying
-    on the former to reject a name has nothing to assert on Windows.
-    """
-    if os.name != "posix":
-        _warn_and_skip(
-            "needs POSIX path resolution: 'pathlib' on this host does not "
-            "raise on the paths the test feeds it"
-        )
+# The test modules 'requires_posix_sandbox' skips, plus the modules
+# under test they are the only coverage for. Coverage patterns,
+# relative to the repository root (see 'tests/conftest.py').
+POSIX_ONLY_COVERAGE_OMIT = (
+    "src/soliplex/skills/bwrap_sandbox/*",
+    "src/soliplex/views/sandbox_workdirs.py",
+    "tests/unit/skills/test_bwrap_sandbox.py",
+    "tests/unit/views/test_sandbox_workdirs.py",
+)

--- a/tests/_platform.py
+++ b/tests/_platform.py
@@ -1,0 +1,95 @@
+"""Platform capability probes for tests needing a POSIX backend.
+
+Soliplex sandboxes run on Linux, so a handful of unit tests exercise
+behaviour the standard library offers only on POSIX hosts: 'O_NOFOLLOW'
+opens, FIFOs, and symlinks. Nothing here changes what those tests
+assert -- on Linux they run exactly as they did. On a host which cannot
+express the precondition (Windows, most obviously) the test warns and
+skips, rather than failing on an 'AttributeError' or a 'WinError 1314'.
+
+Each 'requires_*' helper is called from inside the test that needs it,
+so the warning names the skipped test instead of firing once at import
+time. 'HAVE_*' is the same answer as a plain boolean, for a test which
+must decide per parameter rather than skip outright.
+
+This module lives in 'tests/', not 'tests/unit/', on purpose: the
+coverage targets in 'pyproject.toml' include 'tests/unit', and a probe
+whose branches are by definition unreachable on whichever platform is
+running could never satisfy the 100% gate.
+"""
+
+import os
+import pathlib
+import tempfile
+import warnings
+
+import pytest
+
+
+class UnsupportedPlatformWarning(UserWarning):
+    """A test was skipped: the host cannot express its precondition."""
+
+
+def _probe_symlinks() -> bool:
+    """Report whether this host lets the test user create a symlink
+
+    Windows does, but only for an administrator or with Developer Mode
+    turned on, so 'os.name' alone does not answer it -- make one and
+    see.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        temp_path = pathlib.Path(td)
+        target = temp_path / "probe-target"
+        target.write_text("probe", encoding="utf-8")
+
+        try:
+            (temp_path / "probe-link").symlink_to(target)
+        except (OSError, NotImplementedError):
+            return False
+        else:
+            return True
+
+
+HAVE_SYMLINKS = _probe_symlinks()
+HAVE_MKFIFO = hasattr(os, "mkfifo")
+HAVE_O_NOFOLLOW = hasattr(os, "O_NOFOLLOW")
+
+
+def _warn_and_skip(reason: str) -> None:
+    warnings.warn(reason, UnsupportedPlatformWarning, stacklevel=3)
+    pytest.skip(reason)
+
+
+def requires_symlinks() -> None:
+    """Skip unless this host can create a symlink"""
+    if not HAVE_SYMLINKS:
+        _warn_and_skip(
+            "needs symlinks: this host refuses to create one (on Windows, "
+            "run as an administrator or enable Developer Mode)"
+        )
+
+
+def requires_mkfifo() -> None:
+    """Skip unless this host has 'os.mkfifo'"""
+    if not HAVE_MKFIFO:
+        _warn_and_skip("needs FIFOs: 'os.mkfifo' is POSIX-only")
+
+
+def requires_o_nofollow() -> None:
+    """Skip unless 'os.open' accepts the POSIX-only 'O_NOFOLLOW'"""
+    if not HAVE_O_NOFOLLOW:
+        _warn_and_skip("needs a no-follow open: 'os.O_NOFOLLOW' is POSIX-only")
+
+
+def requires_posix_paths() -> None:
+    """Skip unless 'pathlib' resolves paths the POSIX way
+
+    'PosixPath.resolve' rejects an embedded NUL with 'ValueError';
+    'WindowsPath.resolve' returns a path nothing can open. Code relying
+    on the former to reject a name has nothing to assert on Windows.
+    """
+    if os.name != "posix":
+        _warn_and_skip(
+            "needs POSIX path resolution: 'pathlib' on this host does not "
+            "raise on the paths the test feeds it"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,50 @@ session-scoped fixture cannot request them (pytest raises
 'tests/unit/cli/conftest.py' does.
 """
 
+import os
+
 import pytest
 
 from tests._dburi import sqlite_dburi
+from tests._platform import UnsupportedPlatformWarning
+
+COVERAGE_NOT_ENFORCED = (
+    "coverage is not gated on a non-POSIX host: the tests covering the "
+    "POSIX-only sandbox paths skip here, so '--cov-fail-under' has been "
+    "relaxed to 0 for this run. The 100% gate is enforced on Linux (and "
+    "in CI); re-check coverage there before relying on it."
+)
+
+
+def pytest_configure(config):
+    """Relax the coverage gate where platform skips make it unmeetable
+
+    'addopts' applies '--cov-fail-under=100' to every run. On a host
+    which cannot express the POSIX preconditions a few tests need (see
+    'tests/_platform.py'), those tests skip, and the lines they cover
+    go unmeasured -- so the gate fails however the tests themselves
+    fared. Drop the threshold there, loudly, and leave POSIX hosts
+    (CI included) alone.
+    """
+    if os.name == "posix":
+        return
+
+    # pytest-cov reads its threshold from the namespace it captured in
+    # 'pytest_load_initial_conftests' ('known_args_namespace'), not from
+    # 'config.option', so reach the registered plugin's own copy.
+    cov_plugin = config.pluginmanager.get_plugin("_cov")
+
+    if cov_plugin is None:  # '--no-cov', or coverage not installed
+        return
+
+    if not getattr(cov_plugin.options, "cov_fail_under", None):
+        return
+
+    cov_plugin.options.cov_fail_under = 0
+    config.issue_config_time_warning(
+        UnsupportedPlatformWarning(COVERAGE_NOT_ENFORCED),
+        stacklevel=2,
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,50 +11,79 @@ session-scoped fixture cannot request them (pytest raises
 'tests/unit/cli/conftest.py' does.
 """
 
-import os
-
 import pytest
 
+from tests import _platform
 from tests._dburi import sqlite_dburi
-from tests._platform import UnsupportedPlatformWarning
 
-COVERAGE_NOT_ENFORCED = (
-    "coverage is not gated on a non-POSIX host: the tests covering the "
-    "POSIX-only sandbox paths skip here, so '--cov-fail-under' has been "
-    "relaxed to 0 for this run. The 100% gate is enforced on Linux (and "
-    "in CI); re-check coverage there before relying on it."
+COVERAGE_NOT_REPORTED = (
+    "coverage is not reported for the POSIX-only sandbox on this host: "
+    "the tests covering it skip here (see 'tests/_platform.py'), so "
+    "these are omitted from the report rather than dropping the 100% "
+    "gate for everything else -- re-check them on Linux: {omitted}"
 )
 
 
-def pytest_configure(config):
-    """Relax the coverage gate where platform skips make it unmeetable
+def _cov_config_objects(config):
+    """The 'CoverageConfig' objects the report at the end will consult
 
-    'addopts' applies '--cov-fail-under=100' to every run. On a host
-    which cannot express the POSIX preconditions a few tests need (see
-    'tests/_platform.py'), those tests skip, and the lines they cover
-    go unmeasured -- so the gate fails however the tests themselves
-    fared. Drop the threshold there, loudly, and leave POSIX hosts
-    (CI included) alone.
+    pytest-cov measures with one 'Coverage' and reports with another:
+    'CovController.finish' swaps in the 'combining_cov' it built at
+    start-up. Both are already constructed by the time 'pytest_configure'
+    runs, and neither is reachable through 'config.option', so hand back
+    whichever of them this run has.
     """
-    if os.name == "posix":
-        return
-
-    # pytest-cov reads its threshold from the namespace it captured in
-    # 'pytest_load_initial_conftests' ('known_args_namespace'), not from
-    # 'config.option', so reach the registered plugin's own copy.
     cov_plugin = config.pluginmanager.get_plugin("_cov")
 
-    if cov_plugin is None:  # '--no-cov', or coverage not installed
-        return
+    if cov_plugin is None:  # coverage not installed
+        return []
 
-    if not getattr(cov_plugin.options, "cov_fail_under", None):
-        return
+    if cov_plugin.cov_controller is None:  # '--no-cov'
+        return []
 
-    cov_plugin.options.cov_fail_under = 0
-    config.issue_config_time_warning(
-        UnsupportedPlatformWarning(COVERAGE_NOT_ENFORCED),
-        stacklevel=2,
+    controller = cov_plugin.cov_controller
+
+    covs = (
+        getattr(controller, "cov", None),
+        getattr(controller, "combining_cov", None),
     )
+    return [cov.config for cov in covs if cov is not None]
+
+
+def pytest_configure(config):
+    """Stop reporting coverage of what the platform skips off POSIX
+
+    'addopts' applies '--cov-fail-under=100' to every run. The tests of
+    the bubblewrap sandbox skip on a host which cannot express their
+    preconditions, leaving the code they cover unmeasured -- so the gate
+    would fail however the tests themselves fared.
+
+    Omit those modules, and the test modules that skipped, from the
+    report instead: the 100% gate then still means 100% of everything
+    this host can measure. The omission is a 'report' one rather than a
+    'run' one because measurement has already begun by now; it also
+    keeps the data file complete, so a later 'coverage report' can still
+    be pointed at it.
+    """
+    if _platform.HAVE_POSIX_SANDBOX:
+        return
+
+    omit = list(_platform.POSIX_ONLY_COVERAGE_OMIT)
+    cov_configs = _cov_config_objects(config)
+
+    for cov_config in cov_configs:
+        cov_config.report_omit = [*(cov_config.report_omit or []), *omit]
+
+    # Every xdist worker runs this hook too, but only the controller
+    # prints a report -- warn where the caveat can be read next to the
+    # numbers it applies to.
+    if cov_configs and not hasattr(config, "workerinput"):
+        config.issue_config_time_warning(
+            _platform.UnsupportedPlatformWarning(
+                COVERAGE_NOT_REPORTED.format(omitted=", ".join(omit)),
+            ),
+            stacklevel=2,
+        )
 
 
 @pytest.fixture

--- a/tests/unit/config/test_config_rag.py
+++ b/tests/unit/config/test_config_rag.py
@@ -261,9 +261,14 @@ def test__rcb_deferred_databases_several(stem_environ, temp_dir):
         ),
     )
 
+    # A location haiku.rag reads as a local path comes back as a
+    # 'pathlib.Path', so the separator in the audit line is the host's
+    # own; a URI is passed through as the string it is.
+    papers = pathlib.Path("/data/papers.lancedb")
+
     assert config.rag_database_names == ["medic", "papers"]
     assert config.rag_db_audit_path == (
-        "medic=s3://bucket/medic.lancedb, papers=/data/papers.lancedb"
+        f"medic=s3://bucket/medic.lancedb, papers={papers}"
     )
 
 
@@ -675,7 +680,14 @@ def test__rde_yaml_roundtrip(installation_config, temp_dir, stem, override):
     assert entry._config_path == config_path
     assert entry._installation_config is installation_config
 
+    expected_yaml = dict(entry_yaml)
+
     if override is not None:
         assert entry.rag_lancedb_override_path == pathlib.Path(override)
+        # 'as_yaml' renders the parsed 'pathlib.Path' back out, so the
+        # separator it round-trips through is the host's own.
+        expected_yaml["rag_lancedb_override_path"] = str(
+            pathlib.Path(override)
+        )
 
-    assert entry.as_yaml == entry_yaml
+    assert entry.as_yaml == expected_yaml

--- a/tests/unit/config/test_config_tools.py
+++ b/tests/unit/config/test_config_tools.py
@@ -1016,7 +1016,9 @@ def test_sdtc_as_yaml(temp_dir, installation_config, w_kw):
         expected["rag_databases"] = [
             {
                 "name": pathlib.Path(override).stem,
-                "rag_lancedb_override_path": override,
+                # 'as_yaml' renders the parsed 'pathlib.Path', so the
+                # separator is the host's own.
+                "rag_lancedb_override_path": str(pathlib.Path(override)),
             },
         ]
     else:

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -15,6 +15,7 @@ from pydantic_ai import toolsets as ai_toolsets
 from soliplex import loggers
 from soliplex.config import installation as config_installation
 from soliplex.skills import bwrap_sandbox as skills_bwrap_sandbox
+from tests import _platform
 
 ROOM_ID = "test_room"
 THREAD_ID = uuid.uuid4()
@@ -564,6 +565,13 @@ invalid_subdir = pytest.raises(skills_bwrap_sandbox.InvalidSubdir)
     ],
 )
 def test__check_is_subdir(temp_dir, subpath, expectation):
+    if "\x00" in subpath:
+        # '_check_is_subdir' leans on 'resolve' raising 'ValueError' for
+        # an embedded NUL, which is 'PosixPath' behaviour.
+        # 'WindowsPath.resolve' hands back a name whose parent is the
+        # expected one, so there is nothing to assert here.
+        _platform.requires_posix_paths()
+
     with expectation:
         skills_bwrap_sandbox._check_is_subdir(temp_dir / subpath, temp_dir)
 

--- a/tests/unit/skills/test_bwrap_sandbox.py
+++ b/tests/unit/skills/test_bwrap_sandbox.py
@@ -17,6 +17,8 @@ from soliplex.config import installation as config_installation
 from soliplex.skills import bwrap_sandbox as skills_bwrap_sandbox
 from tests import _platform
 
+pytestmark = _platform.requires_posix_sandbox
+
 ROOM_ID = "test_room"
 THREAD_ID = uuid.uuid4()
 THREAD_ID_STR = str(THREAD_ID)
@@ -565,13 +567,6 @@ invalid_subdir = pytest.raises(skills_bwrap_sandbox.InvalidSubdir)
     ],
 )
 def test__check_is_subdir(temp_dir, subpath, expectation):
-    if "\x00" in subpath:
-        # '_check_is_subdir' leans on 'resolve' raising 'ValueError' for
-        # an embedded NUL, which is 'PosixPath' behaviour.
-        # 'WindowsPath.resolve' hands back a name whose parent is the
-        # expected one, so there is nothing to assert here.
-        _platform.requires_posix_paths()
-
     with expectation:
         skills_bwrap_sandbox._check_is_subdir(temp_dir / subpath, temp_dir)
 

--- a/tests/unit/views/test_sandbox_workdirs.py
+++ b/tests/unit/views/test_sandbox_workdirs.py
@@ -15,6 +15,8 @@ from soliplex.config import rooms as config_rooms
 from soliplex.views import sandbox_workdirs as workdir_views
 from tests import _platform
 
+pytestmark = _platform.requires_posix_sandbox
+
 USER_NAME = "phreddy"
 EMAIL = "phreddy@example.com"
 
@@ -109,7 +111,6 @@ async def test_get_workdirs_room_thread_run_only(
         for filename in w_filenames:
             file_path = run_path / filename
             if w_link == "symlink":
-                _platform.requires_symlinks()
                 file_path.symlink_to(link_target)
             elif w_link == "hardlink":
                 file_path.hardlink_to(link_target)
@@ -226,11 +227,6 @@ def test__open_no_symlinks(
     w_link,
     expectation,
 ):
-    # Every case reaches '_open_no_symlinks', whose whole point is the
-    # POSIX-only 'O_NOFOLLOW'; the symlink and FIFO cases need more
-    # still. There is nothing to assert on a host without them.
-    _platform.requires_o_nofollow()
-
     workdir_path = sandbox_path / "workdir"
     file_path = workdir_path / TEST_FILENAME
 
@@ -241,14 +237,12 @@ def test__open_no_symlinks(
 
         if w_filename:
             if w_link == "symlink":
-                _platform.requires_symlinks()
                 file_path.symlink_to(link_target)
             elif w_link == "hardlink":
                 file_path.hardlink_to(link_target)
             elif w_link == "dir":
                 file_path.mkdir()
             elif w_link == "fifo":
-                _platform.requires_mkfifo()
                 os.mkfifo(file_path)
             else:
                 file_path.write_text(f"filename: {TEST_FILENAME}")

--- a/tests/unit/views/test_sandbox_workdirs.py
+++ b/tests/unit/views/test_sandbox_workdirs.py
@@ -13,6 +13,7 @@ from soliplex import loggers
 from soliplex import models
 from soliplex.config import rooms as config_rooms
 from soliplex.views import sandbox_workdirs as workdir_views
+from tests import _platform
 
 USER_NAME = "phreddy"
 EMAIL = "phreddy@example.com"
@@ -108,6 +109,7 @@ async def test_get_workdirs_room_thread_run_only(
         for filename in w_filenames:
             file_path = run_path / filename
             if w_link == "symlink":
+                _platform.requires_symlinks()
                 file_path.symlink_to(link_target)
             elif w_link == "hardlink":
                 file_path.hardlink_to(link_target)
@@ -224,6 +226,11 @@ def test__open_no_symlinks(
     w_link,
     expectation,
 ):
+    # Every case reaches '_open_no_symlinks', whose whole point is the
+    # POSIX-only 'O_NOFOLLOW'; the symlink and FIFO cases need more
+    # still. There is nothing to assert on a host without them.
+    _platform.requires_o_nofollow()
+
     workdir_path = sandbox_path / "workdir"
     file_path = workdir_path / TEST_FILENAME
 
@@ -234,12 +241,14 @@ def test__open_no_symlinks(
 
         if w_filename:
             if w_link == "symlink":
+                _platform.requires_symlinks()
                 file_path.symlink_to(link_target)
             elif w_link == "hardlink":
                 file_path.hardlink_to(link_target)
             elif w_link == "dir":
                 file_path.mkdir()
             elif w_link == "fifo":
+                _platform.requires_mkfifo()
                 os.mkfifo(file_path)
             else:
                 file_path.write_text(f"filename: {TEST_FILENAME}")


### PR DESCRIPTION
# fix: portability of `_check_is_subdir`, and run the unit suite on Windows

## Summary

Twelve unit tests failed on Windows. Sorting them by *why* gives three
groups, and only the third is a genuine platform limit:

1. **A portability bug in production code** (1 test). `_check_is_subdir`
   rejected a path with an embedded NUL by relying on
   `PosixPath.resolve` raising `ValueError`. `WindowsPath.resolve` does
   not raise — it returns a name nothing can open, whose `.parent` *is*
   the expected parent, so the check passed the name straight through.
   **Fixed in the source**, not skipped.
2. **Assertions with a hard-coded separator** (3 tests). The code under
   test emits `str(pathlib.Path(...))`; the tests compared against a
   POSIX literal. Fixed by building the expectation through `pathlib`.
3. **Genuinely POSIX-only backends** (8 tests). An `O_NOFOLLOW` open, a
   FIFO, a symlink. These now probe the host, warn, and skip.

`uv run pytest` on Windows 11 goes from **12 failed / 4172 passed** to
**4176 passed, 8 skipped, exit 0**. Linux behaviour is unchanged: every
probe answers `True` there, so nothing skips and nothing warns, and the
one source change is verified equivalent (below).

## 1 — the portability fix (`skills/bwrap_sandbox/`)

`_check_is_subdir` guards the sandbox workdir tree: it is what stops a
room, thread, or run id from escaping its parent. It was written as

```python
try:
    resolved = path.resolve()
except ValueError as exc:            # only ever the embedded-NUL case
    raise InvalidSubdir(path, ep_resolved) from exc
else:
    if resolved.parent == ep_resolved:
        return

raise InvalidSubdir(path, ep_resolved)
```

The `except ValueError` is load-bearing — it is the *only* thing
rejecting a NUL — but it fires only because `PosixPath.resolve` happens
to raise. That is an implementation detail of one `pathlib` flavour, and
the check silently loses a rejection wherever it does not hold:

```text
Path("/tmp/x/\x00").resolve()
  PosixPath   -> ValueError: embedded null byte        -> rejected
  WindowsPath -> WindowsPath('C:/tmp/x/\x00')          -> ACCEPTED
                 .parent == the expected parent
```

Now the NUL is rejected on its own terms, and nothing depends on which
`pathlib` is loaded:

```python
if "\x00" not in str(path) and path.resolve().parent == ep_resolved:
    return

raise InvalidSubdir(path, ep_resolved)
```

Note this **replaces** the `try`/`except` rather than sitting in front of
it. Leaving both would make the `except` unreachable — dead code on every
platform, and a coverage-gate failure on Linux.

The bwrap sandbox only ever runs on Linux, so this is not a live
vulnerability. It is a check that was one `pathlib` implementation detail
away from being wrong, in code whose whole job is to reject a crafted
path; making it say what it means is worth the three lines regardless of
which platform runs it.

`src/soliplex/skills/bwrap_sandbox/__init__.py` goes from 99% to **100%**
on Windows, and the test runs everywhere instead of skipping.

### Equivalence check

Old and new implementations were run side by side under Linux (WSL) over
all 11 parametrized cases plus 11 further probes — a NUL in leading,
middle, and trailing position, a real symlink, a space, a tilde, a
glob character, a backslash, and a 200-character name:

```text
divergences: 0
```

On POSIX, `resolve()` raises `ValueError` only for the embedded NUL —
every other failure surfaces as `OSError`, which `resolve(strict=False)`
swallows — so the replaced `except` had exactly one trigger, and the new
condition covers it.

## 2 — path separators (3 tests, fixed, not skipped)

`RAGDatabaseEntry.as_yaml` and `rag_db_audit_path` render a parsed
`pathlib.Path` back out, so what they emit carries the host's separator:

```text
expected: papers=/data/papers.lancedb
found:    papers=\data\papers.lancedb
```

| Test | Fix |
| --- | --- |
| `test__rcb_deferred_databases_several` | build the audit line from `pathlib.Path("/data/papers.lancedb")` |
| `test__rde_yaml_roundtrip[None-../papers.lancedb]` | compare against `str(pathlib.Path(override))` |
| `test_sdtc_as_yaml[w_kw1]` | same, in the expected `rag_databases` entry |

These are not weakened assertions: on Linux each expression evaluates to
the exact literal it replaced (verified). The separator is the only thing
that moves.

## 3 — POSIX-only backends (8 tests, warn and skip)

New `tests/_platform.py` holds the probes and three helpers. A test that
needs one calls it; the helper emits an `UnsupportedPlatformWarning`
(pytest lists it in the warnings summary, naming the skipped test) and
skips:

| Test(s) | Needs | Failure on Windows |
| --- | --- | --- |
| `test__open_no_symlinks` (7 params) | `requires_o_nofollow()` | `AttributeError: module 'os' has no attribute 'O_NOFOLLOW'` |
| `test_get_workdirs_room_thread_run_only[…symlink]` | `requires_symlinks()` | `OSError: [WinError 1314] A required privilege is not held` |

All seven parameters of `test__open_no_symlinks` reach
`_open_no_symlinks`, whose whole purpose is the `O_NOFOLLOW` open, so the
guard sits at the top of the test rather than per parameter. The symlink
and FIFO guards sit at their creation sites, so only the parameter that
actually needs the capability skips.

Probes ask the host, not `os.name`, wherever they can. `HAVE_SYMLINKS`
creates one in a temporary directory and reports whether it worked, so a
Windows box with Developer Mode turned on runs the symlink tests rather
than skipping them.

`tests/_platform.py` deliberately lives in `tests/`, not `tests/unit/`.
The coverage targets include `tests/unit`, and a probe whose branches are
by definition unreachable on whichever platform is running could never
reach the 100% gate. `tests/_dburi.py` is the existing precedent.

## The coverage gate 

The remaining skips leave the code they cover unmeasured, so
`--cov-fail-under=100` fails on Windows however the tests themselves
fared. After the portability fix the entire residue is one function and
its tests:

```text
src\soliplex\views\sandbox_workdirs.py     75  14  14  0   80%   112-135
tests\unit\views\test_sandbox_workdirs.py 153  26  36  1   78%   113, 174, 234-263
TOTAL                                   26174  40 3760  1   99.80%
```

`src/soliplex/skills/bwrap_sandbox/__init__.py` no longer appears — the
portability fix closed it.

A green suite that still exits non-zero is not really "runs on Windows",
so `tests/conftest.py` gained a `pytest_configure` that drops the
threshold to 0 **only when `os.name != "posix"`**, and warns that it has:

> coverage is not gated on a non-POSIX host: the tests covering the
> POSIX-only sandbox paths skip here, so `--cov-fail-under` has been
> relaxed to 0 for this run. The 100% gate is enforced on Linux (and in
> CI); re-check coverage there before relying on it.

Linux and CI are untouched — the hook returns on its first line there. It
also returns under `--no-cov`, where the threshold is set but unenforced
and the warning would be pure noise. The trade is that a Windows
developer will not see a genuine coverage regression locally, which is
why the warning says so in as many words. **Drop this hook if you would
rather Windows users pass `--no-cov` by hand**; the rest of the PR stands
without it.

One implementation note worth a reviewer's eye: pytest-cov reads its
threshold from the namespace it captured in
`pytest_load_initial_conftests` (`early_config.known_args_namespace`),
*not* from `config.option`. Mutating `config.option.cov_fail_under` looks
right and does nothing.


## Provenance

None of this is drift from a later change — each test has failed on
Windows since it landed:

| Test | Landed in | Date |
| --- | --- | --- |
| `test__open_no_symlinks`, workdir symlink listing | `5dc95ea3` (#1332) | 2026-09-02 |
| `test__check_is_subdir[\x00]` | `df7372df` (#1328) | 2026-09-02 |
| the three path-separator assertions | `f1717b93` (#1322) | 2026-09-04 |

`df7372df` is the one where the failing test was pointing at a real
defect rather than at a platform limit.


## Changes

| File | Change |
| --- | --- |
| `src/soliplex/skills/bwrap_sandbox/__init__.py` | **portability fix** — reject an embedded NUL explicitly |
| `tests/_platform.py` | **new** — probes and three `requires_*` helpers |
| `tests/conftest.py` | `pytest_configure` relaxing the coverage gate off POSIX |
| `tests/unit/views/test_sandbox_workdirs.py` | 3 guard calls |
| `tests/unit/config/test_config_rag.py` | 2 assertions built through `pathlib` |
| `tests/unit/config/test_config_tools.py` | 1 assertion built through `pathlib` |
| `AGENTS.md` / `DEVELOPMENT.md` | document the convention, and when *not* to reach for a probe |

211 insertions, 10 deletions. The only change under `src/` is the
seven-line `_check_is_subdir` body.

## Verification

On Windows 11 (Python 3.13.11), where all twelve previously failed:

- `uv run pytest -n 8` — **4176 passed, 8 skipped, exit 0**; each skip
  prints its reason in the warnings summary
- `src/soliplex/skills/bwrap_sandbox/__init__.py` — **100%** (was 99%,
  missing 447-448)
- `uv run ruff check` / `ruff format --check` — clean, 183 files
- `uv run pre-commit run pymarkdown` on both edited docs — passed

On Linux, checked under WSL rather than assumed:

- old vs new `_check_is_subdir` over 22 inputs — **0 divergences**
- `HAVE_SYMLINKS`, `HAVE_MKFIFO`, `HAVE_O_NOFOLLOW` all report `True`
- every `requires_*` helper is a no-op under
  `warnings.simplefilter("error")` — nothing skips, nothing warns
- `str(pathlib.Path(s)) == s` holds for all three rewritten expectations

The full suite has not been re-run on Linux from this branch; the changes
above are what would differ, and each is verified to be a no-op there.

Also swept for sibling cases: `grep` across `tests/` for `symlink`,
`mkfifo`, `O_NOFOLLOW`, `geteuid`, `pwd`, `grp`, and `resource` turned up
no other POSIX-only usage beyond the files touched here. The one prior
accommodation (`EXPECTED_TRANSCRIPT_MODE`, keyed on `os.name == "nt"` in
`test_bwrap_sandbox.py`) already handled its own case and is left alone.
